### PR TITLE
Add grid-stride loops and ROCm cap to reorder_batched_ad_{lengths,indices,sequence_embeddings}_kernel (#5938)

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_reorder_batched_ad.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_reorder_batched_ad.cu
@@ -28,23 +28,25 @@ __launch_bounds__(kMaxThreads) void reorder_batched_ad_lengths_kernel(
   const int32_t B = batch_offsets.size(0) - 1;
 
   const int32_t num_ads_in_batch = batch_offsets[B];
-  // warp-per-segment.
-  const auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
-  const int32_t b = b_t % B;
-  const int32_t t = b_t / B;
-  if (t >= T) {
-    return;
-  }
+  // warp-per-segment with grid-stride loop. A capped grid (used on ROCm to
+  // avoid the 2^32 launch-side limit) still covers all B*T segments.
+  const auto b_t_init = blockIdx.x * blockDim.y + threadIdx.y;
+  const auto stride = gridDim.x * blockDim.y;
+  for (auto b_t = b_t_init; b_t < B * T; b_t += stride) {
+    const int32_t b = b_t % B;
+    const int32_t t = b_t / B;
 
-  const int32_t num_ads_b = batch_offsets[b + 1] - batch_offsets[b];
-  const int32_t input_segment_start =
-      broadcast_lengths ? T * b + t : T * batch_offsets[b] + t * num_ads_b;
-  const int32_t output_segment_start = t * num_ads_in_batch + batch_offsets[b];
+    const int32_t num_ads_b = batch_offsets[b + 1] - batch_offsets[b];
+    const int32_t input_segment_start =
+        broadcast_lengths ? T * b + t : T * batch_offsets[b] + t * num_ads_b;
+    const int32_t output_segment_start =
+        t * num_ads_in_batch + batch_offsets[b];
 
-  for (auto i = threadIdx.x; i < num_ads_b; i += blockDim.x) {
-    reordered_cat_ad_lengths[output_segment_start + i] = broadcast_lengths
-        ? cat_ad_lengths[input_segment_start]
-        : cat_ad_lengths[input_segment_start + i];
+    for (auto i = threadIdx.x; i < num_ads_b; i += blockDim.x) {
+      reordered_cat_ad_lengths[output_segment_start + i] = broadcast_lengths
+          ? cat_ad_lengths[input_segment_start]
+          : cat_ad_lengths[input_segment_start + i];
+    }
   }
 }
 
@@ -68,18 +70,26 @@ DLL_PUBLIC Tensor reorder_batched_ad_lengths_gpu(
       ? at::empty({T * num_ads_in_batch}, cat_ad_lengths.options())
       : at::empty_like(cat_ad_lengths);
 
-  const int64_t grid_size = (B * T + 32 - 1) / 32;
+  const int64_t grid_size_uncapped = (B * T + 32 - 1) / 32;
   TORCH_CHECK(
-      grid_size >= 0,
+      grid_size_uncapped >= 0,
       "grid_size must be positive, got ",
-      grid_size,
+      grid_size_uncapped,
       " where B =",
       B,
       " and T =",
       T);
 
   const dim3 threads(32, 32);
-  const dim3 blocks(grid_size);
+  // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
+  // which silently wraps). reorder_batched_ad_lengths_kernel grid-strides
+  // over b_t, so capping is correctness-preserving.
+  // See: https://github.com/ROCm/hip/issues/2253
+  const dim3 blocks(
+      utils::cuda::cap_grid_dim_x(
+          grid_size_uncapped,
+          static_cast<int64_t>(threads.x) * static_cast<int64_t>(threads.y),
+          at::cuda::getCurrentCUDAStream()));
 
   FBGEMM_DISPATCH_ALL_TYPES(
       cat_ad_lengths.scalar_type(),
@@ -200,41 +210,43 @@ __launch_bounds__(kMaxThreads) void reorder_batched_ad_indices_kernel(
     const bool broadcast_indices) {
   const int32_t B = batch_offsets.size(0) - 1;
   const int32_t num_ads_in_batch = batch_offsets[B];
-  // warp-per-segment.
-  const auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
-  const int32_t b = b_t % B;
-  const int32_t t = b_t / B;
-  if (t >= T) {
-    return;
-  }
+  // warp-per-segment with grid-stride loop. A capped grid (used on ROCm to
+  // avoid the 2^32 launch-side limit) still covers all B*T segments.
+  const auto b_t_init = blockIdx.x * blockDim.y + threadIdx.y;
+  const auto stride = gridDim.x * blockDim.y;
+  for (auto b_t = b_t_init; b_t < B * T; b_t += stride) {
+    const int32_t b = b_t % B;
+    const int32_t t = b_t / B;
 
-  const auto num_ads_b = batch_offsets[b + 1] - batch_offsets[b];
-  const auto output_segment_offset_start =
-      t * num_ads_in_batch + batch_offsets[b];
-  const auto output_segment_start =
-      reordered_cat_ad_offsets[output_segment_offset_start];
-  const int32_t input_segment_offset_start =
-      broadcast_indices ? T * b + t : T * batch_offsets[b] + t * num_ads_b;
-  const int32_t input_segment_offset_end = broadcast_indices
-      ? input_segment_offset_start + 1
-      : input_segment_offset_start + num_ads_b;
-  const auto input_segment_start = cat_ad_offsets[input_segment_offset_start];
-  const auto input_segment_end = cat_ad_offsets[input_segment_offset_end];
-  const auto num_elements = input_segment_end - input_segment_start;
+    const auto num_ads_b = batch_offsets[b + 1] - batch_offsets[b];
+    const auto output_segment_offset_start =
+        t * num_ads_in_batch + batch_offsets[b];
+    const auto output_segment_start =
+        reordered_cat_ad_offsets[output_segment_offset_start];
+    const int32_t input_segment_offset_start =
+        broadcast_indices ? T * b + t : T * batch_offsets[b] + t * num_ads_b;
+    const int32_t input_segment_offset_end = broadcast_indices
+        ? input_segment_offset_start + 1
+        : input_segment_offset_start + num_ads_b;
+    const auto input_segment_start = cat_ad_offsets[input_segment_offset_start];
+    const auto input_segment_end = cat_ad_offsets[input_segment_offset_end];
+    const auto num_elements = input_segment_end - input_segment_start;
 
-  if (broadcast_indices) {
-    for (auto i = threadIdx.x; i < num_ads_b * num_elements; i += blockDim.x) {
-      reordered_cat_ad_indices[output_segment_start + i] =
-          cat_ad_indices[input_segment_start + i % num_elements];
-    }
-  } else {
-    // Idea: we want to copy the entire segment of size sum_a(length_{b, t, a})
-    // from starting point (given by cat_ad_offsets[b, t])
-    // to end point (given by reordered_cat_ad_indices[t][b])
-    for (auto i = threadIdx.x; i < input_segment_end - input_segment_start;
-         i += blockDim.x) {
-      reordered_cat_ad_indices[output_segment_start + i] =
-          cat_ad_indices[input_segment_start + i];
+    if (broadcast_indices) {
+      for (auto i = threadIdx.x; i < num_ads_b * num_elements;
+           i += blockDim.x) {
+        reordered_cat_ad_indices[output_segment_start + i] =
+            cat_ad_indices[input_segment_start + i % num_elements];
+      }
+    } else {
+      // Idea: we want to copy the entire segment of size sum_a(length_{b, t,
+      // a}) from starting point (given by cat_ad_offsets[b, t]) to end point
+      // (given by reordered_cat_ad_indices[t][b])
+      for (auto i = threadIdx.x; i < input_segment_end - input_segment_start;
+           i += blockDim.x) {
+        reordered_cat_ad_indices[output_segment_start + i] =
+            cat_ad_indices[input_segment_start + i];
+      }
     }
   }
 }
@@ -267,95 +279,97 @@ __launch_bounds__(fbgemm_gpu::kMaxThreads) void reorder_batched_ad_indices_kerne
       typename std::conditional<sizeof(Dtype) == 8, long4, float4>::type;
   const int32_t B = batch_offsets.size(0) - 1;
   const int32_t num_ads_in_batch = batch_offsets[B];
-  // warp-per-segment.
-  const auto b_t = blockIdx.x * blockDim.y +
+  // warp-per-segment with grid-stride loop. A capped grid (used on ROCm to
+  // avoid the 2^32 launch-side limit) still covers all B*T segments.
+  const auto b_t_init = blockIdx.x * blockDim.y +
       threadIdx.y; // can be more efficient through bitwise op
-  const int32_t b = b_t % B;
-  const int32_t t = b_t / B;
-  if (t >= T) {
-    return;
-  }
+  const auto stride = gridDim.x * blockDim.y;
+  for (auto b_t = b_t_init; b_t < B * T; b_t += stride) {
+    const int32_t b = b_t % B;
+    const int32_t t = b_t / B;
 
-  const auto num_ads_b = batch_offsets[b + 1] - batch_offsets[b];
-  const auto output_segment_offset_start =
-      t * num_ads_in_batch + batch_offsets[b];
-  const auto output_segment_start =
-      reordered_cat_ad_offsets[output_segment_offset_start];
-  const int32_t input_segment_offset_start =
-      broadcast_indices ? T * b + t : T * batch_offsets[b] + t * num_ads_b;
-  const int32_t input_segment_offset_end = broadcast_indices
-      ? input_segment_offset_start + 1
-      : input_segment_offset_start + num_ads_b;
-  const auto input_segment_start = cat_ad_offsets[input_segment_offset_start];
-  const auto input_segment_end = cat_ad_offsets[input_segment_offset_end];
-  const auto num_elements = input_segment_end - input_segment_start;
+    const auto num_ads_b = batch_offsets[b + 1] - batch_offsets[b];
+    const auto output_segment_offset_start =
+        t * num_ads_in_batch + batch_offsets[b];
+    const auto output_segment_start =
+        reordered_cat_ad_offsets[output_segment_offset_start];
+    const int32_t input_segment_offset_start =
+        broadcast_indices ? T * b + t : T * batch_offsets[b] + t * num_ads_b;
+    const int32_t input_segment_offset_end = broadcast_indices
+        ? input_segment_offset_start + 1
+        : input_segment_offset_start + num_ads_b;
+    const auto input_segment_start = cat_ad_offsets[input_segment_offset_start];
+    const auto input_segment_end = cat_ad_offsets[input_segment_offset_end];
+    const auto num_elements = input_segment_end - input_segment_start;
 
-  Dtype* dst_ptr = reordered_cat_ad_indices.data() + output_segment_start;
-  Dtype* src_ptr = cat_ad_indices.data() + input_segment_start;
-  if (broadcast_indices) {
-    for (auto i = threadIdx.x; i < num_ads_b * num_elements; i += blockDim.x) {
-      reordered_cat_ad_indices[output_segment_start + i] =
-          cat_ad_indices[input_segment_start + i % num_elements];
-    }
-  } else {
-    // Idea: we want to copy the entire segment of size sum_a(length_{b, t, a})
-    // from starting point (given by cat_ad_offsets[b, t])
-    // to end point (given by reordered_cat_ad_indices[t][b])
-    if (num_elements <= 64 || !(sizeof(Dtype) == 4 || sizeof(Dtype) == 8)) {
-      for (auto i = threadIdx.x; i < input_segment_end - input_segment_start;
+    Dtype* dst_ptr = reordered_cat_ad_indices.data() + output_segment_start;
+    Dtype* src_ptr = cat_ad_indices.data() + input_segment_start;
+    if (broadcast_indices) {
+      for (auto i = threadIdx.x; i < num_ads_b * num_elements;
            i += blockDim.x) {
-        // coalesced global memory access, can be optimzed through ILP with the
-        // help of shared memory or vector load/store (if num_ads_b>=64)
         reordered_cat_ad_indices[output_segment_start + i] =
-            cat_ad_indices[input_segment_start + i];
+            cat_ad_indices[input_segment_start + i % num_elements];
       }
-    } else if (num_elements > 64 && num_elements <= 128) {
-      // Check alignment for vec2_t (8-byte alignment required)
-      bool vec2_t_aligned =
-          reinterpret_cast<uintptr_t>(dst_ptr) % alignof(vec2_t) == 0 &&
-          reinterpret_cast<uintptr_t>(src_ptr) % alignof(vec2_t) == 0;
-      if (vec2_t_aligned) {
-        // Use vectorized loads if properly aligned
-        auto dst = (vec2_t*)dst_ptr;
-        auto src = (vec2_t*)src_ptr;
-        for (auto i = threadIdx.x; i < num_elements / 2; i += blockDim.x) {
-          dst[i] = src[i];
-        }
-        if ((num_elements % 2) && threadIdx.x == 31) {
-          reordered_cat_ad_indices[output_segment_start + num_elements - 1] =
-              cat_ad_indices[input_segment_start + num_elements - 1];
-        }
-      } else {
-        // Fall back to scalar loads if misaligned
-        for (auto i = threadIdx.x; i < num_elements; i += blockDim.x) {
+    } else {
+      // Idea: we want to copy the entire segment of size sum_a(length_{b, t,
+      // a}) from starting point (given by cat_ad_offsets[b, t]) to end point
+      // (given by reordered_cat_ad_indices[t][b])
+      if (num_elements <= 64 || !(sizeof(Dtype) == 4 || sizeof(Dtype) == 8)) {
+        for (auto i = threadIdx.x; i < input_segment_end - input_segment_start;
+             i += blockDim.x) {
+          // coalesced global memory access, can be optimzed through ILP with
+          // the help of shared memory or vector load/store (if num_ads_b>=64)
           reordered_cat_ad_indices[output_segment_start + i] =
               cat_ad_indices[input_segment_start + i];
         }
-      }
-    } else if (num_elements > 128) {
-      // Check alignment for vec4_t (16-byte alignment required)
-      bool vec4_t_aligned =
-          reinterpret_cast<uintptr_t>(dst_ptr) % alignof(vec4_t) == 0 &&
-          reinterpret_cast<uintptr_t>(src_ptr) % alignof(vec4_t) == 0;
-      if (vec4_t_aligned) {
-        // Use vectorized loads if properly aligned
-        auto dst = (vec4_t*)dst_ptr;
-        auto src = (vec4_t*)src_ptr;
-        for (auto i = threadIdx.x; i < num_elements / 4; i += blockDim.x) {
-          dst[i] = src[i];
+      } else if (num_elements > 64 && num_elements <= 128) {
+        // Check alignment for vec2_t (8-byte alignment required)
+        bool vec2_t_aligned =
+            reinterpret_cast<uintptr_t>(dst_ptr) % alignof(vec2_t) == 0 &&
+            reinterpret_cast<uintptr_t>(src_ptr) % alignof(vec2_t) == 0;
+        if (vec2_t_aligned) {
+          // Use vectorized loads if properly aligned
+          auto dst = (vec2_t*)dst_ptr;
+          auto src = (vec2_t*)src_ptr;
+          for (auto i = threadIdx.x; i < num_elements / 2; i += blockDim.x) {
+            dst[i] = src[i];
+          }
+          if ((num_elements % 2) && threadIdx.x == 31) {
+            reordered_cat_ad_indices[output_segment_start + num_elements - 1] =
+                cat_ad_indices[input_segment_start + num_elements - 1];
+          }
+        } else {
+          // Fall back to scalar loads if misaligned
+          for (auto i = threadIdx.x; i < num_elements; i += blockDim.x) {
+            reordered_cat_ad_indices[output_segment_start + i] =
+                cat_ad_indices[input_segment_start + i];
+          }
         }
-        int remainder = num_elements % 4;
-        if (remainder && threadIdx.x < remainder) {
-          reordered_cat_ad_indices
-              [output_segment_start + num_elements - threadIdx.x - 1] =
-                  cat_ad_indices
-                      [input_segment_start + num_elements - threadIdx.x - 1];
-        }
-      } else {
-        // Fall back to scalar loads if misaligned
-        for (auto i = threadIdx.x; i < num_elements; i += blockDim.x) {
-          reordered_cat_ad_indices[output_segment_start + i] =
-              cat_ad_indices[input_segment_start + i];
+      } else if (num_elements > 128) {
+        // Check alignment for vec4_t (16-byte alignment required)
+        bool vec4_t_aligned =
+            reinterpret_cast<uintptr_t>(dst_ptr) % alignof(vec4_t) == 0 &&
+            reinterpret_cast<uintptr_t>(src_ptr) % alignof(vec4_t) == 0;
+        if (vec4_t_aligned) {
+          // Use vectorized loads if properly aligned
+          auto dst = (vec4_t*)dst_ptr;
+          auto src = (vec4_t*)src_ptr;
+          for (auto i = threadIdx.x; i < num_elements / 4; i += blockDim.x) {
+            dst[i] = src[i];
+          }
+          int remainder = num_elements % 4;
+          if (remainder && threadIdx.x < remainder) {
+            reordered_cat_ad_indices
+                [output_segment_start + num_elements - threadIdx.x - 1] =
+                    cat_ad_indices
+                        [input_segment_start + num_elements - threadIdx.x - 1];
+          }
+        } else {
+          // Fall back to scalar loads if misaligned
+          for (auto i = threadIdx.x; i < num_elements; i += blockDim.x) {
+            reordered_cat_ad_indices[output_segment_start + i] =
+                cat_ad_indices[input_segment_start + i];
+          }
         }
       }
     }
@@ -463,15 +477,24 @@ DLL_PUBLIC Tensor reorder_batched_ad_indices_gpu(
 #if defined __HIP_PLATFORM_AMD__
               constexpr auto NUM_WARPS = 4;
               const dim3 threads(32, NUM_WARPS); // 32 x 4
-              const dim3 blocks(cuda_calc_xblock_count(B * T, NUM_WARPS));
 #else
               constexpr auto NUM_WARPS = 32;
               auto maxWarpSize = kMaxThreads / NUM_WARPS;
               const dim3 threads(
                   NUM_WARPS,
                   maxWarpSize < kWarpSize ? maxWarpSize : kWarpSize); // 32 x 32
-              const dim3 blocks(cuda_calc_xblock_count(B * T, NUM_WARPS));
 #endif
+              // HIP enforces a hard limit of 2^32 total threads per launch
+              // (unlike CUDA, which silently wraps).
+              // reorder_batched_ad_indices_kernel_vec grid-strides over b_t,
+              // so capping is correctness-preserving.
+              // See: https://github.com/ROCm/hip/issues/2253
+              const dim3 blocks(
+                  utils::cuda::cap_grid_dim_x(
+                      cuda_calc_xblock_count(B * T, NUM_WARPS),
+                      static_cast<int64_t>(threads.x) *
+                          static_cast<int64_t>(threads.y),
+                      at::cuda::getCurrentCUDAStream()));
               FBGEMM_LAUNCH_KERNEL(
                   (reorder_batched_ad_indices_kernel_name),
                   blocks,
@@ -511,34 +534,35 @@ __launch_bounds__(kMaxThreads) void reorder_batched_sequence_embeddings_kernel(
     const int32_t D) {
   const int32_t B = batch_offsets.size(0) - 1;
   const int32_t num_items_in_batch = batch_offsets[B];
-  // warp-per-segment.
-  const auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
-  const int32_t b = b_t % B;
-  const int32_t t = b_t / B;
-  if (t >= T) {
-    return;
-  }
+  // warp-per-segment with grid-stride loop. A capped grid (used on ROCm to
+  // avoid the 2^32 launch-side limit) still covers all B*T segments.
+  const auto b_t_init = blockIdx.x * blockDim.y + threadIdx.y;
+  const auto stride = gridDim.x * blockDim.y;
+  for (auto b_t = b_t_init; b_t < B * T; b_t += stride) {
+    const int32_t b = b_t % B;
+    const int32_t t = b_t / B;
 
-  const auto num_ads_b = batch_offsets[b + 1] - batch_offsets[b];
-  const auto output_segment_offset_start =
-      t * num_items_in_batch + batch_offsets[b];
-  const auto output_segment_start =
-      reordered_cat_sequence_embeddings_offsets[output_segment_offset_start];
-  const int32_t input_segment_offset_start =
-      T * batch_offsets[b] + t * num_ads_b;
-  const int32_t input_segment_offset_end =
-      input_segment_offset_start + num_ads_b;
-  const auto input_segment_start =
-      cat_sequence_embeddings_offsets[input_segment_offset_start];
-  const auto input_segment_end =
-      cat_sequence_embeddings_offsets[input_segment_offset_end];
+    const auto num_ads_b = batch_offsets[b + 1] - batch_offsets[b];
+    const auto output_segment_offset_start =
+        t * num_items_in_batch + batch_offsets[b];
+    const auto output_segment_start =
+        reordered_cat_sequence_embeddings_offsets[output_segment_offset_start];
+    const int32_t input_segment_offset_start =
+        T * batch_offsets[b] + t * num_ads_b;
+    const int32_t input_segment_offset_end =
+        input_segment_offset_start + num_ads_b;
+    const auto input_segment_start =
+        cat_sequence_embeddings_offsets[input_segment_offset_start];
+    const auto input_segment_end =
+        cat_sequence_embeddings_offsets[input_segment_offset_end];
 
-  for (size_t i = 0; i < input_segment_end - input_segment_start; i++) {
-    const auto output_offset = output_segment_start + i;
-    const auto input_offset = input_segment_start + i;
-    for (auto d = threadIdx.x; d < D; d += blockDim.x) {
-      reordered_cat_sequence_embeddings[output_offset][d] =
-          cat_sequence_embeddings[input_offset][d];
+    for (size_t i = 0; i < input_segment_end - input_segment_start; i++) {
+      const auto output_offset = output_segment_start + i;
+      const auto input_offset = input_segment_start + i;
+      for (auto d = threadIdx.x; d < D; d += blockDim.x) {
+        reordered_cat_sequence_embeddings[output_offset][d] =
+            cat_sequence_embeddings[input_offset][d];
+      }
     }
   }
 }
@@ -568,7 +592,16 @@ DLL_PUBLIC Tensor reorder_batched_sequence_embeddings_gpu(
       at::empty_like(cat_sequence_embeddings);
 
   const dim3 threads(32, 32);
-  const dim3 blocks((B * T + 32 - 1) / 32);
+  const auto grid_size_uncapped = (B * T + 32 - 1) / 32;
+  // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
+  // which silently wraps). reorder_batched_sequence_embeddings_kernel
+  // grid-strides over b_t, so capping is correctness-preserving.
+  // See: https://github.com/ROCm/hip/issues/2253
+  const dim3 blocks(
+      utils::cuda::cap_grid_dim_x(
+          grid_size_uncapped,
+          static_cast<int64_t>(threads.x) * static_cast<int64_t>(threads.y),
+          at::cuda::getCurrentCUDAStream()));
 
   FBGEMM_DISPATCH_FLOATING_TYPES_AND(
       at::ScalarType::Byte,

--- a/fbgemm_gpu/test/sparse/reorder_batched_test.py
+++ b/fbgemm_gpu/test/sparse/reorder_batched_test.py
@@ -11,6 +11,7 @@
 
 import random
 import unittest
+from typing import Any, Callable
 
 import hypothesis.strategies as st
 import torch
@@ -20,10 +21,15 @@ from .common import extend_test_class, open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_unavailable, optests, skipIfRocm
+    from test_utils import gpu_memory_lt_gb, gpu_unavailable, optests, skipIfRocm
 else:
     import fbgemm_gpu.sparse_ops  # noqa: F401, E402
-    from fbgemm_gpu.test.test_utils import gpu_unavailable, optests, skipIfRocm
+    from fbgemm_gpu.test.test_utils import (
+        gpu_memory_lt_gb,
+        gpu_unavailable,
+        optests,
+        skipIfRocm,
+    )
 
 
 class ReorderBatchedTest(unittest.TestCase):
@@ -531,7 +537,7 @@ class ReorderBatchedTest(unittest.TestCase):
     ) -> None:
         MAX_H = 1000
         DIM = 32
-        device = torch.device("cuda")
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
         ref_embeddings = torch.rand(MAX_H, DIM, dtype=emb_dtype, device=device)
         feature_lengths = [
             torch.randint(
@@ -605,8 +611,189 @@ class ReorderBatchedTest(unittest.TestCase):
             reordered_sequence_embedding_from_indices, reordered_cat_sequence_embeddings
         )
 
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(4))
+    def test_reorder_batched_ad_lengths_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in reorder_batched_ad_lengths_kernel
+        and verifies output correctness against the CPU dispatch.
 
-extend_test_class(ReorderBatchedTest)
+        With block dim3(32, 32) (1024 threads per block), grid = (B*T+31)/32.
+        Total threads ~= B*T * 32. For B*T > 2**27, total threads exceed the
+        HIP 2**32 limit, causing FBGEMM_LAUNCH_KERNEL ->
+        KernelLauncher::checkThreadCountNotExceeded to TORCH_CHECK-fail on
+        ROCm pre-fix.
+
+        ``cat_ad_lengths`` is sparse: zero everywhere except sentinel
+        non-zero entries at start / middle / end so any "kernel
+        addressed wrong row" bug surfaces in the assertion below.
+        """
+        T = 1
+        B = (1 << 27) + 1  # B*T > 2**27
+        num_ads_in_batch = B
+
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+
+        # Sparse non-zero lengths at sentinel positions.
+        cat_ad_lengths_cpu = torch.zeros(T * B, dtype=torch.int32)
+        cat_ad_lengths_cpu[0] = 1
+        cat_ad_lengths_cpu[(T * B) // 2] = 2
+        cat_ad_lengths_cpu[T * B - 1] = 3
+        batch_offsets_cpu = torch.arange(B + 1, dtype=torch.int32)
+
+        # CPU reference oracle.
+        reordered_cpu = torch.ops.fbgemm.reorder_batched_ad_lengths(
+            cat_ad_lengths_cpu, batch_offsets_cpu, num_ads_in_batch, False, -1
+        )
+
+        # GPU op under test. Pre-fix, this launch trips
+        # KernelLauncher::checkThreadCountNotExceeded on ROCm.
+        reordered_gpu = torch.ops.fbgemm.reorder_batched_ad_lengths(
+            cat_ad_lengths_cpu.to(device),
+            batch_offsets_cpu.to(device),
+            num_ads_in_batch,
+            False,
+            -1,
+        )
+
+        torch.testing.assert_close(reordered_gpu.cpu(), reordered_cpu)
+
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(4))
+    def test_reorder_batched_ad_indices_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in
+        reorder_batched_ad_indices_kernel_vec and verifies output
+        correctness against the CPU dispatch. AMD branch uses
+        dim3(32, NUM_WARPS=4) blocks; total threads ~= B*T * 32.
+
+        ``cat_ad_offsets`` is sparse: most segments have length zero with
+        sentinel non-zero entries at start / middle / end, so the kernel
+        actually reorders a small number of indices while the launch
+        grid still trips the cap pre-fix.
+        """
+        T = 1
+        B = (1 << 27) + 1
+        num_ads_in_batch = B
+
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+
+        # Sparse non-zero lengths at sentinel positions, total = 6.
+        lengths_cpu = torch.zeros(T * B, dtype=torch.int32)
+        lengths_cpu[0] = 1
+        lengths_cpu[(T * B) // 2] = 2
+        lengths_cpu[T * B - 1] = 3
+        # Cumulative offsets.
+        cat_ad_offsets_cpu = torch.zeros(T * B + 1, dtype=torch.int32)
+        cat_ad_offsets_cpu[1:] = torch.cumsum(lengths_cpu, dim=0).to(torch.int32)
+        # Distinct indices so any out-of-order copy bug surfaces.
+        cat_ad_indices_cpu = torch.tensor([10, 20, 21, 30, 31, 32], dtype=torch.int32)
+        batch_offsets_cpu = torch.arange(B + 1, dtype=torch.int32)
+        # reordered_cat_ad_offsets matches cat_ad_offsets when num_ads_in_batch == B.
+        reordered_cat_ad_offsets_cpu = cat_ad_offsets_cpu.clone()
+
+        # CPU reference oracle.
+        reordered_cpu = torch.ops.fbgemm.reorder_batched_ad_indices(
+            cat_ad_offsets_cpu,
+            cat_ad_indices_cpu,
+            reordered_cat_ad_offsets_cpu,
+            batch_offsets_cpu,
+            num_ads_in_batch,
+            False,  # broadcast_indices
+            int(cat_ad_indices_cpu.numel()),
+        )
+
+        # GPU op under test.
+        reordered_gpu = torch.ops.fbgemm.reorder_batched_ad_indices(
+            cat_ad_offsets_cpu.to(device),
+            cat_ad_indices_cpu.to(device),
+            reordered_cat_ad_offsets_cpu.to(device),
+            batch_offsets_cpu.to(device),
+            num_ads_in_batch,
+            False,
+            int(cat_ad_indices_cpu.numel()),
+        )
+
+        torch.testing.assert_close(reordered_gpu.cpu(), reordered_cpu)
+
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(4))
+    def test_reorder_batched_sequence_embeddings_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in
+        reorder_batched_sequence_embeddings_kernel and verifies output
+        correctness against the CPU dispatch.
+
+        ``cat_sequence_embeddings_offsets`` is sparse with sentinel
+        non-zero segments at start / middle / end; the embedding values
+        are distinct per row so any "kernel addressed wrong row" bug
+        surfaces.
+        """
+        T = 1
+        B = (1 << 27) + 1
+        num_items_in_batch = B
+
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+
+        # Sparse non-zero lengths, total = 6.
+        lengths_cpu = torch.zeros(T * B, dtype=torch.int32)
+        lengths_cpu[0] = 1
+        lengths_cpu[(T * B) // 2] = 2
+        lengths_cpu[T * B - 1] = 3
+        cat_seq_offsets_cpu = torch.zeros(T * B + 1, dtype=torch.int32)
+        cat_seq_offsets_cpu[1:] = torch.cumsum(lengths_cpu, dim=0).to(torch.int32)
+        # Distinct embedding values, shape (6, D).
+        cat_seq_emb_cpu = torch.tensor(
+            [[1.0], [2.0], [3.0], [4.0], [5.0], [6.0]], dtype=torch.float32
+        )
+        reordered_cat_seq_offsets_cpu = cat_seq_offsets_cpu.clone()
+        batch_offsets_cpu = torch.arange(B + 1, dtype=torch.int32)
+
+        # CPU reference oracle.
+        reordered_cpu = torch.ops.fbgemm.reorder_batched_sequence_embeddings(
+            cat_seq_offsets_cpu,
+            cat_seq_emb_cpu,
+            reordered_cat_seq_offsets_cpu,
+            batch_offsets_cpu,
+            num_items_in_batch,
+        )
+
+        # GPU op under test.
+        reordered_gpu = torch.ops.fbgemm.reorder_batched_sequence_embeddings(
+            cat_seq_offsets_cpu.to(device),
+            cat_seq_emb_cpu.to(device),
+            reordered_cat_seq_offsets_cpu.to(device),
+            batch_offsets_cpu.to(device),
+            num_items_in_batch,
+        )
+
+        torch.testing.assert_close(reordered_gpu.cpu(), reordered_cpu)
+
+
+# Large-grid tests allocate B = 2^27 elements, which causes OOM/timeout
+# during opcheck tracing (faketensor, aot_dispatch_dynamic).  Skip them.
+additional_decorators: dict[str, list[Callable[..., Any]]] = {
+    "test_faketensor__test_reorder_batched_ad_lengths_large_grid": [
+        unittest.skip("large-grid test OOMs under faketensor tracing")
+    ],
+    "test_aot_dispatch_dynamic__test_reorder_batched_ad_lengths_large_grid": [
+        unittest.skip("large-grid test OOMs under aot_dispatch tracing")
+    ],
+    "test_faketensor__test_reorder_batched_ad_indices_large_grid": [
+        unittest.skip("large-grid test OOMs under faketensor tracing")
+    ],
+    "test_aot_dispatch_dynamic__test_reorder_batched_ad_indices_large_grid": [
+        unittest.skip("large-grid test OOMs under aot_dispatch tracing")
+    ],
+    "test_faketensor__test_reorder_batched_sequence_embeddings_large_grid": [
+        unittest.skip("large-grid test OOMs under faketensor tracing")
+    ],
+    "test_aot_dispatch_dynamic__test_reorder_batched_sequence_embeddings_large_grid": [
+        unittest.skip("large-grid test OOMs under aot_dispatch tracing")
+    ],
+}
+
+extend_test_class(ReorderBatchedTest, additional_decorators)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2855


Tier-2 fix for HIP grid-overflow in `sparse_ops/sparse_reorder_batched_ad.cu`. Three saturating kernels — all using direct `b_t = blockIdx.x * blockDim.y + threadIdx.y` with early-returns.

Changes:
- `reorder_batched_ad_lengths_kernel`: Pattern B grid-stride loop over `b_t`. The `t >= T` early-return becomes the implicit loop bound.
- `reorder_batched_ad_indices_kernel` and `reorder_batched_ad_indices_kernel_vec`: Pattern B grid-stride loop. All per-iteration locals (`output_segment_*`, `input_segment_*`, `num_elements`, `dst_ptr`, `src_ptr`) reset naturally. Inner `if (num_elements <= 64) / else if ... <= 128 / else > 128` branch dispatch is also per-iteration.
- `reorder_batched_sequence_embeddings_kernel`: Pattern B grid-stride loop. Inner per-row and per-D loops are intra-block and unchanged.

Apply standard `#ifdef USE_ROCM min(grid_uncapped, get_max_thread_blocks(stream)) #else grid_uncapped #endif` cap to all three launch sites:
- `reorder_batched_ad_lengths_gpu`: `grid_size = (B*T+31)/32` (manual ceil-div).
- `reorder_batched_ad_indices_gpu`: `cuda_calc_xblock_count(B*T, NUM_WARPS)` cap is applied once outside the `#if defined __HIP_PLATFORM_AMD__ / #else / #endif` block, after `NUM_WARPS` is determined.
- `reorder_batched_sequence_embeddings_gpu`: `(B*T+31)/32` (manual ceil-div).

Stacked on top of D105029511 (Tier-2 Diff 6/7). Plan:
`/home/bensonma415/.llms/plans/sparse_ops_rocm_grid_overflow_tier2_fix.plan.md` (Diff 7/7) — final diff in the Tier-2 stack.

Reviewed By: henrylhtsang

Differential Revision: D105030655


