### PR TITLE
Round-4 OMH residuals: GPU-only opcheck suppression, timeouts, flaky test fixes

### DIFF
--- a/fbgemm_gpu/test/jagged/failures_dict.json
+++ b/fbgemm_gpu/test/jagged/failures_dict.json
@@ -85,7 +85,12 @@
         "status": "xfail"
       }
     },
-    "fbgemm::jagged_index_select": {},
+    "fbgemm::jagged_index_select": {
+      "JaggedIndexSelect2DTest.test_aot_dispatch_dynamic__test_jagged_index_select_2d": {
+        "comment": "Not an op bug: fails in AOT-autograd setup, where a real empty tensor is detached under FakeTensorMode (aten.detach.default(tensor([]))). The meta/_check_is_size is correct and faketensor passes. Skip (not xfail) so it does not flag the PT2-compliant op. T191384137",
+        "status": "skip"
+      }
+    },
     "fbgemm::jagged_jagged_bmm": {},
     "fbgemm::jagged_slice": {
       "JaggedSliceTest.test_aot_dispatch_dynamic__test_jagged_slice": {

--- a/fbgemm_gpu/test/jagged/keyed_jagged_index_select_test.py
+++ b/fbgemm_gpu/test/jagged/keyed_jagged_index_select_test.py
@@ -224,6 +224,10 @@ class KeyedJaggedIndexSelectTest(unittest.TestCase):
             use_selected_lengths_sum,
         )
 
+    @optests.dontGenerateOpCheckTests(
+        "int32-overflow GPU-memory-gated stress repro; opcheck variants only skip "
+        "on CPU samples and add no op coverage (T191384137)"
+    )
     @given(
         index_dtype=st.sampled_from([torch.int, torch.long]),
         jagged_tensor_dtype=st.sampled_from(

--- a/fbgemm_gpu/test/sparse/block_bucketize_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_test.py
@@ -20,13 +20,14 @@ from .common import extend_test_class, open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_available, gpu_memory_lt_gb, gpu_unavailable
+    from test_utils import gpu_available, gpu_memory_lt_gb, gpu_unavailable, optests
 else:
     import fbgemm_gpu.sparse_ops  # noqa: F401, E402  (registers FakeTensor/meta impls)
     from fbgemm_gpu.test.test_utils import (
         gpu_available,
         gpu_memory_lt_gb,
         gpu_unavailable,
+        optests,
     )
 
 
@@ -2150,6 +2151,10 @@ class BlockBucketizeTest(unittest.TestCase):
 
     @unittest.skipIf(*gpu_unavailable)
     @unittest.skipIf(*gpu_memory_lt_gb(4))
+    @optests.dontGenerateOpCheckTests(
+        "large-grid GPU-memory-gated stress repro; opcheck variants only skip on "
+        "CPU samples and add no op coverage (T191384137)"
+    )
     def test_block_bucketize_sparse_features_populate_large_grid(self) -> None:
         """
         Reproduces the HIP grid-overflow bug in
@@ -2221,6 +2226,10 @@ class BlockBucketizeTest(unittest.TestCase):
     # bucketized_lengths is int32[lengths_size * my_size] (~2.1 GiB at
     # the chosen lengths_size); the output permutation is tiny.
     @unittest.skipIf(*gpu_memory_lt_gb(8))
+    @optests.dontGenerateOpCheckTests(
+        "large-grid GPU-memory-gated stress repro; opcheck variants only skip on "
+        "CPU samples and add no op coverage (T191384137)"
+    )
     def test_populate_bucketized_permute_warp_parallel_large_grid(self) -> None:
         """
         Reproduces the HIP grid-overflow bug in

--- a/fbgemm_gpu/test/sparse/cumsum_test.py
+++ b/fbgemm_gpu/test/sparse/cumsum_test.py
@@ -19,13 +19,14 @@ from .common import extend_test_class, open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import cpu_and_maybe_gpu, gpu_memory_lt_gb, gpu_unavailable
+    from test_utils import cpu_and_maybe_gpu, gpu_memory_lt_gb, gpu_unavailable, optests
 else:
     import fbgemm_gpu.sparse_ops  # noqa: F401, E402
     from fbgemm_gpu.test.test_utils import (
         cpu_and_maybe_gpu,
         gpu_memory_lt_gb,
         gpu_unavailable,
+        optests,
     )
 
 
@@ -174,6 +175,10 @@ class CumSumTest(unittest.TestCase):
 
     @unittest.skipIf(*gpu_unavailable)
     @unittest.skipIf(*gpu_memory_lt_gb(4))
+    @optests.dontGenerateOpCheckTests(
+        "large-grid GPU-memory-gated stress repro; opcheck variants only skip on "
+        "CPU samples and add no op coverage (T191384137)"
+    )
     def test_asynchronous_batched_complete_cumsum_large_grid(self) -> None:
         """
         Reproduces the HIP grid-overflow bug in _batched_complete_cumsum_kernel

--- a/fbgemm_gpu/test/sparse/index_select_test.py
+++ b/fbgemm_gpu/test/sparse/index_select_test.py
@@ -33,6 +33,10 @@ else:
 
 
 class IndexSelectTest(unittest.TestCase):
+    @optests.dontGenerateOpCheckTests(
+        "opcheck variants of index_select_dim0 hang under the harness; the base "
+        "test covers the op on CPU+GPU (T191384137)"
+    )
     @given(
         N=st.integers(1, 32),
         shape=st.one_of(
@@ -553,11 +557,6 @@ class IndexSelectTest(unittest.TestCase):
 # Please avoid putting tests here, you should put operator-specific
 # skips and failures in deeplearning/fbgemm/fbgemm_gpu/test/failures_dict.json
 additional_decorators: dict[str, list[Callable[..., Any]]] = {
-    "test_aot_dispatch_dynamic__test_index_select_dim0": [unittest.skip("hangs")],
-    "test_aot_dispatch_static__test_index_select_dim0": [unittest.skip("hangs")],
-    "test_faketensor__test_index_select_dim0": [unittest.skip("hangs")],
-    "test_autograd_registration__test_index_select_dim0": [unittest.skip("hangs")],
-    "test_schema__test_index_select_dim0": [unittest.skip("hangs")],
     "test_faketensor__test_group_index_select_dim0": [unittest.skip("hangs")],
 }
 

--- a/fbgemm_gpu/test/sparse/zipf_test.py
+++ b/fbgemm_gpu/test/sparse/zipf_test.py
@@ -26,8 +26,9 @@ else:
 class ZipfTest(unittest.TestCase):
     @unittest.skipIf(*gpu_unavailable)
     # Skip on GPUs with insufficient HBM. The test allocates int64[n] for
-    # n = 2**32 + 1 (~32 GiB) so we need a GPU with ~36 GiB of free HBM.
-    @unittest.skipIf(*gpu_memory_lt_gb(36))
+    # n = 2**32 + 1 (~32 GiB), so it needs a large-HBM GPU. Gate at 64 GiB to
+    # avoid OOM/timeouts on 36-42 GiB CI GPUs (it only needs to run somewhere).
+    @unittest.skipIf(*gpu_memory_lt_gb(64))
     # large-grid CUDA-only stress repro (allocates ~32 GiB); the generated
     # opcheck variants add no op-schema coverage and only produce FAILURE/
     # SKIPPING test-health records on CPU/small-GPU runs (T191384137).


### PR DESCRIPTION
Summary:
Round-4 fbgemm_dev OMH test-health fixes (T191384137). Grounded in meta
testinfra run data; addresses the residual open records not covered by the
landed stack (D108979354 -> D109040643 -> D109227373 -> D109233312).

dontGenerateOpCheckTests on GPU-only large-grid / int32-overflow stress repros
whose generated opcheck variants only skip on CPU/AMD samples and add no op
coverage (placed above given so the marker survives the hypothesis wrapper):
- block_bucketize: test_block_bucketize_sparse_features_populate_large_grid,
  test_populate_bucketized_permute_warp_parallel_large_grid
- cumsum: test_asynchronous_batched_complete_cumsum_large_grid
- index_select: test_index_select_dim0 (replaces 5 stale unittest.skip("hangs")
  per-variant entries in additional_decorators; base still covers CPU+GPU)
- keyed_jagged_index_select: test_keyed_jagged_index_select_dim1_int32_overflow

failures_dict (skip; eager + faketensor still cover the op):
- cumsum test_aot_dispatch_dynamic__test_batched_complete_cumsum: xfail->skip
  (xfail still ran -> per-example PT2 recompile exceeded the 600s tpx timeout)
- jagged_index_select_2d test_aot_dispatch_dynamic__test_jagged_index_select_2d:
  fails in AOT-autograd setup (real empty tensor detached under FakeTensorMode),
  not an op/meta bug

Flaky / timeout fixes:
- layer_norm test_swish_layer_norm: max_examples 20->10 (ran 520-575s vs 600s cap)
- kmeans test_kmeans_compute_centroids: suppress HealthCheck.too_slow
- zipf test_zipf_large_n_grid: HBM guard gpu_memory_lt_gb(36)->(64) so the ~32GiB
  alloc only runs on big GPUs (OOM/timeout on 36-42GB CI GPUs)
- utils_manifold_client_test TestSyncCreateAndRemoveDirectory: randomize the
  directory path per run (shared hardcoded path raced under stress -> ~55% flaky)

Reviewed By: spcyppt

Differential Revision: D109395630


