### PR TITLE
Implement DRAM+SSD composite logic in DramSsdKVEmbeddingCache (#5951)

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -41,6 +41,11 @@
 #include "feature_evict.h"
 #include "fixed_block_pool.h"
 
+namespace kv_db {
+template <typename W>
+class DramSsdKVEmbeddingCache;
+} // namespace kv_db
+
 namespace kv_mem {
 
 #define TORCH_CHECK_TENSOR_PROPERTIES(tensor, scalar_type) \
@@ -75,6 +80,9 @@ namespace kv_mem {
 ///
 template <typename weight_type>
 class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
+  template <typename W>
+  friend class kv_db::DramSsdKVEmbeddingCache;
+
  public:
   /// DramKVEmbeddingCache constructor
   ///

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_ssd_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_ssd_kv_embedding_cache.h
@@ -8,53 +8,281 @@
 
 #pragma once
 
+#include <folly/MPMCQueue.h>
+#include <folly/coro/BlockingWait.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/futures/Future.h>
+#include <folly/logging/xlog.h>
+#include <thread>
 
 #include "dram_kv_embedding_cache.h"
 
 namespace kv_db {
 
+/// A batch of dirty blocks evicted from DRAM, to be written to SSD.
+struct WriteBatchItem {
+  std::vector<std::pair<int64_t, std::string>> blocks; // key -> serialized
+};
+
 /// @ingroup KVMemEmbedding
 ///
-/// @brief Composite backend that wraps the DRAM (L2) embedding cache.
+/// @brief Composite backend that orchestrates DRAM (L2) + RocksDB SSD (L3).
 ///
-/// This is the forwarding skeleton: every EmbeddingKVDB method delegates to
-/// the wrapped DRAM cache. The SSD (L3) tier and its orchestration (two-phase
-/// lookup, async backfill, eviction writeback, flush-to-SSD, and checkpoint
-/// reads) are layered on top in a follow-up.
+/// Lookup path: DRAM first -> SSD for misses -> backfill DRAM on SSD hits.
+/// Write path: Write to DRAM only (dirty bit marks for eventual SSD writeback).
+/// Eviction path: Dirty blocks evicted from DRAM are enqueued to a writeback
+/// queue and asynchronously flushed to SSD by a background thread.
+///
+/// Checkpoint: flush() drains all dirty DRAM blocks to SSD, then the caller
+/// can create a RocksDB snapshot for consistent reads.
 ///
 template <typename weight_type>
 class DramSsdKVEmbeddingCache : public EmbeddingKVDB {
  public:
-  /// Construct the composite backend over the DRAM tier (L2).
+  /// Construct the composite backend.
   ///
   /// @param dram_cache The DRAM tier (L2)
-  explicit DramSsdKVEmbeddingCache(
-      std::shared_ptr<kv_mem::DramKVEmbeddingCache<weight_type>> dram_cache)
+  /// @param rocksdb_backend The SSD tier (L3), an EmbeddingKVDB implementation
+  /// @param writeback_queue_size Capacity of the writeback queue
+  /// @param writeback_batch_size Max items to batch-write to SSD per iteration
+  DramSsdKVEmbeddingCache(
+      std::shared_ptr<kv_mem::DramKVEmbeddingCache<weight_type>> dram_cache,
+      std::shared_ptr<EmbeddingKVDB> rocksdb_backend,
+      int64_t writeback_queue_size = 1024,
+      int64_t writeback_batch_size = 1024)
       : EmbeddingKVDB(
             require_dram_cache(dram_cache)->get_num_shards(),
             require_dram_cache(dram_cache)->get_max_D(),
             /*cache_size_gb=*/0,
             /*unique_id=*/0,
             /*ele_size_bytes=*/sizeof(weight_type)),
-        dram_cache_(std::move(dram_cache)) {}
+        dram_cache_(std::move(dram_cache)),
+        rocksdb_backend_(std::move(rocksdb_backend)),
+        writeback_queue_(writeback_queue_size),
+        writeback_batch_size_(writeback_batch_size),
+        metaheader_dim_(
+            kv_mem::FixedBlockPool::get_metaheader_dim<weight_type>()) {
+    TORCH_CHECK(
+        dram_cache_->get_backend_return_whole_row(),
+        "DramSsdKVEmbeddingCache requires the DRAM cache to be constructed "
+        "with backend_return_whole_row=true; checkpoint restore is not "
+        "supported otherwise.");
 
-  ~DramSsdKVEmbeddingCache() override = default;
+    // Wire eviction writeback callback (Step 2)
+    // When DRAM evicts dirty blocks, they are enqueued to writeback queue.
+    auto* feature_evict = dram_cache_->get_feature_evict();
+    if (feature_evict) {
+      feature_evict->set_writeback_callback(
+          [this](std::vector<std::pair<int64_t, std::string>> batch) {
+            enqueue_writeback(WriteBatchItem{std::move(batch)});
+          });
+    }
 
-  // --- Core EmbeddingKVDB interface (forwarded to DRAM) ---
+    // Dedicated executor for async DRAM backfill (won't compete with
+    // L2 cache or forward/backward thread pools).
+    backfill_executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(2);
 
+    // Start background writeback thread
+    start_writeback_thread();
+  }
+
+  ~DramSsdKVEmbeddingCache() override {
+    stop_writeback_thread();
+  }
+
+  // --- SSD metrics accessors ---
+
+  int64_t get_ssd_num_lookups() const {
+    return ssd_num_lookups_.load(std::memory_order_relaxed);
+  }
+  int64_t get_ssd_num_hits() const {
+    return ssd_num_hits_.load(std::memory_order_relaxed);
+  }
+  int64_t get_ssd_num_writes() const {
+    return ssd_num_writes_.load(std::memory_order_relaxed);
+  }
+
+  // --- Core EmbeddingKVDB interface ---
+
+  /// Two-phase lookup: DRAM first, then SSD for misses, backfill DRAM on hits.
+  ///
+  /// Phase 1: Call dram_cache_->get_kv_db_async(indices, weights, count)
+  ///   DRAM hits fill weights directly. Misses remain as zero rows.
+  ///
+  /// Phase 2: For zero rows (DRAM misses), batch-lookup in SSD.
+  ///   SSD hits fill the weights.
+  ///
+  /// Phase 3: Backfill DRAM with SSD hits so future lookups are fast.
+  ///   This marks them dirty — feature score eviction handles thrash.
   folly::SemiFuture<std::vector<folly::Unit>> get_kv_db_async(
       const at::Tensor& indices,
       const at::Tensor& weights,
       const at::Tensor& count) override {
-    return dram_cache_->get_kv_db_async(indices, weights, count);
+    // Phase 1: DRAM lookup
+    dram_cache_->get_kv_db_async(indices, weights, count).wait();
+
+    auto num = count.scalar_type() == at::ScalarType::Long
+        ? *(count.const_data_ptr<int64_t>())
+        : static_cast<int64_t>(*(count.const_data_ptr<int32_t>()));
+
+    if (num <= 0) {
+      return folly::makeSemiFuture(std::vector<folly::Unit>());
+    }
+
+    // Phase 2: Check for DRAM misses (all-zero rows)
+    auto* idx_ptr = indices.const_data_ptr<int64_t>();
+    auto* w_ptr = weights.template data_ptr<weight_type>();
+    int64_t stride = weights.size(1);
+
+    std::vector<int64_t> miss_indices;
+    std::vector<int64_t> miss_positions; // position in original tensor
+    miss_indices.reserve(num);
+    miss_positions.reserve(num);
+
+    for (int64_t i = 0; i < num; ++i) {
+      if (idx_ptr[i] < 0) {
+        continue;
+      }
+      bool all_zero = true;
+      for (int64_t j = 0; j < stride; ++j) {
+        if (w_ptr[i * stride + j] != static_cast<weight_type>(0)) {
+          all_zero = false;
+          break;
+        }
+      }
+      if (all_zero) {
+        miss_indices.push_back(idx_ptr[i]);
+        miss_positions.push_back(i);
+      }
+    }
+
+    if (miss_indices.empty()) {
+      return folly::makeSemiFuture(std::vector<folly::Unit>());
+    }
+
+    // Track SSD lookups
+    ssd_num_lookups_.fetch_add(miss_indices.size(), std::memory_order_relaxed);
+
+    // Create tensors for SSD lookup.
+    // Use weights-only read (skip MetaHeader) for the critical path.
+    auto miss_count_val = static_cast<int64_t>(miss_indices.size());
+    auto miss_idx_tensor = at::from_blob(
+                               miss_indices.data(),
+                               {miss_count_val},
+                               at::TensorOptions().dtype(at::kLong))
+                               .clone();
+    auto ssd_weights = at::zeros(
+        {miss_count_val, stride},
+        at::TensorOptions().dtype(
+            c10::CppTypeToScalarType<weight_type>::value));
+    auto miss_count_tensor = at::tensor({miss_count_val}, at::ScalarType::Long);
+
+    // SSD lookup for misses (weights only, skipping MetaHeader prefix)
+    rocksdb_backend_
+        ->get_kv_db_weights_only_async(
+            miss_idx_tensor, ssd_weights, miss_count_tensor)
+        .wait();
+
+    // Phase 3: Merge SSD hits into output weights and backfill DRAM.
+    // ssd_weights is already weights-only (no MetaHeader prefix).
+    auto* ssd_w_ptr = ssd_weights.template data_ptr<weight_type>();
+    std::vector<int64_t> backfill_indices;
+    std::vector<int64_t> backfill_positions; // positions in ssd_weights
+    backfill_indices.reserve(miss_count_val);
+    backfill_positions.reserve(miss_count_val);
+
+    for (int64_t m = 0; m < miss_count_val; ++m) {
+      bool has_nonzero = false;
+      for (int64_t j = 0; j < stride; ++j) {
+        if (ssd_w_ptr[m * stride + j] != static_cast<weight_type>(0)) {
+          has_nonzero = true;
+          break;
+        }
+      }
+      if (has_nonzero) {
+        // Copy weights directly into the output tensor
+        int64_t orig_pos = miss_positions[m];
+        std::copy(
+            ssd_w_ptr + m * stride,
+            ssd_w_ptr + (m + 1) * stride,
+            w_ptr + orig_pos * stride);
+        backfill_indices.push_back(miss_indices[m]);
+        backfill_positions.push_back(m);
+      }
+    }
+
+    // Track SSD hits
+    ssd_num_hits_.fetch_add(backfill_indices.size(), std::memory_order_relaxed);
+
+    // Backfill DRAM with SSD hits asynchronously (fire-and-forget).
+    // The metadata will be read from SSD (likely cache-hot) on the backfill
+    // thread. This unblocks the critical path.
+    XLOG_EVERY_MS(INFO, 30000)
+        << "[DramSsdKVEmbeddingCache] SSD->DRAM backfill: "
+        << backfill_indices.size() << " hits out of " << miss_indices.size()
+        << " SSD lookups";
+    if (!backfill_indices.empty()) {
+      auto bf_count_val = static_cast<int64_t>(backfill_indices.size());
+      auto bf_idx_tensor = at::from_blob(
+                               backfill_indices.data(),
+                               {bf_count_val},
+                               at::TensorOptions().dtype(at::kLong))
+                               .clone();
+      // Build backfill weights from SSD results (already weights-only)
+      auto bf_weights = at::zeros(
+          {bf_count_val, stride},
+          at::TensorOptions().dtype(
+              c10::CppTypeToScalarType<weight_type>::value));
+      auto* bf_w_ptr = bf_weights.template data_ptr<weight_type>();
+      for (int64_t b = 0; b < bf_count_val; ++b) {
+        int64_t m = backfill_positions[b];
+        std::copy(
+            ssd_w_ptr + m * stride,
+            ssd_w_ptr + (m + 1) * stride,
+            bf_w_ptr + b * stride);
+      }
+      auto bf_count_tensor = at::tensor({bf_count_val}, at::ScalarType::Long);
+
+      // Fire-and-forget: backfill DRAM on dedicated backfill executor
+      auto dram_cache = dram_cache_;
+      folly::via(
+          backfill_executor_.get(),
+          [dram_cache,
+           bf_idx = std::move(bf_idx_tensor),
+           bf_wts = std::move(bf_weights),
+           bf_cnt = std::move(bf_count_tensor)]() {
+            dram_cache->set_kv_db_async(bf_idx, bf_wts, bf_cnt).wait();
+            ;
+          });
+    }
+
+    return folly::makeSemiFuture(std::vector<folly::Unit>());
   }
 
+  /// Checkpoint restore writes directly to SSD, bypassing DRAM allocation.
+  /// For KVZCH (backend_return_whole_row), the correct linearized IDs are
+  /// already embedded in the first 8 bytes of each weight row by
+  /// KVTensorWrapper::set_range() via replace_weights_id(). We extract
+  /// them here rather than using the `start` parameter, which is
+  /// PMT_offset + row_offset_ and can be very negative for later shards.
   void set_range_to_storage(
       const at::Tensor& weights_with_metaheader,
       const int64_t start,
       const int64_t length) override {
-    dram_cache_->set_range_to_storage(weights_with_metaheader, start, length);
+    // Extract keys from the embedded IDs in the first 8 bytes of each row
+    // (set by replace_weights_id in KVTensorWrapper::set_range).
+    // Follows the same pattern as write_blocks_to_ssd().
+    std::vector<int64_t> keys(weights_with_metaheader.size(0), 0);
+    for (int64_t i = 0; i < weights_with_metaheader.size(0); ++i) {
+      keys[i] = kv_mem::FixedBlockPool::get_key(
+          weights_with_metaheader[i].data_ptr());
+    }
+    auto indices =
+        torch::from_blob(keys.data(), {int64_t(keys.size())}, torch::kInt64);
+    const auto count =
+        at::tensor({weights_with_metaheader.size(0)}, at::ScalarType::Long);
+    folly::coro::blockingWait(rocksdb_backend_->set_kv_db_async(
+        indices, weights_with_metaheader, count));
   }
 
   folly::SemiFuture<std::vector<folly::Unit>> set_kv_db_async(
@@ -77,6 +305,7 @@ class DramSsdKVEmbeddingCache : public EmbeddingKVDB {
   }
 
   /// Delegate enrichment query ID processing to DRAM cache.
+  /// The DRAM cache already has SSD existence check wired (Step 3).
   void set_embedding_cache_enrich_query_id_async(
       at::Tensor hashed_indices,
       at::Tensor unhashed_indices,
@@ -88,7 +317,7 @@ class DramSsdKVEmbeddingCache : public EmbeddingKVDB {
   }
 
   void compact() override {
-    dram_cache_->compact();
+    rocksdb_backend_->compact();
   }
 
   /// Delegate sync SID fetch to the DRAM cache. Without this override the
@@ -148,22 +377,48 @@ class DramSsdKVEmbeddingCache : public EmbeddingKVDB {
       const int64_t interval) override {
     // Call through base class pointer to access the private override via
     // virtual dispatch.
-    EmbeddingKVDB* base = dram_cache_.get();
-    return base->get_dram_kv_perf(step, interval);
+    auto ret = dram_cache_->get_dram_kv_perf(step, interval);
+
+    // Append SSD metrics (indices 38-41)
+    // Base DRAM returns 38 elements (0-37), with hit/miss counts at 36-37.
+    ret.resize(43, 0);
+    if (step > 0 && step % interval == 0) {
+      int64_t reset_val = 0;
+      auto lookups = ssd_num_lookups_.exchange(reset_val);
+      auto hits = ssd_num_hits_.exchange(reset_val);
+      auto writes = ssd_num_writes_.exchange(reset_val);
+
+      ret[38] = static_cast<double>(lookups) / interval;
+      ret[39] = static_cast<double>(hits) / interval;
+      ret[40] = static_cast<double>(writes) / interval;
+      // ret[41]: SSD estimated num keys (absolute, not averaged).
+      // Read from cached atomic to avoid blocking the training thread on
+      // RocksDB mutex contention with the background writeback thread.
+      ret[41] = static_cast<double>(cached_ssd_num_keys_.load());
+      // ret[42]: Cumulative actual rows written to SSD (absolute, not
+      // averaged). Tracked inside EmbeddingRocksDB::set_kv_db_async after
+      // skipping negative keys, so this reflects real writes.
+      ret[42] = static_cast<double>(rocksdb_backend_->get_total_rows_written());
+    }
+    return ret;
   }
 
-  /// Delegate to the DRAM cache via base-class pointer to dispatch through the
-  /// virtual interface (the override is private in DramKVEmbeddingCache).
+  /// DRAM_SSD stores the full DRAM block in SSD (MetaHeader + weight +
+  /// optimizer) so that checkpoint can read the complete row including
+  /// eviction metadata.  Delegate to the DRAM cache via base-class pointer
+  /// to dispatch through the virtual interface (the override is private in
+  /// DramKVEmbeddingCache).
   bool get_backend_return_whole_row() override {
-    EmbeddingKVDB* base = dram_cache_.get();
-    return base->get_backend_return_whole_row();
+    return dram_cache_->get_backend_return_whole_row();
   }
 
+  /// SSD stores MetaHeader as a prefix, matching the DRAM block layout.
   int64_t get_metaheader_width_in_front() override {
-    EmbeddingKVDB* base = dram_cache_.get();
-    return base->get_metaheader_width_in_front();
+    return dram_cache_->get_metaheader_width_in_front();
   }
 
+  /// Checkpoint: read weights from SSD after flush-then-snapshot.
+  /// After flush(), SSD has all data — read only from SSD for consistency.
   void get_range_from_snapshot(
       const at::Tensor& weights,
       const int64_t start,
@@ -171,22 +426,27 @@ class DramSsdKVEmbeddingCache : public EmbeddingKVDB {
       const ssd::SnapshotHandle* snapshot_handle,
       int64_t width_offset = 0,
       std::optional<int64_t> width_length = std::nullopt) override {
-    dram_cache_->get_range_from_snapshot(
+    rocksdb_backend_->get_range_from_snapshot(
         weights, start, length, snapshot_handle, width_offset, width_length);
   }
 
+  /// Checkpoint: read weights by IDs from SSD after flush-then-snapshot.
   void get_kv_from_storage_by_snapshot(
       const at::Tensor& ids,
       const at::Tensor& weights,
       const ssd::SnapshotHandle* snapshot_handle,
       int64_t width_offset = 0,
       std::optional<int64_t> width_length = std::nullopt) override {
-    dram_cache_->get_kv_from_storage_by_snapshot(
+    rocksdb_backend_->get_kv_from_storage_by_snapshot(
         ids, weights, snapshot_handle, width_offset, width_length);
   }
 
   // --- Key range and metadata ---
 
+  /// Get keys in range. For checkpoint use, the wrapper routes directly to
+  /// EmbeddingRocksDB::get_keys_in_range_by_snapshot() which is the proper
+  /// SSD key iteration method. This fallback delegates to DRAM cache for
+  /// non-checkpoint use cases (e.g. get_keys_in_range without snapshot).
   at::Tensor get_keys_in_range_impl(
       int64_t start,
       int64_t end,
@@ -200,11 +460,191 @@ class DramSsdKVEmbeddingCache : public EmbeddingKVDB {
     return dram_cache_->get_kv_zch_eviction_metadata_impl(indices, count);
   }
 
+  // --- Flush: drain all dirty DRAM blocks to SSD ---
+
+  /// Flush dirty DRAM blocks to SSD for checkpoint consistency.
+  ///
+  /// Steps:
+  /// 1. Iterate all DRAM shards under rlock
+  /// 2. Collect dirty blocks (key + serialized data)
+  /// 3. Clear dirty bits
+  /// 4. Batch write collected blocks to SSD
+  /// 5. Drain any pending writeback queue items
+  ///
+  /// Only dirty blocks are written. All DRAM write paths that produce
+  /// new data (enrichment, checkpoint load, metadata updates) set the
+  /// dirty bit. SSD backfill paths skip set_dirty since SSD already
+  /// has the data.
+  void flush() {
+    auto flush_start_us = facebook::WallClockUtil::NowInUsecFast();
+    int64_t num_shards = dram_cache_->get_num_shards();
+    auto& kv_store = dram_cache_->get_kv_store();
+    int64_t block_size = dram_cache_->get_block_size();
+
+    std::vector<int64_t> shard_entry_counts(num_shards, 0);
+
+    // Per-shard timing (microseconds) for diagnosing QPS regression.
+    std::vector<int64_t> shard_rlock_us(num_shards, 0);
+    std::vector<int64_t> shard_dirty_write_us(num_shards, 0);
+    std::vector<int64_t> shard_metadata_read_us(num_shards, 0);
+    std::vector<int64_t> shard_metadata_write_us(num_shards, 0);
+    std::vector<int64_t> shard_total_keys(num_shards, 0);
+
+    // Step 1: Collect and write dirty blocks from all DRAM shards in parallel.
+    // Each shard's rlock is independent, so shards can be processed
+    // concurrently. rlock allows training reads to proceed during flush.
+    // SSD writes are done per-shard since RocksDB supports concurrent
+    // writes.
+    // After dirty blocks, also flush ALL metadata for this shard to SSD.
+    std::atomic<int64_t> total_metadata_keys{0};
+    std::vector<std::thread> workers;
+    workers.reserve(num_shards);
+    for (int64_t shard_id = 0; shard_id < num_shards; ++shard_id) {
+      workers.emplace_back([this,
+                            &kv_store,
+                            &shard_entry_counts,
+                            &total_metadata_keys,
+                            &shard_rlock_us,
+                            &shard_dirty_write_us,
+                            &shard_metadata_read_us,
+                            &shard_metadata_write_us,
+                            &shard_total_keys,
+                            shard_id,
+                            block_size]() {
+        ShardData shard;
+        std::vector<int64_t> non_dirty_keys;
+        {
+          auto rlock_start = facebook::WallClockUtil::NowInUsecFast();
+          auto rlmap = kv_store.by(shard_id).rlock();
+          auto* pool = kv_store.pool_by(shard_id);
+          shard.keys.reserve(rlmap->size());
+          shard.blocks.reserve(rlmap->size());
+          non_dirty_keys.reserve(rlmap->size());
+          for (auto& [key, block] : *rlmap) {
+            if (pool->get_dirty(block)) {
+              shard.keys.push_back(key);
+              shard.blocks.emplace_back(
+                  reinterpret_cast<const char*>(block), block_size);
+              pool->clear_dirty(block);
+            } else {
+              non_dirty_keys.push_back(key);
+            }
+          }
+          shard_rlock_us[shard_id] =
+              facebook::WallClockUtil::NowInUsecFast() - rlock_start;
+        }
+        shard_total_keys[shard_id] =
+            static_cast<int64_t>(shard.keys.size() + non_dirty_keys.size());
+        shard_entry_counts[shard_id] = shard.keys.size();
+        if (!shard.keys.empty()) {
+          auto write_start = facebook::WallClockUtil::NowInUsecFast();
+          write_blocks_to_ssd(shard.keys, shard.blocks);
+          shard_dirty_write_us[shard_id] =
+              facebook::WallClockUtil::NowInUsecFast() - write_start;
+        }
+
+        // Flush metadata for non-dirty keys to SSD.
+        // Dirty keys already have their metadata written atomically
+        // with embeddings via write_blocks_to_ssd/set_kv_db_async.
+        // Non-dirty keys may still have metadata updates
+        // (set_kv_zch_eviction_metadata_async only writes to DRAM
+        // without setting the dirty bit).
+        if (rocksdb_backend_ && !non_dirty_keys.empty()) {
+          auto num_keys = static_cast<int64_t>(non_dirty_keys.size());
+          auto md_read_start = facebook::WallClockUtil::NowInUsecFast();
+          auto indices = at::from_blob(
+                             non_dirty_keys.data(),
+                             {num_keys},
+                             at::TensorOptions().dtype(at::kLong))
+                             .clone();
+          auto count = at::tensor({num_keys}, at::ScalarType::Long);
+          auto metadata = dram_cache_->get_kv_metadata_rows(indices, count);
+          shard_metadata_read_us[shard_id] =
+              facebook::WallClockUtil::NowInUsecFast() - md_read_start;
+
+          auto md_write_start = facebook::WallClockUtil::NowInUsecFast();
+          rocksdb_backend_->set_kv_metadata_async(indices, metadata, count)
+              .wait();
+          shard_metadata_write_us[shard_id] =
+              facebook::WallClockUtil::NowInUsecFast() - md_write_start;
+          total_metadata_keys.fetch_add(num_keys);
+        }
+      });
+    }
+    for (auto& t : workers) {
+      t.join();
+    }
+
+    auto workers_done_us = facebook::WallClockUtil::NowInUsecFast();
+
+    int64_t total_entries = 0;
+    for (auto c : shard_entry_counts) {
+      total_entries += c;
+    }
+
+    // Log per-shard timing breakdown for QPS regression diagnosis.
+    int64_t max_rlock = 0, max_dirty_write = 0, max_md_read = 0,
+            max_md_write = 0;
+    for (int64_t s = 0; s < num_shards; ++s) {
+      max_rlock = std::max(max_rlock, shard_rlock_us[s]);
+      max_dirty_write = std::max(max_dirty_write, shard_dirty_write_us[s]);
+      max_md_read = std::max(max_md_read, shard_metadata_read_us[s]);
+      max_md_write = std::max(max_md_write, shard_metadata_write_us[s]);
+    }
+    LOG(INFO) << "[DramSsdKVEmbeddingCache] flush() max across shards:"
+              << " rlock_ms=" << max_rlock / 1000.0
+              << " dirty_write_ms=" << max_dirty_write / 1000.0
+              << " metadata_read_ms=" << max_md_read / 1000.0
+              << " metadata_write_ms=" << max_md_write / 1000.0;
+
+    LOG(INFO) << "[DramSsdKVEmbeddingCache] flush() wrote " << total_entries
+              << " dirty entries (with metadata) and metadata for "
+              << total_metadata_keys.load() << " non-dirty keys to SSD across "
+              << num_shards << " shards, block_size=" << block_size
+              << " metaheader_dim=" << metaheader_dim_
+              << " max_D=" << dram_cache_->get_max_D() << " workers_elapsed_ms="
+              << (workers_done_us - flush_start_us) / 1000.0;
+
+    // Drain the writeback queue
+    auto drain_start_us = facebook::WallClockUtil::NowInUsecFast();
+    drain_writeback_queue();
+    auto drain_us = facebook::WallClockUtil::NowInUsecFast() - drain_start_us;
+    auto total_us = facebook::WallClockUtil::NowInUsecFast() - flush_start_us;
+    LOG(INFO) << "[DramSsdKVEmbeddingCache] flush() done"
+              << " drain_writeback_ms=" << drain_us / 1000.0
+              << " total_flush_ms=" << total_us / 1000.0;
+  }
+
+  // --- Writeback thread management ---
+
+  void start_writeback_thread() {
+    if (writeback_running_.load()) {
+      return;
+    }
+    writeback_running_.store(true);
+    writeback_thread_ =
+        std::make_unique<std::thread>([this]() { writeback_loop(); });
+  }
+
+  void stop_writeback_thread() {
+    if (!writeback_running_.load()) {
+      return;
+    }
+    writeback_running_.store(false);
+    if (writeback_thread_ && writeback_thread_->joinable()) {
+      writeback_thread_->join();
+    }
+    writeback_thread_.reset();
+  }
+
   // --- Accessors ---
 
   const std::shared_ptr<kv_mem::DramKVEmbeddingCache<weight_type>>& dram_cache()
       const {
     return dram_cache_;
+  }
+  auto& ssd_backend() {
+    return rocksdb_backend_;
   }
 
  private:
@@ -217,10 +657,149 @@ class DramSsdKVEmbeddingCache : public EmbeddingKVDB {
   }
 
   void flush_or_compact(const int64_t /*timestep*/) override {
-    // No-op; flush is explicit and added with the SSD tier.
+    // No-op; flush is explicit via flush() method
   }
 
+  /// Enqueue a batch of dirty evicted blocks for async SSD writeback.
+  /// Non-blocking: if queue is full, log a warning instead of blocking
+  /// eviction.
+  void enqueue_writeback(WriteBatchItem item) {
+    if (!writeback_queue_.write(std::move(item))) {
+      XLOG_EVERY_MS(WARNING, 60000)
+          << "[DramSsdKVEmbeddingCache] Writeback queue full, "
+          << "dropping evicted dirty blocks. Consider increasing queue size.";
+    }
+  }
+
+  /// Background writeback loop: consume from queue, write to SSD in batches.
+  void writeback_loop() {
+    while (writeback_running_.load()) {
+      WriteBatchItem item;
+      auto deadline =
+          std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+      if (writeback_queue_.tryReadUntil(deadline, item)) {
+        if (!item.blocks.empty()) {
+          std::vector<int64_t> keys;
+          std::vector<std::string> blocks;
+          keys.reserve(item.blocks.size());
+          blocks.reserve(item.blocks.size());
+          for (auto& [key, data] : item.blocks) {
+            keys.push_back(key);
+            blocks.push_back(std::move(data));
+          }
+          write_blocks_to_ssd(keys, blocks);
+        }
+      }
+    }
+  }
+
+  /// Drain all remaining items in the writeback queue.
+  void drain_writeback_queue() {
+    WriteBatchItem item;
+    while (writeback_queue_.read(item)) {
+      if (!item.blocks.empty()) {
+        std::vector<int64_t> keys;
+        std::vector<std::string> blocks;
+        keys.reserve(item.blocks.size());
+        blocks.reserve(item.blocks.size());
+        for (auto& [key, data] : item.blocks) {
+          keys.push_back(key);
+          blocks.push_back(std::move(data));
+        }
+        write_blocks_to_ssd(keys, blocks);
+      }
+    }
+  }
+
+  /// Write serialized blocks to SSD via rocksdb_backend_->set_kv_db_async().
+  /// Writes the FULL DRAM block (MetaHeader + weight + optimizer) so that
+  /// checkpoint can read the complete row including eviction metadata.
+  void write_blocks_to_ssd(
+      const std::vector<int64_t>& keys,
+      const std::vector<std::string>& serialized_blocks) {
+    if (keys.empty()) {
+      return;
+    }
+
+    // Track SSD writes
+    ssd_num_writes_.fetch_add(keys.size(), std::memory_order_relaxed);
+    XLOG_EVERY_MS(INFO, 30000)
+        << "[DramSsdKVEmbeddingCache] write_blocks_to_ssd: writing "
+        << keys.size() << " blocks, total_writes="
+        << ssd_num_writes_.load(std::memory_order_relaxed);
+
+    int64_t max_D = dram_cache_->get_max_D();
+    // Total SSD row width: MetaHeader (as weight_type elements) + data
+    int64_t total_width = metaheader_dim_ + max_D;
+    int64_t num_keys = static_cast<int64_t>(keys.size());
+
+    // Process in batches of writeback_batch_size_
+    for (int64_t offset = 0; offset < num_keys;
+         offset += writeback_batch_size_) {
+      int64_t batch_size = std::min(writeback_batch_size_, num_keys - offset);
+
+      auto indices =
+          at::zeros({batch_size}, at::TensorOptions().dtype(at::kLong));
+      auto weights = at::zeros(
+          {batch_size, total_width},
+          at::TensorOptions().dtype(
+              c10::CppTypeToScalarType<weight_type>::value));
+
+      auto* idx_ptr = indices.data_ptr<int64_t>();
+      auto* w_ptr = weights.template data_ptr<weight_type>();
+
+      for (int64_t i = 0; i < batch_size; ++i) {
+        int64_t global_idx = offset + i;
+        idx_ptr[i] = keys[global_idx];
+
+        // Copy the full DRAM block (MetaHeader + weight + optimizer),
+        // treating MetaHeader bytes as weight_type elements.
+        const auto& block_data = serialized_blocks[global_idx];
+        const auto* block_start =
+            reinterpret_cast<const weight_type*>(block_data.data());
+        int64_t copy_len = std::min(
+            total_width,
+            static_cast<int64_t>(block_data.size() / sizeof(weight_type)));
+        std::copy(block_start, block_start + copy_len, w_ptr + i * total_width);
+      }
+
+      auto count = at::tensor({batch_size}, at::ScalarType::Long);
+      try {
+        rocksdb_backend_->set_kv_db_async(indices, weights, count).wait();
+      } catch (const std::exception& e) {
+        XLOG_EVERY_MS(WARNING, 60000)
+            << "[DramSsdKVEmbeddingCache] SSD write failed: " << e.what();
+      }
+    }
+    cached_ssd_num_keys_.store(rocksdb_backend_->get_estimated_num_keys());
+  }
+
+  struct ShardData {
+    std::vector<int64_t> keys;
+    std::vector<std::string> blocks;
+  };
+
   std::shared_ptr<kv_mem::DramKVEmbeddingCache<weight_type>> dram_cache_;
+  std::shared_ptr<EmbeddingKVDB> rocksdb_backend_;
+
+  // Writeback queue: evicted dirty blocks -> SSD
+  folly::MPMCQueue<WriteBatchItem> writeback_queue_;
+  std::unique_ptr<std::thread> writeback_thread_;
+  std::atomic<bool> writeback_running_{false};
+
+  int64_t writeback_batch_size_;
+
+  // MetaHeader width in weight_type elements
+  int64_t metaheader_dim_;
+
+  // Dedicated executor for async DRAM backfill
+  std::unique_ptr<folly::CPUThreadPoolExecutor> backfill_executor_;
+
+  // SSD metrics (per-interval, reset on read via exchange)
+  std::atomic<int64_t> ssd_num_lookups_{0}; // DRAM misses sent to SSD
+  std::atomic<int64_t> ssd_num_hits_{0}; // SSD hits (backfilled to DRAM)
+  std::atomic<int64_t> ssd_num_writes_{0}; // blocks written to SSD
+  std::atomic<int64_t> cached_ssd_num_keys_{0}; // refreshed by writeback thread
 }; // class DramSsdKVEmbeddingCache
 
 } // namespace kv_db

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_ssd_kv_embedding_cache_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_ssd_kv_embedding_cache_wrapper.h
@@ -10,7 +10,9 @@
 
 #include <ATen/ATen.h>
 #include <fmt/format.h>
+#include <functional>
 #include "../ssd_split_embeddings_cache/kv_tensor_wrapper.h"
+#include "../ssd_split_embeddings_cache/ssd_table_batched_embeddings.h"
 #include "dram_kv_embedding_cache.h"
 #include "dram_ssd_kv_embedding_cache.h"
 
@@ -20,11 +22,17 @@ struct EmbeddingSnapshotHandleWrapper;
 
 namespace kv_mem {
 
-/// @brief TorchScript wrapper for DramSsdKVEmbeddingCache composite backend.
+/// @brief TorchScript wrapper for the DramSsdKVEmbeddingCache composite
+/// backend.
 ///
-/// Forwarding skeleton: constructs the DRAM cache, wraps it in a
-/// DramSsdKVEmbeddingCache, and forwards all calls to it. The SSD (L3) backend
-/// wiring is added in a follow-up.
+/// This wrapper is the sole initializer of the DRAM+SSD backend: it builds the
+/// DRAM (L2) cache, constructs the SSD (L3) RocksDB tier internally, and
+/// assembles the composite DramSsdKVEmbeddingCache from both. The wrapper layer
+/// keeps a single DRAM-backed composite (impl_) and a single RocksDB storage
+/// (rocksdb_impl_); the weight-type (Half/float) selection is confined to the
+/// templated init_composite() helper. Because RocksDB is always created in the
+/// constructor, rocksdb_impl_ is guaranteed non-null for all
+/// checkpoint/snapshot code paths.
 class DramSsdKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
  public:
   DramSsdKVEmbeddingCacheWrapper(
@@ -47,36 +55,33 @@ class DramSsdKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
       std::vector<std::string> table_names = {},
       std::vector<int64_t> table_offsets = {},
       std::vector<int64_t> table_sizes = {},
+      int64_t writeback_queue_size = 1024,
+      int64_t writeback_batch_size = 1024,
       std::optional<c10::intrusive_ptr<kv_mem::EnrichmentConfig>>
-          enrichment_config = std::nullopt) {
+          enrichment_config = std::nullopt,
+      // SSD (RocksDB L3 tier) construction params; mirror EmbeddingRocksDB.
+      std::string ssd_path = "",
+      int64_t memtable_flush_period = 0,
+      int64_t memtable_flush_offset = 0,
+      int64_t l0_files_per_compact = 0,
+      int64_t rate_limit_mbps = 0,
+      int64_t size_ratio = 10,
+      int64_t compaction_ratio = 0,
+      int64_t write_buffer_size = 0,
+      int64_t max_write_buffer_num = 0,
+      int64_t block_cache_size = 0,
+      bool use_passed_in_path = true,
+      int64_t tbe_unique_id = 0,
+      int64_t l2_cache_size_gb = 0,
+      bool ssd_enable_async_update = false,
+      int64_t flushing_block_size = 2000000000 /*2GB*/,
+      bool enable_blob_db = false) {
+    row_storage_bitwidth_ = row_storage_bitwidth;
+    writeback_queue_size_ = writeback_queue_size;
+    writeback_batch_size_ = writeback_batch_size;
+
     if (row_storage_bitwidth == 16) {
-      auto dram_cache =
-          std::make_shared<kv_mem::DramKVEmbeddingCache<at::Half>>(
-              max_D,
-              uniform_init_lower,
-              uniform_init_upper,
-              feature_evict_config,
-              num_shards,
-              num_threads,
-              row_storage_bitwidth,
-              backend_return_whole_row,
-              enable_async_update,
-              table_dims,
-              hash_size_cumsum,
-              true, // is_training
-              disable_random_init,
-              enable_raw_embedding_streaming,
-              res_store_shards,
-              res_server_port,
-              std::move(table_names),
-              std::move(table_offsets),
-              std::move(table_sizes),
-              enrichment_config,
-              /*enable_ssd_backend=*/true);
-      impl_ = std::make_shared<kv_db::DramSsdKVEmbeddingCache<at::Half>>(
-          std::move(dram_cache));
-    } else if (row_storage_bitwidth == 32) {
-      auto dram_cache = std::make_shared<kv_mem::DramKVEmbeddingCache<float>>(
+      init_composite<at::Half>(
           max_D,
           uniform_init_lower,
           uniform_init_upper,
@@ -84,22 +89,71 @@ class DramSsdKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
           num_shards,
           num_threads,
           row_storage_bitwidth,
-          backend_return_whole_row,
-          enable_async_update,
           table_dims,
           hash_size_cumsum,
-          true, // is_training
+          backend_return_whole_row,
+          enable_async_update,
           disable_random_init,
           enable_raw_embedding_streaming,
           res_store_shards,
           res_server_port,
-          std::move(table_names),
-          std::move(table_offsets),
-          std::move(table_sizes),
+          table_names,
+          table_offsets,
+          table_sizes,
           enrichment_config,
-          /*enable_ssd_backend=*/true);
-      impl_ = std::make_shared<kv_db::DramSsdKVEmbeddingCache<float>>(
-          std::move(dram_cache));
+          ssd_path,
+          memtable_flush_period,
+          memtable_flush_offset,
+          l0_files_per_compact,
+          rate_limit_mbps,
+          size_ratio,
+          compaction_ratio,
+          write_buffer_size,
+          max_write_buffer_num,
+          block_cache_size,
+          use_passed_in_path,
+          tbe_unique_id,
+          l2_cache_size_gb,
+          ssd_enable_async_update,
+          flushing_block_size,
+          enable_blob_db);
+    } else if (row_storage_bitwidth == 32) {
+      init_composite<float>(
+          max_D,
+          uniform_init_lower,
+          uniform_init_upper,
+          feature_evict_config,
+          num_shards,
+          num_threads,
+          row_storage_bitwidth,
+          table_dims,
+          hash_size_cumsum,
+          backend_return_whole_row,
+          enable_async_update,
+          disable_random_init,
+          enable_raw_embedding_streaming,
+          res_store_shards,
+          res_server_port,
+          table_names,
+          table_offsets,
+          table_sizes,
+          enrichment_config,
+          ssd_path,
+          memtable_flush_period,
+          memtable_flush_offset,
+          l0_files_per_compact,
+          rate_limit_mbps,
+          size_ratio,
+          compaction_ratio,
+          write_buffer_size,
+          max_write_buffer_num,
+          block_cache_size,
+          use_passed_in_path,
+          tbe_unique_id,
+          l2_cache_size_gb,
+          ssd_enable_async_update,
+          flushing_block_size,
+          enable_blob_db);
     } else {
       throw std::runtime_error(
           fmt::format(
@@ -128,7 +182,15 @@ class DramSsdKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
   }
 
   void flush() {
-    impl_->flush();
+    // EmbeddingKVDB::flush() is NOT virtual; calling impl_->flush() would
+    // dispatch to the base version (which only flushes l2_cache_). Invoke the
+    // typed composite's flush() (captured at construction) to flush dirty DRAM
+    // blocks to SSD and drain the writeback queue.
+    if (flush_composite_) {
+      flush_composite_();
+    } else {
+      impl_->flush();
+    }
   }
 
   void set_range_to_storage(
@@ -136,6 +198,9 @@ class DramSsdKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
       const int64_t start,
       const int64_t length) {
     impl_->set_range_to_storage(weights, start, length);
+    XLOG(INFO) << "DramSsdKVEmbeddingCacheWrapper::set_range_to_storage()"
+               << " start=" << start << " length=" << length
+               << " impl_type=" << typeid(*impl_).name();
   }
 
   at::Tensor get_keys_in_range_by_snapshot(
@@ -144,7 +209,16 @@ class DramSsdKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
       int64_t id_offset,
       const std::optional<
           c10::intrusive_ptr<ssd::EmbeddingSnapshotHandleWrapper>>&
-      /*snapshot_handle*/) {
+          snapshot_handle) {
+    if (rocksdb_impl_) {
+      // DRAM_SSD: read keys directly from SSD (which has all data after flush)
+      const ssd::SnapshotHandle* snap = nullptr;
+      if (snapshot_handle.has_value() && snapshot_handle.value()) {
+        snap = snapshot_handle.value()->handle;
+      }
+      return rocksdb_impl_->get_keys_in_range_by_snapshot(
+          start_id, end_id, id_offset, snap);
+    }
     return impl_->get_keys_in_range_impl(start_id, end_id, id_offset);
   }
 
@@ -153,7 +227,15 @@ class DramSsdKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
       const at::Tensor& count,
       const std::optional<
           c10::intrusive_ptr<ssd::EmbeddingSnapshotHandleWrapper>>&
-      /*snapshot_handle*/) {
+          snapshot_handle) {
+    if (rocksdb_impl_) {
+      const ssd::SnapshotHandle* snap = nullptr;
+      if (snapshot_handle.has_value() && snapshot_handle.value()) {
+        snap = snapshot_handle.value()->handle;
+      }
+      return rocksdb_impl_->get_kv_zch_eviction_metadata_by_snapshot(
+          indices, count, snap);
+    }
     return impl_->get_kv_zch_eviction_metadata_impl(indices, count);
   }
 
@@ -170,7 +252,10 @@ class DramSsdKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
   }
 
   at::Tensor get_keys_in_range(int64_t start, int64_t end) {
-    return impl_->get_keys_in_range_impl(start, end, std::nullopt);
+    CHECK(rocksdb_impl_) << "SSD backend not initialized";
+    // DRAM_SSD: read keys from SSD (all data after flush)
+    return rocksdb_impl_->get_keys_in_range_by_snapshot(
+        start, end, /*id_offset=*/0, /*snapshot_handle=*/nullptr);
   }
 
   size_t get_map_used_memsize_in_bytes() const {
@@ -241,10 +326,190 @@ class DramSsdKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
         std::move(count));
   }
 
+  /// Create a RocksDB snapshot for consistent checkpoint reads.
+  /// Must be called AFTER flush() so SSD has all data.
+  c10::intrusive_ptr<ssd::EmbeddingSnapshotHandleWrapper> create_snapshot() {
+    CHECK(rocksdb_impl_) << "SSD backend not initialized";
+    auto handle = rocksdb_impl_->create_snapshot();
+    return c10::make_intrusive<ssd::EmbeddingSnapshotHandleWrapper>(
+        handle, rocksdb_impl_);
+  }
+
+  /// Get the number of active RocksDB snapshots.
+  int64_t get_snapshot_count() {
+    CHECK(rocksdb_impl_) << "SSD backend not initialized";
+    return rocksdb_impl_->get_snapshot_count();
+  }
+
+  /// Create a RocksDB hard-link checkpoint for cross-process access.
+  /// Delegates to the underlying RocksDB backend.
+  void create_rocksdb_hard_link_snapshot(int64_t global_step) {
+    CHECK(rocksdb_impl_) << "SSD backend not initialized";
+    rocksdb_impl_->create_checkpoint(global_step);
+  }
+
+  /// Get the active checkpoint UUID for cross-process checkpoint reading.
+  /// Returns nullopt if no checkpoint is available for the given step.
+  std::optional<c10::intrusive_ptr<ssd::RocksdbCheckpointHandleWrapper>>
+  get_active_checkpoint_uuid(int64_t global_step) {
+    CHECK(rocksdb_impl_) << "SSD backend not initialized";
+    auto uuid_opt = rocksdb_impl_->get_active_checkpoint_uuid(global_step);
+    if (uuid_opt.has_value()) {
+      return c10::make_intrusive<ssd::RocksdbCheckpointHandleWrapper>(
+          uuid_opt.value(), rocksdb_impl_);
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  void delete_rocksdb_checkpoint_dir() {
+    CHECK(rocksdb_impl_) << "SSD backend not initialized";
+    rocksdb_impl_->delete_rocksdb_checkpoint_dir();
+  }
+
  private:
   friend class ssd::KVTensorWrapper;
 
+  /// Build the DRAM (L2) cache, the SSD (L3) RocksDB tier, and the composite
+  /// DramSsdKVEmbeddingCache that orchestrates them. The weight-type template
+  /// parameter is the only place Half/float is differentiated; all persistent
+  /// state is stored as a single composite (impl_) plus a single RocksDB tier
+  /// (rocksdb_impl_).
+  template <typename weight_type>
+  void init_composite(
+      int64_t max_D,
+      double uniform_init_lower,
+      double uniform_init_upper,
+      const std::optional<c10::intrusive_ptr<kv_mem::FeatureEvictConfig>>&
+          feature_evict_config,
+      int64_t num_shards,
+      int64_t num_threads,
+      int64_t row_storage_bitwidth,
+      const std::optional<at::Tensor>& table_dims,
+      const std::optional<at::Tensor>& hash_size_cumsum,
+      bool backend_return_whole_row,
+      bool enable_async_update,
+      bool disable_random_init,
+      bool enable_raw_embedding_streaming,
+      int64_t res_store_shards,
+      int64_t res_server_port,
+      std::vector<std::string> table_names,
+      std::vector<int64_t> table_offsets,
+      std::vector<int64_t> table_sizes,
+      const std::optional<c10::intrusive_ptr<kv_mem::EnrichmentConfig>>&
+          enrichment_config,
+      std::string ssd_path,
+      int64_t memtable_flush_period,
+      int64_t memtable_flush_offset,
+      int64_t l0_files_per_compact,
+      int64_t rate_limit_mbps,
+      int64_t size_ratio,
+      int64_t compaction_ratio,
+      int64_t write_buffer_size,
+      int64_t max_write_buffer_num,
+      int64_t block_cache_size,
+      bool use_passed_in_path,
+      int64_t tbe_unique_id,
+      int64_t l2_cache_size_gb,
+      bool ssd_enable_async_update,
+      int64_t flushing_block_size,
+      bool enable_blob_db) {
+    // DRAM (L2) cache. enable_ssd_backend=true turns on dirty-bit tracking so
+    // the composite can write back dirty DRAM blocks to SSD.
+    auto dram_cache =
+        std::make_shared<kv_mem::DramKVEmbeddingCache<weight_type>>(
+            max_D,
+            uniform_init_lower,
+            uniform_init_upper,
+            feature_evict_config,
+            num_shards,
+            num_threads,
+            row_storage_bitwidth,
+            backend_return_whole_row,
+            enable_async_update,
+            table_dims,
+            hash_size_cumsum,
+            /*is_training=*/true,
+            disable_random_init,
+            enable_raw_embedding_streaming,
+            res_store_shards,
+            res_server_port,
+            table_names,
+            table_offsets,
+            table_sizes,
+            enrichment_config,
+            /*enable_ssd_backend=*/true);
+
+    // The SSD tier stores the full DRAM block including the MetaHeader, so the
+    // RocksDB max_D / table_dims must be widened by the MetaHeader dimension.
+    const int64_t metaheader_dim = static_cast<int64_t>(
+        kv_mem::FixedBlockPool::get_metaheader_dim<weight_type>());
+    const int64_t ssd_max_D = max_D + metaheader_dim;
+    std::optional<at::Tensor> ssd_table_dims = std::nullopt;
+    if (table_dims.has_value()) {
+      ssd_table_dims = table_dims.value() + metaheader_dim;
+    }
+
+    // SSD (L3) RocksDB tier. enable_metadata_cf=true + metadata_dim create the
+    // metadata column family used to store per-row metadata separately.
+    rocksdb_impl_ = std::make_shared<ssd::EmbeddingRocksDB>(
+        std::move(ssd_path),
+        num_shards,
+        num_threads,
+        memtable_flush_period,
+        memtable_flush_offset,
+        l0_files_per_compact,
+        ssd_max_D,
+        rate_limit_mbps,
+        size_ratio,
+        compaction_ratio,
+        write_buffer_size,
+        max_write_buffer_num,
+        static_cast<float>(uniform_init_lower),
+        static_cast<float>(uniform_init_upper),
+        row_storage_bitwidth,
+        block_cache_size,
+        use_passed_in_path,
+        tbe_unique_id,
+        l2_cache_size_gb,
+        ssd_enable_async_update,
+        enable_raw_embedding_streaming,
+        res_store_shards,
+        res_server_port,
+        std::move(table_names),
+        std::move(table_offsets),
+        table_sizes,
+        ssd_table_dims,
+        hash_size_cumsum,
+        flushing_block_size,
+        disable_random_init,
+        enable_blob_db,
+        /*enable_metadata_cf=*/true,
+        /*metadata_dim=*/metaheader_dim);
+
+    // Assemble the composite (DRAM L2 + RocksDB L3).
+    auto composite =
+        std::make_shared<kv_db::DramSsdKVEmbeddingCache<weight_type>>(
+            dram_cache,
+            rocksdb_impl_,
+            writeback_queue_size_,
+            writeback_batch_size_);
+    impl_ = composite;
+    flush_composite_ = [composite]() { composite->flush(); };
+  }
+
+  // Single composite backend (DRAM L2 + RocksDB L3).
   std::shared_ptr<kv_db::EmbeddingKVDB> impl_;
+
+  // Single RocksDB storage tier, kept for snapshot/checkpoint operations.
+  std::shared_ptr<ssd::EmbeddingRocksDB> rocksdb_impl_;
+
+  // Typed composite flush(), captured at construction (flush() is non-virtual).
+  std::function<void()> flush_composite_;
+
+  int64_t row_storage_bitwidth_;
+  int64_t writeback_queue_size_;
+  int64_t writeback_batch_size_;
 };
 
 } // namespace kv_mem

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -14,6 +14,7 @@
 #include <torch/library.h>
 #include <mutex>
 #include "../dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h"
+#include "../dram_kv_embedding_cache/dram_ssd_kv_embedding_cache_wrapper.h"
 #include "./ssd_table_batched_embeddings.h"
 #include "embedding_rocksdb_wrapper.h"
 #include "fbgemm_gpu/split_embeddings_cache/kv_db_cpp_utils.h"
@@ -1253,6 +1254,192 @@ static auto dram_kv_embedding_cache_wrapper =
         .def(
             "get_dram_kv_perf",
             &DramKVEmbeddingCacheWrapper::get_dram_kv_perf);
+auto dram_ssd_kv_embedding_cache_wrapper =
+    torch::class_<DramSsdKVEmbeddingCacheWrapper>(
+        "fbgemm",
+        "DramSsdKVEmbeddingCacheWrapper")
+        .def(
+            torch::init<
+                int64_t,
+                double,
+                double,
+                std::optional<c10::intrusive_ptr<kv_mem::FeatureEvictConfig>>,
+                int64_t,
+                int64_t,
+                int64_t,
+                std::optional<at::Tensor>,
+                std::optional<at::Tensor>,
+                bool,
+                bool,
+                bool,
+                bool,
+                int64_t,
+                int64_t,
+                std::vector<std::string>,
+                std::vector<int64_t>,
+                std::vector<int64_t>,
+                int64_t,
+                int64_t,
+                std::optional<c10::intrusive_ptr<kv_mem::EnrichmentConfig>>,
+                std::string,
+                int64_t,
+                int64_t,
+                int64_t,
+                int64_t,
+                int64_t,
+                int64_t,
+                int64_t,
+                int64_t,
+                int64_t,
+                bool,
+                int64_t,
+                int64_t,
+                bool,
+                int64_t,
+                bool>(),
+            "",
+            {
+                torch::arg("max_D"),
+                torch::arg("uniform_init_lower"),
+                torch::arg("uniform_init_upper"),
+                torch::arg("feature_evict_config") = std::nullopt,
+                torch::arg("num_shards") = 8,
+                torch::arg("num_threads") = 32,
+                torch::arg("row_storage_bitwidth") = 32,
+                torch::arg("table_dims") = std::nullopt,
+                torch::arg("hash_size_cumsum") = std::nullopt,
+                torch::arg("backend_return_whole_row") = false,
+                torch::arg("enable_async_update") = false,
+                torch::arg("disable_random_init") = false,
+                torch::arg("enable_raw_embedding_streaming") = false,
+                torch::arg("res_store_shards") = 0,
+                torch::arg("res_server_port") = 0,
+                torch::arg("table_names") = std::vector<std::string>{},
+                torch::arg("table_offsets") = std::vector<int64_t>{},
+                torch::arg("table_sizes") = std::vector<int64_t>{},
+                torch::arg("writeback_queue_size") = 1024,
+                torch::arg("writeback_batch_size") = 1024,
+                torch::arg("enrichment_config") = std::nullopt,
+                torch::arg("ssd_path") = std::string(""),
+                torch::arg("memtable_flush_period") = 0,
+                torch::arg("memtable_flush_offset") = 0,
+                torch::arg("l0_files_per_compact") = 0,
+                torch::arg("rate_limit_mbps") = 0,
+                torch::arg("size_ratio") = 10,
+                torch::arg("compaction_ratio") = 0,
+                torch::arg("write_buffer_size") = 0,
+                torch::arg("max_write_buffer_num") = 0,
+                torch::arg("block_cache_size") = 0,
+                torch::arg("use_passed_in_path") = true,
+                torch::arg("tbe_unique_id") = 0,
+                torch::arg("l2_cache_size_gb") = 0,
+                torch::arg("ssd_enable_async_update") = false,
+                torch::arg("flushing_block_size") = 2000000000,
+                torch::arg("enable_blob_db") = false,
+            })
+        .def(
+            "set_cuda",
+            &DramSsdKVEmbeddingCacheWrapper::set_cuda,
+            "",
+            {
+                torch::arg("indices"),
+                torch::arg("weights"),
+                torch::arg("count"),
+                torch::arg("timestep"),
+                torch::arg("is_bwd") = false,
+            })
+        .def("get_cuda", &DramSsdKVEmbeddingCacheWrapper::get_cuda)
+        .def(
+            "set_backend_return_whole_row",
+            &DramSsdKVEmbeddingCacheWrapper::set_backend_return_whole_row,
+            "",
+            {
+                torch::arg("backend_return_whole_row"),
+            })
+        .def(
+            "trigger_feature_evict",
+            &DramSsdKVEmbeddingCacheWrapper::trigger_feature_evict)
+        .def("is_evicting", &DramSsdKVEmbeddingCacheWrapper::is_evicting)
+        .def("set", &DramSsdKVEmbeddingCacheWrapper::set)
+        .def(
+            "set_range_to_storage",
+            &DramSsdKVEmbeddingCacheWrapper::set_range_to_storage)
+        .def(
+            "get",
+            &DramSsdKVEmbeddingCacheWrapper::get,
+            "",
+            {
+                torch::arg("indices"),
+                torch::arg("weights"),
+                torch::arg("count"),
+                torch::arg("sleep_ms") = 0,
+            })
+        .def(
+            "wait_util_filling_work_done",
+            &DramSsdKVEmbeddingCacheWrapper::wait_util_filling_work_done)
+        .def(
+            "wait_until_eviction_done",
+            &DramSsdKVEmbeddingCacheWrapper::wait_until_eviction_done)
+        .def(
+            "get_keys_in_range",
+            &DramSsdKVEmbeddingCacheWrapper::get_keys_in_range,
+            "",
+            {
+                torch::arg("start"),
+                torch::arg("end"),
+            })
+        .def(
+            "set_feature_score_metadata_cuda",
+            &DramSsdKVEmbeddingCacheWrapper::set_feature_score_metadata_cuda,
+            "",
+            {
+                torch::arg("indices"),
+                torch::arg("count"),
+                torch::arg("engage_rates"),
+            })
+        .def("flush", &DramSsdKVEmbeddingCacheWrapper::flush)
+        .def(
+            "get_keys_in_range_by_snapshot",
+            &DramSsdKVEmbeddingCacheWrapper::get_keys_in_range_by_snapshot)
+        .def(
+            "get_kv_zch_eviction_metadata_by_snapshot",
+            &DramSsdKVEmbeddingCacheWrapper::
+                get_kv_zch_eviction_metadata_by_snapshot)
+        .def(
+            "get_feature_evict_metric",
+            &DramSsdKVEmbeddingCacheWrapper::get_feature_evict_metric)
+        .def(
+            "get_dram_kv_perf",
+            &DramSsdKVEmbeddingCacheWrapper::get_dram_kv_perf)
+        .def(
+            "set_embedding_cache_enrich_query_id_cuda",
+            &DramSsdKVEmbeddingCacheWrapper::
+                set_embedding_cache_enrich_query_id_cuda,
+            "",
+            {
+                torch::arg("hashed_indices"),
+                torch::arg("unhashed_indices"),
+                torch::arg("count"),
+            })
+        .def(
+            "create_snapshot",
+            &DramSsdKVEmbeddingCacheWrapper::create_snapshot)
+        .def(
+            "get_snapshot_count",
+            &DramSsdKVEmbeddingCacheWrapper::get_snapshot_count)
+        .def(
+            "create_rocksdb_hard_link_snapshot",
+            &DramSsdKVEmbeddingCacheWrapper::create_rocksdb_hard_link_snapshot,
+            "",
+            {
+                torch::arg("global_step"),
+            })
+        .def(
+            "get_active_checkpoint_uuid",
+            &DramSsdKVEmbeddingCacheWrapper::get_active_checkpoint_uuid)
+        .def(
+            "delete_rocksdb_checkpoint_dir",
+            &DramSsdKVEmbeddingCacheWrapper::delete_rocksdb_checkpoint_dir);
 static auto embedding_rocks_db_read_only_wrapper =
     torch::class_<ReadOnlyEmbeddingKVDB>("fbgemm", "ReadOnlyEmbeddingKVDB")
         .def(

--- a/fbgemm_gpu/test/dram_kv_embedding_cache/dram_ssd_kv_embedding_cache_test.cpp
+++ b/fbgemm_gpu/test/dram_kv_embedding_cache/dram_ssd_kv_embedding_cache_test.cpp
@@ -1,0 +1,575 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "deeplearning/fbgemm/fbgemm_gpu/src/dram_kv_embedding_cache/dram_ssd_kv_embedding_cache.h"
+
+#include <fmt/format.h>
+#include <folly/coro/BlockingWait.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <future>
+#include <thread>
+#include <vector>
+
+#include "deeplearning/fbgemm/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h"
+
+namespace kv_db {
+
+namespace {
+
+// Number of float-sized elements occupied by the MetaHeader prefix that the
+// SSD tier stores ahead of each embedding payload (see fixed_block_pool.h).
+constexpr int64_t kMetaHeaderDim = 4;
+
+// Local mirror of the production MetaHeader layout (fixed_block_pool.h), 16
+// bytes: [int64 key][uint32 timestamp][uint32 count:31][bool used:1].
+struct alignas(8) MetaHeader {
+  int64_t key;
+  uint32_t timestamp;
+  uint32_t count : 31;
+  bool used : 1;
+};
+static_assert(sizeof(MetaHeader) == kMetaHeaderDim * sizeof(float));
+
+// Write a valid MetaHeader prefix into the first kMetaHeaderDim floats of
+// `row`.
+void create_metaheader_row(float* row, int64_t row_dim, int64_t key) {
+  std::memset(row, 0, row_dim * sizeof(float));
+  MetaHeader header{};
+  header.key = key;
+  header.timestamp = 0;
+  header.count = 0;
+  header.used = true;
+  std::memcpy(row, &header, sizeof(header));
+}
+
+// Construct a real on-disk EmbeddingRocksDB to act as the SSD (L3) tier, with
+// the metadata column family enabled so that get_kv_db_weights_only_async()
+// returns only the embedding payload (skipping the MetaHeader prefix) — exactly
+// what the composite's SSD read path expects.
+std::shared_ptr<ssd::EmbeddingRocksDB> makeRocksDbBackend(
+    const std::string& path,
+    int64_t num_shards,
+    int64_t max_D,
+    int64_t metadata_dim) {
+  std::filesystem::create_directories(path);
+  return std::make_shared<ssd::EmbeddingRocksDB>(
+      path,
+      num_shards,
+      /*num_threads=*/8,
+      /*memtable_flush_period=*/0,
+      /*memtable_flush_offset=*/0,
+      /*l0_files_per_compact=*/4,
+      max_D,
+      /*rate_limit_mbps=*/0,
+      /*size_ratio=*/1,
+      /*compaction_trigger=*/8,
+      /*write_buffer_size=*/536870912,
+      /*max_write_buffer_num=*/8,
+      /*uniform_init_lower=*/-0.01,
+      /*uniform_init_upper=*/0.01,
+      /*row_storage_bitwidth=*/32,
+      /*cache_size=*/0,
+      /*use_passed_in_path=*/true,
+      /*tbe_unqiue_id=*/0,
+      /*l2_cache_size_gb=*/0,
+      /*enable_async_update=*/false,
+      /*enable_raw_embedding_streaming=*/false,
+      /*res_store_shards=*/0,
+      /*res_server_port=*/0,
+      /*table_names=*/std::vector<std::string>{},
+      /*table_offsets=*/std::vector<int64_t>{},
+      /*table_sizes=*/std::vector<int64_t>{},
+      /*table_dims=*/std::nullopt,
+      /*hash_size_cumsum=*/std::nullopt,
+      /*flushing_block_size=*/2000000000,
+      /*disable_random_init=*/true,
+      /*enable_blob_db=*/false,
+      /*enable_metadata_cf=*/true,
+      metadata_dim);
+}
+
+} // namespace
+
+class DramSsdKVEmbeddingCacheTest : public ::testing::Test {
+ protected:
+  static constexpr int EMBEDDING_DIM = 16;
+  static constexpr int NUM_SHARDS = 4;
+
+  void SetUp() override {
+    FLAGS_logtostderr = true;
+    FLAGS_minloglevel = 0;
+
+    auto hash_size_cumsum = at::tensor({0, 100000}, at::kLong);
+
+    dram_cache_ = std::make_shared<kv_mem::DramKVEmbeddingCache<float>>(
+        EMBEDDING_DIM,
+        /*uniform_init_lower=*/-0.1,
+        /*uniform_init_upper=*/0.1,
+        /*feature_evict_config=*/std::nullopt,
+        NUM_SHARDS,
+        /*num_threads=*/4,
+        /*row_storage_bitwidth=*/32,
+        /*backend_return_whole_row=*/true,
+        /*enable_async_update=*/false,
+        /*table_dims=*/std::nullopt,
+        hash_size_cumsum,
+        /*is_training=*/true, // training mode for dirty bit writes
+        /*disable_random_init=*/true,
+        /*enable_raw_embedding_streaming=*/false,
+        /*res_store_shards=*/0,
+        /*res_server_port=*/0,
+        /*table_names=*/std::vector<std::string>{},
+        /*table_offsets=*/std::vector<int64_t>{},
+        /*table_sizes=*/std::vector<int64_t>{},
+        /*enrichment_config=*/std::nullopt,
+        // Enables dirty-bit tracking on the DRAM tier, required for flush().
+        /*enable_ssd_backend=*/true);
+
+    // Unique on-disk path per test so RocksDB instances don't collide.
+    const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    ssd_path_ = (std::filesystem::temp_directory_path() /
+                 fmt::format(
+                     "dram_ssd_test_{}_{}",
+                     info != nullptr ? info->name() : "unknown",
+                     static_cast<int64_t>(::getpid())))
+                    .string();
+    ssd_backend_ = makeRocksDbBackend(
+        ssd_path_, /*num_shards=*/1, EMBEDDING_DIM, kMetaHeaderDim);
+  }
+
+  void TearDown() override {
+    composite_.reset();
+    dram_cache_.reset();
+    ssd_backend_.reset();
+    if (!ssd_path_.empty()) {
+      std::error_code ec;
+      std::filesystem::remove_all(ssd_path_, ec);
+    }
+  }
+
+  /// Create the composite backend
+  void createComposite(int64_t queue_size = 1024, int64_t batch_size = 1024) {
+    composite_ = std::make_shared<DramSsdKVEmbeddingCache<float>>(
+        dram_cache_, ssd_backend_, queue_size, batch_size);
+  }
+
+  /// Insert an embedding into the composite via set
+  void insertViaComposite(int64_t id, float value) {
+    auto indices = at::tensor({id}, at::kLong);
+    auto weights = at::full({1, EMBEDDING_DIM}, value, at::kFloat);
+    auto count = at::tensor({1}, at::kLong);
+    composite_->set_kv_db_async(indices, weights, count).wait();
+  }
+
+  /// Seed an embedding directly into the SSD tier (MetaHeader + payload row).
+  void insertIntoSsd(int64_t id, float value) {
+    const int64_t row_dim = kMetaHeaderDim + EMBEDDING_DIM;
+    auto indices = at::tensor({id}, at::kLong);
+    auto rows = at::zeros({1, row_dim}, at::kFloat);
+    auto* row = rows.data_ptr<float>();
+    create_metaheader_row(row, row_dim, id);
+    for (int i = 0; i < EMBEDDING_DIM; ++i) {
+      row[kMetaHeaderDim + i] = value;
+    }
+    auto count = at::tensor({1}, at::kLong);
+    ssd_backend_->set_kv_db_async(indices, rows, count).wait();
+  }
+
+  /// Read embeddings via composite get
+  at::Tensor getViaComposite(const std::vector<int64_t>& ids) {
+    auto num = static_cast<int64_t>(ids.size());
+    auto indices = at::tensor(ids, at::TensorOptions().dtype(at::kLong));
+    auto weights = at::zeros({num, EMBEDDING_DIM}, at::kFloat);
+    auto count = at::tensor({num}, at::kLong);
+    composite_->get_kv_db_async(indices, weights, count).wait();
+    return weights;
+  }
+
+  /// Read embedding payloads directly from the SSD tier (weights only).
+  at::Tensor readSsd(const std::vector<int64_t>& ids) {
+    auto num = static_cast<int64_t>(ids.size());
+    auto indices = at::tensor(ids, at::TensorOptions().dtype(at::kLong));
+    auto weights = at::zeros({num, EMBEDDING_DIM}, at::kFloat);
+    auto count = at::tensor({num}, at::kLong);
+    ssd_backend_->get_kv_db_weights_only_async(indices, weights, count).wait();
+    return weights;
+  }
+
+  std::shared_ptr<kv_mem::DramKVEmbeddingCache<float>> dram_cache_;
+  std::shared_ptr<ssd::EmbeddingRocksDB> ssd_backend_;
+  std::shared_ptr<DramSsdKVEmbeddingCache<float>> composite_;
+  std::string ssd_path_;
+};
+
+// Test: Constructor wires up SSD backend and starts writeback thread
+TEST_F(DramSsdKVEmbeddingCacheTest, ConstructorWiresUpComponents) {
+  createComposite();
+  EXPECT_NE(composite_->dram_cache().get(), nullptr);
+  EXPECT_NE(composite_->ssd_backend().get(), nullptr);
+}
+
+// Test: get_kv_db_async returns DRAM hit immediately
+TEST_F(DramSsdKVEmbeddingCacheTest, GetDramHitReturnsImmediately) {
+  createComposite();
+
+  // Insert into DRAM via composite set
+  insertViaComposite(42, 1.5f);
+
+  // Read back
+  auto weights = getViaComposite({42});
+
+  // Should find the DRAM value
+  auto* w_ptr = weights.data_ptr<float>();
+  EXPECT_FLOAT_EQ(w_ptr[0], 1.5f);
+  EXPECT_FLOAT_EQ(w_ptr[1], 1.5f);
+
+  // A DRAM hit must short-circuit: no SSD lookup and no SSD->DRAM backfill.
+  EXPECT_EQ(composite_->get_ssd_num_lookups(), 0);
+  EXPECT_EQ(composite_->get_ssd_num_hits(), 0);
+}
+
+// Test: get_kv_db_async falls through to SSD on DRAM miss
+TEST_F(DramSsdKVEmbeddingCacheTest, GetDramMissSsdHit) {
+  createComposite();
+
+  // Insert into SSD only (not in DRAM)
+  insertIntoSsd(99, 2.5f);
+
+  // Read via composite — should find in SSD
+  auto weights = getViaComposite({99});
+
+  auto* w_ptr = weights.data_ptr<float>();
+  EXPECT_FLOAT_EQ(w_ptr[0], 2.5f);
+  EXPECT_FLOAT_EQ(w_ptr[EMBEDDING_DIM - 1], 2.5f);
+
+  // DRAM miss falls through to exactly one SSD lookup that hit, which is what
+  // schedules the SSD->DRAM backfill.
+  EXPECT_EQ(composite_->get_ssd_num_lookups(), 1);
+  EXPECT_EQ(composite_->get_ssd_num_hits(), 1);
+}
+
+// Test: get_kv_db_async returns zeros when both DRAM and SSD miss
+TEST_F(DramSsdKVEmbeddingCacheTest, GetBothMissReturnsZeros) {
+  createComposite();
+
+  // Key 999 is neither in DRAM nor SSD
+  auto weights = getViaComposite({999});
+
+  auto* w_ptr = weights.data_ptr<float>();
+  for (int j = 0; j < EMBEDDING_DIM; ++j) {
+    EXPECT_FLOAT_EQ(w_ptr[j], 0.0f) << "Expected zero at index " << j;
+  }
+}
+
+// Test: get_kv_db_async with mixed hits (DRAM + SSD + miss)
+TEST_F(DramSsdKVEmbeddingCacheTest, GetMixedHits) {
+  createComposite();
+
+  // Key 1: in DRAM
+  insertViaComposite(1, 1.0f);
+  // Key 2: in SSD only
+  insertIntoSsd(2, 2.0f);
+  // Key 3: nowhere
+
+  auto weights = getViaComposite({1, 2, 3});
+  auto* w_ptr = weights.data_ptr<float>();
+  int64_t stride = EMBEDDING_DIM;
+
+  // Key 1: DRAM hit
+  EXPECT_FLOAT_EQ(w_ptr[0 * stride], 1.0f);
+  // Key 2: SSD hit
+  EXPECT_FLOAT_EQ(w_ptr[1 * stride], 2.0f);
+  // Key 3: both miss -> zeros
+  EXPECT_FLOAT_EQ(w_ptr[2 * stride], 0.0f);
+}
+
+// Test: set_kv_db_async writes to DRAM only (not SSD)
+TEST_F(DramSsdKVEmbeddingCacheTest, SetWritesToDramOnly) {
+  createComposite();
+
+  insertViaComposite(10, 3.0f);
+
+  // Verify it's in DRAM (readable via composite)
+  auto weights = getViaComposite({10});
+  EXPECT_FLOAT_EQ(weights.data_ptr<float>()[0], 3.0f);
+
+  // SSD tier should not have the key: a direct SSD read returns zeros.
+  auto ssd = readSsd({10});
+  auto* s = ssd.data_ptr<float>();
+  for (int j = 0; j < EMBEDDING_DIM; ++j) {
+    EXPECT_FLOAT_EQ(s[j], 0.0f) << "set() must not write to SSD";
+  }
+}
+
+// Test: SSD hit backfills DRAM (subsequent DRAM read should hit)
+TEST_F(DramSsdKVEmbeddingCacheTest, SsdHitBackfillsDram) {
+  createComposite();
+
+  // Insert into SSD only
+  insertIntoSsd(50, 5.0f);
+
+  // First read: DRAM miss -> SSD hit -> schedules async DRAM backfill.
+  auto weights1 = getViaComposite({50});
+  EXPECT_FLOAT_EQ(weights1.data_ptr<float>()[0], 5.0f);
+
+  // Deterministically verify the backfill path ran: the SSD lookup hit, which
+  // is what schedules the SSD->DRAM backfill. ssd_num_hits_ is incremented
+  // synchronously (before the async task is queued), so this is race-free.
+  EXPECT_EQ(composite_->get_ssd_num_lookups(), 1);
+  EXPECT_EQ(composite_->get_ssd_num_hits(), 1);
+
+  // Best-effort (non-asserting) check that the value actually lands in DRAM.
+  // The backfill is fire-and-forget on backfill_executor_ with no deterministic
+  // await hook, so a hard assertion here would make the test flaky. Instead we
+  // poll with a timeout and only log a warning if it never appears.
+  // TODO: Replace with a hard assertion once DramSsdKVEmbeddingCache exposes a
+  // way to await pending backfills.
+  auto dram_indices = at::tensor({50}, at::kLong);
+  auto dram_count = at::tensor({1}, at::kLong);
+  float dram_val = 0.0f;
+  for (int attempt = 0; attempt < 100; ++attempt) {
+    auto dram_weights = at::zeros({1, EMBEDDING_DIM}, at::kFloat);
+    dram_cache_->get_kv_db_async(dram_indices, dram_weights, dram_count).wait();
+    dram_val = dram_weights.data_ptr<float>()[0];
+    if (dram_val == 5.0f) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  if (dram_val != 5.0f) {
+    GTEST_LOG_(WARNING)
+        << "SSD->DRAM backfill did not land within timeout (got " << dram_val
+        << ", expected 5.0). Backfill is async/best-effort in this test.";
+  }
+}
+
+// Test: stop/start writeback thread
+TEST_F(DramSsdKVEmbeddingCacheTest, WritebackThreadLifecycle) {
+  createComposite();
+
+  // Writeback thread should be running after construction
+  composite_->stop_writeback_thread();
+
+  // Should be safe to stop again
+  composite_->stop_writeback_thread();
+
+  // Should be safe to start again
+  composite_->start_writeback_thread();
+}
+
+// Test: Destructor stops writeback thread cleanly
+TEST_F(DramSsdKVEmbeddingCacheTest, DestructorCleanup) {
+  createComposite();
+
+  // Insert some data
+  insertViaComposite(300, 30.0f);
+
+  // Destroy composite — should not hang or crash
+  composite_.reset();
+}
+
+// Test: async backfill work does not block shutdown.
+TEST_F(DramSsdKVEmbeddingCacheTest, AsyncBackfillShutdownDoesNotHang) {
+  createComposite();
+
+  // Populate many SSD-only keys to schedule a sizable async backfill batch.
+  constexpr int64_t kNumKeys = 2000;
+  std::vector<int64_t> ids;
+  ids.reserve(kNumKeys);
+  for (int64_t i = 0; i < kNumKeys; ++i) {
+    const int64_t key = 100000 + i;
+    ids.push_back(key);
+    insertIntoSsd(key, 10.0f + static_cast<float>(i));
+  }
+
+  // Trigger SSD lookups and async backfill scheduling.
+  auto weights = getViaComposite(ids);
+  EXPECT_EQ(weights.size(0), kNumKeys);
+
+  auto shutdown_future =
+      std::async(std::launch::async, [this]() { composite_.reset(); });
+
+  // Destructor must complete quickly even with pending async backfill work.
+  EXPECT_EQ(
+      shutdown_future.wait_for(std::chrono::seconds(5)),
+      std::future_status::ready);
+  shutdown_future.get();
+}
+
+// Test: stopping writeback thread while async backfill is active remains safe.
+TEST_F(DramSsdKVEmbeddingCacheTest, StopWritebackDuringAsyncBackfill) {
+  createComposite();
+
+  constexpr int64_t kNumKeys = 1024;
+  std::vector<int64_t> ids;
+  ids.reserve(kNumKeys);
+  for (int64_t i = 0; i < kNumKeys; ++i) {
+    const int64_t key = 200000 + i;
+    ids.push_back(key);
+    insertIntoSsd(key, 20.0f + static_cast<float>(i));
+  }
+
+  // Schedule async backfill by issuing SSD-hit reads.
+  auto weights = getViaComposite(ids);
+  EXPECT_EQ(weights.size(0), kNumKeys);
+
+  // Should be safe and non-hanging while backfill tasks may still be running.
+  EXPECT_NO_THROW(composite_->stop_writeback_thread());
+  EXPECT_NO_THROW(composite_->start_writeback_thread());
+}
+
+// Test: Delegation of set_kv_zch_eviction_metadata_async
+TEST_F(DramSsdKVEmbeddingCacheTest, DelegatesEvictionMetadata) {
+  createComposite();
+
+  auto indices = at::tensor({1, 2, 3}, at::kLong);
+  auto count = at::tensor({3}, at::kLong);
+  auto engage = at::zeros({3}, at::kFloat);
+
+  // Should not throw
+  EXPECT_NO_THROW(
+      composite_->set_kv_zch_eviction_metadata_async(indices, count, engage)
+          .wait());
+}
+
+// Test: get with negative indices (sentinels) are skipped
+TEST_F(DramSsdKVEmbeddingCacheTest, GetSkipsNegativeIndices) {
+  createComposite();
+
+  insertViaComposite(1, 1.0f);
+  insertIntoSsd(2, 2.0f);
+
+  auto indices = at::tensor({-1, 1, -1, 2}, at::kLong);
+  auto weights = at::zeros({4, EMBEDDING_DIM}, at::kFloat);
+  auto count = at::tensor({4}, at::kLong);
+  composite_->get_kv_db_async(indices, weights, count).wait();
+
+  auto* w_ptr = weights.data_ptr<float>();
+  int64_t stride = EMBEDDING_DIM;
+
+  // -1 indices should remain zero
+  EXPECT_FLOAT_EQ(w_ptr[0 * stride], 0.0f);
+  // Key 1: DRAM hit
+  EXPECT_FLOAT_EQ(w_ptr[1 * stride], 1.0f);
+  // -1 index: zero
+  EXPECT_FLOAT_EQ(w_ptr[2 * stride], 0.0f);
+  // Key 2: SSD hit
+  EXPECT_FLOAT_EQ(w_ptr[3 * stride], 2.0f);
+}
+
+// Test: flush() drains dirty DRAM blocks to SSD.
+TEST_F(DramSsdKVEmbeddingCacheTest, FlushDirtyBlocksToSsd) {
+  createComposite();
+
+  // Seed dirty DRAM blocks via the metaheader write path, which marks blocks
+  // dirty. (The composite's set_kv_db_async is the backfill path and
+  // intentionally does NOT mark dirty, so flush would skip those.) flush() then
+  // drains the dirty blocks to SSD.
+  const int64_t row_dim = kMetaHeaderDim + EMBEDDING_DIM;
+  const std::vector<int64_t> ids = {100, 101};
+  auto rows =
+      at::zeros({static_cast<int64_t>(ids.size()), row_dim}, at::kFloat);
+  auto* rp = rows.data_ptr<float>();
+  for (size_t r = 0; r < ids.size(); ++r) {
+    float* row = rp + r * row_dim;
+    create_metaheader_row(row, row_dim, ids[r]); // embeds key in metaheader
+    for (int i = 0; i < EMBEDDING_DIM; ++i) {
+      row[kMetaHeaderDim + i] = 10.0f + static_cast<float>(r);
+    }
+  }
+  dram_cache_->set_kv_with_metaheader_to_storage(rows);
+
+  // Before flush, the keys are not on SSD yet.
+  auto before = readSsd(ids);
+  auto* b = before.data_ptr<float>();
+  EXPECT_FLOAT_EQ(b[0 * EMBEDDING_DIM], 0.0f);
+  EXPECT_FLOAT_EQ(b[1 * EMBEDDING_DIM], 0.0f);
+
+  // flush() drains dirty DRAM blocks to SSD synchronously.
+  composite_->flush();
+  EXPECT_GT(composite_->get_ssd_num_writes(), 0);
+
+  auto after = readSsd(ids);
+  auto* a = after.data_ptr<float>();
+  EXPECT_FLOAT_EQ(a[0 * EMBEDDING_DIM], 10.0f);
+  EXPECT_FLOAT_EQ(a[1 * EMBEDDING_DIM], 11.0f);
+
+  // flush() clears the dirty bits, so a second flush finds no dirty blocks and
+  // must not re-write anything (avoids duplicated SSD writes).
+  auto writes_after_first = composite_->get_ssd_num_writes();
+  composite_->flush();
+  EXPECT_EQ(composite_->get_ssd_num_writes(), writes_after_first)
+      << "Second flush should not re-write already-flushed (clean) blocks";
+}
+
+// Test: get_dram_kv_perf appends composite SSD metrics (indices 38-42).
+TEST_F(DramSsdKVEmbeddingCacheTest, GetDramKvPerfReportsSsdMetrics) {
+  createComposite();
+
+  // One DRAM-miss -> SSD-hit read: records 1 SSD lookup + 1 SSD hit.
+  insertIntoSsd(7, 7.0f);
+  getViaComposite({7});
+
+  // Seed two dirty DRAM blocks and flush them: records 2 SSD writes.
+  const int64_t row_dim = kMetaHeaderDim + EMBEDDING_DIM;
+  const std::vector<int64_t> ids = {100, 101};
+  auto rows =
+      at::zeros({static_cast<int64_t>(ids.size()), row_dim}, at::kFloat);
+  auto* rp = rows.data_ptr<float>();
+  for (size_t r = 0; r < ids.size(); ++r) {
+    float* row = rp + r * row_dim;
+    create_metaheader_row(row, row_dim, ids[r]);
+    for (int i = 0; i < EMBEDDING_DIM; ++i) {
+      row[kMetaHeaderDim + i] = 10.0f + static_cast<float>(r);
+    }
+  }
+  dram_cache_->set_kv_with_metaheader_to_storage(rows);
+  composite_->flush();
+
+  // interval=1 so per-interval values equal the raw counts. step%interval==0
+  // and step>0 so the SSD metrics block runs.
+  auto perf = composite_->get_dram_kv_perf(/*step=*/1, /*interval=*/1);
+  ASSERT_EQ(perf.size(), 43u);
+  EXPECT_DOUBLE_EQ(perf[38], 1.0); // ssd lookups
+  EXPECT_DOUBLE_EQ(perf[39], 1.0); // ssd hits
+  EXPECT_DOUBLE_EQ(perf[40], 2.0); // ssd writes (2 flushed blocks)
+  EXPECT_GT(perf[42], 0.0); // cumulative rows written to SSD
+}
+
+// Test: set_range_to_storage (checkpoint restore) writes whole rows to SSD.
+TEST_F(DramSsdKVEmbeddingCacheTest, SetRangeToStorageWritesWholeRowToSsd) {
+  createComposite();
+
+  const int64_t row_dim = kMetaHeaderDim + EMBEDDING_DIM;
+  const std::vector<int64_t> ids = {7, 8};
+  auto rows =
+      at::zeros({static_cast<int64_t>(ids.size()), row_dim}, at::kFloat);
+  auto* rp = rows.data_ptr<float>();
+  for (size_t r = 0; r < ids.size(); ++r) {
+    float* row = rp + r * row_dim;
+    create_metaheader_row(row, row_dim, ids[r]); // key read back via get_key()
+    for (int i = 0; i < EMBEDDING_DIM; ++i) {
+      row[kMetaHeaderDim + i] = 70.0f + static_cast<float>(r);
+    }
+  }
+
+  // Keys are taken from each row's metaheader, not from start/length.
+  composite_->set_range_to_storage(
+      rows, /*start=*/0, /*length=*/static_cast<int64_t>(ids.size()));
+
+  auto ssd = readSsd(ids);
+  auto* s = ssd.data_ptr<float>();
+  EXPECT_FLOAT_EQ(s[0 * EMBEDDING_DIM], 70.0f);
+  EXPECT_FLOAT_EQ(s[1 * EMBEDDING_DIM], 71.0f);
+}
+
+} // namespace kv_db


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2866

## Context

The high-level intention of this stack of diffs is to integrate a new storage backend, specifically an SSD (Solid-State Drive) cache, into the FBGEMM (Facebook's Better Gemsm) library. The diffs aim to enable the library to store and manage embedding data and metadata separately, using different column families in RocksDB, a key-value store database.

The main goals of this stack are:

1. **SSD backend integration**: The diffs add support for a new SSD backend to the `DramKVEmbeddingCache` class, allowing it to store embedding data in a separate storage tier.
2. **Metadata management**: The diffs introduce new methods and data structures to manage metadata separately from the main embedding data. This includes adding virtual methods to the `EmbeddingKVDB` interface, declaring new member fields, and implementing methods for metadata-only writes and reads.
3. **Split-read methods**: The diffs add new methods that allow independent reading of embedding weights and metadata from the SSD cache, optimizing read operations and enabling separate lifecycle management for metadata and weights.
4. **Wiring metadata column family**: The diffs wire the metadata column family into existing `EmbeddingRocksDB` methods to support storing and managing KVZCH metadata separately from the main embedding data in SSD.

Overall, this stack of diffs aims to improve the performance and efficiency of the FBGEMM library by enabling it to leverage SSD storage for embedding data and metadata, while also providing better management and optimization of these resources.


## This Diff

**[KVZCH][SSD] Implement DRAM+SSD composite logic in DramSsdKVEmbeddingCache**
====================================================================================

### Overview

This diff implements the DRAM+SSD composite logic in the `DramSsdKVEmbeddingCache` class. The changes include:

### Code Changes

*   Added a new file `dram_ssd_kv_embedding_cache.h` with the class definition for `DramSsdKVEmbeddingCache`.
*   Modified `BUCK` files in `fbcode/deeplearning/fbgemm/fbgemm_gpu/test/dram_kv_embedding_cache` and `fbcode/deeplearning/fbgemm/fbgemm_gpu` to include the new file.
*   Modified `ssd_split_table_batched_embeddings.cpp` to include the new header file.
*   Added a new test file `dram_ssd_kv_embedding_cache_test.cpp` to test the implementation.

### Key Features

*   Implemented the `DramSsdKVEmbeddingCache` class with the following features:
    *   A batch of dirty blocks evicted from DRAM, to be written to SSD.
    *   Uses `folly::MPMCQueue` for thread-safe queuing of blocks to be written to SSD.
    *   Uses `folly::coro::BlockingWait` for asynchronous writes to SSD.
    *   Includes a test file to verify the implementation.

### Impact

This implementation provides a DRAM+SSD composite logic in the `DramSsdKVEmbeddingCache` class, enabling efficient caching and writes to SSD. The test file ensures the correctness of the implementation.

Reviewed By: EddyLXJ

Differential Revision: D109627064


