### PR TITLE
Migrate OMP use to Aten/Parallel.h (#5947)

### DIFF
--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_cpu.cpp
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_cpu.cpp
@@ -17,12 +17,11 @@
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
 #ifdef FBCODE_CAFFE2
 #include <libdivide.h>
-#else
-#include <omp.h>
 #endif
 
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
+#include <ATen/Parallel.h>
 #include <ATen/core/op_registration/op_registration.h>
 #include <torch/script.h>
 
@@ -444,28 +443,29 @@ void csr2csc_template_(
        feature < table_to_feature_offset[1];
        ++feature) {
     const auto FBs = (feature - table_to_feature_offset[0]) * B;
-#pragma omp parallel for
-    for (int b = 0; b < B; ++b) {
-      const auto FBb = feature * B + b;
-      const auto pool_begin = csr_offsets[FBb];
-      const auto pool_end = csr_offsets[FBb + 1];
-      const auto L = pool_end - pool_begin;
-      // MEAN pooling will not work with indice_weights!
-      double scale_factor =
-          (static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN &&
-           !has_weights && L > 0)
-          ? 1.0 / L
-          : 1.0;
-      for (const auto p : c10::irange(pool_begin, pool_end)) {
-        tmpBufKeys[p - FBo] = csr_indices[p];
-        if constexpr (IS_VALUE_PAIR) {
-          tmpBufValues[p - FBo] = std::pair{
-              FBs + b, scale_factor * (has_weights ? csr_weights[p] : 1.0f)};
-        } else {
-          tmpBufValues[p - FBo] = FBs + b;
+    at::parallel_for(0, B, 0, [&](int64_t b_begin, int64_t b_end) {
+      for (int b = b_begin; b < b_end; ++b) {
+        const auto FBb = feature * B + b;
+        const auto pool_begin = csr_offsets[FBb];
+        const auto pool_end = csr_offsets[FBb + 1];
+        const auto L = pool_end - pool_begin;
+        // MEAN pooling will not work with indice_weights!
+        double scale_factor =
+            (static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN &&
+             !has_weights && L > 0)
+            ? 1.0 / L
+            : 1.0;
+        for (const auto p : c10::irange(pool_begin, pool_end)) {
+          tmpBufKeys[p - FBo] = csr_indices[p];
+          if constexpr (IS_VALUE_PAIR) {
+            tmpBufValues[p - FBo] = std::pair{
+                FBs + b, scale_factor * (has_weights ? csr_weights[p] : 1.0f)};
+          } else {
+            tmpBufValues[p - FBo] = FBs + b;
+          }
         }
       }
-    }
+    });
   }
 
   int* sorted_col_row_index_keys;
@@ -479,32 +479,32 @@ void csr2csc_template_(
           NS,
           num_embeddings);
 
-  int max_thds = omp_get_max_threads();
-  int num_uniq[max_thds][64];
-  for (const auto i : c10::irange(max_thds)) {
-    num_uniq[i][0] = 0;
-  }
+  int num_chunks =
+      std::min<int>(at::get_num_threads(), std::max<int>(1, NS - 1));
+  std::vector<int> chunk_uniq_counts(num_chunks, 0);
+  std::vector<int> chunk_uniq_offsets(num_chunks + 1, 0);
 
-  int U = 0;
-  if (at::get_num_threads() > 1) {
-    // This block is not needed for single thread
-#pragma omp parallel
-    {
-      int tid = omp_get_thread_num();
-      num_uniq[tid][0] = 0;
-#pragma omp for schedule(static)
-      for (int i = 1; i < NS; i++) {
-        if (sorted_col_row_index_keys[i] != sorted_col_row_index_keys[i - 1]) {
-          num_uniq[tid][0]++;
+  at::parallel_for(
+      0, num_chunks, 1, [&](int64_t chunk_begin, int64_t chunk_end) {
+        for (int64_t c = chunk_begin; c < chunk_end; ++c) {
+          int64_t begin = 1 + c * (NS - 1) / num_chunks;
+          int64_t end = 1 + (c + 1) * (NS - 1) / num_chunks;
+          int local_count = 0;
+          for (int i = begin; i < end; i++) {
+            if (sorted_col_row_index_keys[i] !=
+                sorted_col_row_index_keys[i - 1]) {
+              local_count++;
+            }
+          }
+          chunk_uniq_counts[c] = local_count;
         }
-      }
-    }
-    num_uniq[0][0] += 1;
-    for (const auto i : c10::irange(1, max_thds)) {
-      num_uniq[i][0] += num_uniq[i - 1][0];
-    }
-    U = num_uniq[max_thds - 1][0];
+      });
+
+  chunk_uniq_offsets[0] = 0;
+  for (int c = 0; c < num_chunks; ++c) {
+    chunk_uniq_offsets[c + 1] = chunk_uniq_offsets[c] + chunk_uniq_counts[c];
   }
+  int U = chunk_uniq_offsets[num_chunks] + 1;
 
   csc.column_segment_ptr = fbgemm::makeAlignedUniquePtr<int>(64, NS + 1);
   csc.column_segment_indices = fbgemm::makeAlignedUniquePtr<int>(64, NS);
@@ -526,35 +526,21 @@ void csr2csc_template_(
   int* col_seg_indices = csc.column_segment_indices.get();
   int* col_seg_ptr = csc.column_segment_ptr.get();
 
-#pragma omp parallel
-  {
-    int tid = omp_get_thread_num();
-    int* tstart =
-        (tid == 0 ? col_seg_indices + 1
-                  : col_seg_indices + num_uniq[tid - 1][0]);
-
-    int* t_offs =
-        (tid == 0 ? col_seg_ptr + 1 : col_seg_ptr + num_uniq[tid - 1][0]);
-
-    if (!IS_VALUE_PAIR && !is_shared_table) {
-      // For non shared table, no need for computing modulo.
-      // As an optimization, pointer swap instead of copying.
-#pragma omp master
-      {
-        auto& buf = sorted_col_row_index_values == tmpBufValues.get()
-            ? tmpBufValues
-            : tmpBuf1Values;
-        int* tmp = csc.row_indices.release();
-        csc.row_indices.reset(reinterpret_cast<int*>(buf.release()));
-        buf.reset(reinterpret_cast<value_t*>(tmp));
-      }
-    } else {
+  if (!IS_VALUE_PAIR && !is_shared_table) {
+    // For non shared table, no need for computing modulo.
+    // As an optimization, pointer swap instead of copying.
+    auto& buf = sorted_col_row_index_values == tmpBufValues.get()
+        ? tmpBufValues
+        : tmpBuf1Values;
+    int* tmp = csc.row_indices.release();
+    csc.row_indices.reset(reinterpret_cast<int*>(buf.release()));
+    buf.reset(reinterpret_cast<value_t*>(tmp));
+  } else {
 #ifdef FBCODE_CAFFE2
-      libdivide::divider<int> divisor(B);
+    libdivide::divider<int> divisor(B);
 #endif
-
-#pragma omp for schedule(static)
-      for (int i = 1; i < NS; ++i) {
+    at::parallel_for(1, NS, 0, [&](int64_t begin, int64_t end) {
+      for (int i = begin; i < end; ++i) {
         int v = IS_VALUE_PAIR ? sorted_col_row_index_values_pair[i].first
                               : sorted_col_row_index_values_int[i];
 #ifdef FBCODE_CAFFE2
@@ -568,24 +554,29 @@ void csr2csc_template_(
           csc.weights[i] = sorted_col_row_index_values_pair[i].second;
         }
       }
-    }
+    });
+  }
 
-#pragma omp for schedule(static)
-    for (int i = 1; i < NS; ++i) {
-      if (sorted_col_row_index_keys[i] != sorted_col_row_index_keys[i - 1]) {
-        *tstart = sorted_col_row_index_keys[i];
-        *t_offs = i;
-        tstart++;
-        t_offs++;
-      }
-    }
+  at::parallel_for(
+      0, num_chunks, 1, [&](int64_t chunk_begin, int64_t chunk_end) {
+        for (int64_t c = chunk_begin; c < chunk_end; ++c) {
+          int64_t begin = 1 + c * (NS - 1) / num_chunks;
+          int64_t end = 1 + (c + 1) * (NS - 1) / num_chunks;
 
-    if (at::get_num_threads() == 1 && tid == 0) {
-      // Special handling of single thread case
-      U = t_offs - csc.column_segment_ptr.get();
-    }
+          int* tstart = col_seg_indices + 1 + chunk_uniq_offsets[c];
+          int* t_offs = col_seg_ptr + 1 + chunk_uniq_offsets[c];
 
-  } // omp parallel
+          for (int i = begin; i < end; ++i) {
+            if (sorted_col_row_index_keys[i] !=
+                sorted_col_row_index_keys[i - 1]) {
+              *tstart = sorted_col_row_index_keys[i];
+              *t_offs = i;
+              tstart++;
+              t_offs++;
+            }
+          }
+        }
+      });
 
   csc.num_non_zero_columns = U;
   csc.column_segment_ptr[U] = NS;


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2862

This is the only direct use of `omp` in the library, and I believe that if we migrate to using `Aten/Parallel.h` it will use `omp` under the hood if `pytorch` is built with `AT_PARALLEL_OPENMP` set to 1 anyway, so this allows `fbgemm_gpu` users to set their threading model consistently based on their PyTorch build.


Test Plan:
Ran the CPU unit test that directly exercises the rewritten `csr2csc_template_` (the function this diff migrates from `#pragma omp` to `at::parallel_for`), covering both `index_t` instantiations:

```
buck2 test fbcode//mode/opt fbcode//deeplearning/fbgemm/fbgemm_gpu/test/tbe:cpu_kernel
```

Result: Pass 2. Fail 0.  (CpuKernelTest.csr2csc_test_int32, CpuKernelTest.csr2csc_test_int64)
Test session: https://www.internalfb.com/intern/testinfra/testrun/26458647838875303

Higher-level TBE suites that exercise csr2csc indirectly:

```
buck2 test fbcode//mode/opt \
  fbcode//deeplearning/fbgemm/fbgemm_gpu/test/tbe:forward \
  fbcode//deeplearning/fbgemm/fbgemm_gpu/test/tbe:backward_sgd
```

Not exercised locally: the Python test runtime fails with `cannot execute binary file: Exec format error` (signal 126) on this aarch64 devserver, including the CPU-only cases (e.g. test_forward_cpu_fp32, test_backward_sgd_fp32_pmNONE_cpu). This is a host arch/toolchain limitation, not a code issue. Run these on an x86_64 GPU host or via Sandcastle CI.

Differential Revision: D109460231

Pulled By: q10
