### PR TITLE
Add FBGEMM 1.6/1.7/1.8 entries to PyTorch compat table

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/__init__.py
@@ -15,6 +15,9 @@ import torch
 # Based on the FBGEMM-PyTorch compatibility table at
 # https://docs.pytorch.org/FBGEMM/general/Releases.html#fbgemm-releases-compatibility
 _fbgemm_torch_compat_table = {
+    "1.8": "2.13",
+    "1.7": "2.12",
+    "1.6": "2.11",
     "1.5": "2.10",
     "1.4": "2.9",
     "1.3": "2.8",


### PR DESCRIPTION
Summary:
The `_fbgemm_torch_compat_table` in `fbgemm_gpu/__init__.py` lagged behind the published FBGEMM-PyTorch compatibility table. It topped out at FBGEMM `1.5` -> PyTorch `2.10`, while `Releases.rst` already lists `1.6.0` -> `2.11.x`.

This adds three entries at the top of the table:
- `1.6` -> `2.11` (confirmed against `Releases.rst`)
- `1.7` -> `2.12` (confirmed by the v1.7.0 release announcement: https://fb.workplace.com/groups/fbgemmusers/permalink/27222344027419687/)
- `1.8` -> `2.13` (inferred from the minor-for-minor pattern)

> **NOTE:** `1.6` is backed by the published `Releases.rst` table and `1.7` by the v1.7.0 release announcement, but neither `1.7` nor `1.8` is yet reflected in `Releases.rst` (the doc still tops out at `1.6.0`). The `1.8` mapping is extrapolated from the consistent minor-for-minor PyTorch versioning pattern. These rows should be reconciled with `Releases.rst` once the corresponding FBGEMM releases are cut and their actual PyTorch / Python / CUDA / ROCm support matrices are known.

Differential Revision: D109308705


