### PR TITLE
Replace TBE type-dispatch macros with C++20 generic-lambda functions

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
@@ -244,7 +244,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
 
     const auto* weights_tys_acc = weights_tys.const_data_ptr<uint8_t>();
 
-    DISPATCH_OUTPUT_TYPES(output.scalar_type(), "intn_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", [&] {
+    fbgemm_gpu::dispatch_output_types(output.scalar_type(), "intn_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", [&]<typename output_t>() {
         {% if weighted %}
         const float* indice_weights_acc = indice_weights.const_data_ptr<float>();
         {% endif %}

--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_host_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_host_template.cu
@@ -269,7 +269,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
 
     {{- define_kernel_invocation("INT2") }}
 
-    DISPATCH_OUTPUT_TYPES(output.scalar_type(), "int2_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&] {
+    fbgemm_gpu::dispatch_output_types(output.scalar_type(), "int2_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&]<typename output_t>() {
       if (max_int2_D > 0) {
         const auto max_D = max_int2_D;
         constexpr auto sparse_type = SparseType::INT2;
@@ -298,7 +298,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
 
     {{- define_kernel_invocation("INT4") }}
 
-    DISPATCH_OUTPUT_TYPES(output.scalar_type(), "int4_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&] {
+    fbgemm_gpu::dispatch_output_types(output.scalar_type(), "int4_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&]<typename output_t>() {
       if (max_int4_D > 0) {
         const auto max_D = max_int4_D;
         constexpr auto sparse_type = SparseType::INT4;
@@ -344,7 +344,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
 
     {{- define_kernel_invocation("INT8") }}
 
-    DISPATCH_OUTPUT_TYPES(output.scalar_type(), "int8_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&] {
+    fbgemm_gpu::dispatch_output_types(output.scalar_type(), "int8_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&]<typename output_t>() {
       if (max_int8_D > 0) {
         const auto max_D = max_int8_D;
         constexpr auto sparse_type = SparseType::INT8;
@@ -401,7 +401,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
 
     {{- define_kernel_invocation("FP8") }}
 
-    DISPATCH_OUTPUT_TYPES(output.scalar_type(), "fp8_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&] {
+    fbgemm_gpu::dispatch_output_types(output.scalar_type(), "fp8_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&]<typename output_t>() {
       if (max_float8_D > 0) {
         const auto max_D = max_float8_D;
         constexpr auto sparse_type = SparseType::FP8;
@@ -436,7 +436,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
 
     {{- define_kernel_invocation("FP16") }}
 
-    DISPATCH_OUTPUT_TYPES(output.scalar_type(), "fp16_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&] {
+    fbgemm_gpu::dispatch_output_types(output.scalar_type(), "fp16_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&]<typename output_t>() {
       if (max_float16_D > 0) {
         const auto max_D = max_float16_D;
         constexpr auto sparse_type = SparseType::FP16;
@@ -471,7 +471,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
 
     {{- define_kernel_invocation("FP32") }}
 
-    DISPATCH_OUTPUT_TYPES(output.scalar_type(), "fp32_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&] {
+    fbgemm_gpu::dispatch_output_types(output.scalar_type(), "fp32_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&]<typename output_t>() {
       if (max_float32_D > 0) {
         const auto max_D = max_float32_D;
         constexpr auto sparse_type = SparseType::FP32;

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_grad_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_grad_template.cu
@@ -208,7 +208,7 @@ __global__ __launch_bounds__(kMaxThreads) void grad_mean{{ vdesc }}_kernel(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Explicitly instantiate the template based on DISPATCH_EMB_GRAD_CACHE_TYPES
+// Explicitly instantiate the template based on dispatch_emb_grad_cache_types
 ////////////////////////////////////////////////////////////////////////////////
 
 {% for grad_type in ['at::Half', 'float', 'at::BFloat16'] %}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_indice_weights_template.cu
@@ -517,7 +517,7 @@ Tensor {{ mdesc }}_embedding_codegen_grad_indice_weights{{ vdesc }}_cuda(
     {%- endif %}
 
     AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "split_embedding_codegen_grad_indice_weights{{ vdesc }}_kernel_1", [&] {
-    DISPATCH_EMB_GRAD_CACHE_TYPES(
+    fbgemm_gpu::dispatch_emb_grad_cache_types(
         dev_weights.scalar_type(),
         aligned_grad_output.scalar_type(),
         {%- if not dense %}
@@ -526,7 +526,7 @@ Tensor {{ mdesc }}_embedding_codegen_grad_indice_weights{{ vdesc }}_cuda(
         dev_weights.scalar_type(),
         {%- endif %}
         "split_embedding_codegen_grad_indice_weights{{ vdesc }}_kernel_2",
-        [&] {
+        [&]<typename emb_t, typename grad_t, typename cache_t>() {
             {%- if vbe %}
             const auto& grad_output_reshaped = aligned_grad_output.reshape({1, -1});
             {%- else %}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
@@ -429,7 +429,7 @@ batch_index_select_dim0_codegen_backward_kernel_cta_per_row(
 
 /*
     Explicitly instantiate the kernel function template.  The instantiations are
-    based on the types enumerated by DISPATCH_EMB_GRAD_CACHE_TYPES macro used in
+    based on the types enumerated by dispatch_emb_grad_cache_types function used in
     embedding_backward_split_template.cu
 */
 

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -348,7 +348,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row(
 
 /*
     Explicitly instantiate the kernel function template.  The instantiations are
-    based on the types enumerated by DISPATCH_EMB_GRAD_CACHE_TYPES macro used in
+    based on the types enumerated by dispatch_emb_grad_cache_types function used in
     embedding_backward_split_template.cu
 */
 

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -882,7 +882,7 @@ Tensor {{ embedding_cuda_op }}(
     {%- endif %}
 
     AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "{{ embedding_cuda_op }}_2", [&] {
-    DISPATCH_EMB_GRAD_CACHE_TYPES(
+    fbgemm_gpu::dispatch_emb_grad_cache_types(
         dev_weights.scalar_type(),
         aligned_grad_output.scalar_type(),
         {%- if not dense %}
@@ -891,7 +891,7 @@ Tensor {{ embedding_cuda_op }}(
         dev_weights.scalar_type(),
         {%- endif %}
             "{{ embedding_cuda_op }}",
-        [&] {
+        [&]<typename emb_t, typename grad_t, typename cache_t>() {
             {%- if weighted %}
             auto indice_weights_sorted = at::empty_like(indice_weights);
             {
@@ -1383,7 +1383,7 @@ Tensor {{ embedding_cuda_op }}(
                 return;
 
             }); // DISPATCH_OPTIMAL_KERNEL
-        }); // DISPATCH_EMB_GRAD_CACHE_TYPES
+        }); // dispatch_emb_grad_cache_types
         }); // AT_DISPATCH_INDEX_TYPES
 
     {%- if dense %}

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_nobag_small_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_nobag_small_template.cu
@@ -194,7 +194,7 @@ batch_index_select_dim0_codegen_forward_small_kernel(
 
 /*
     Explicitly instantiate the kernel function template.  The instantiations are
-    based on the types enumerated by DISPATCH_EMB_GRAD_CACHE_TYPES macro used in
+    based on the types enumerated by dispatch_emb_grad_cache_types function used in
     embedding_forward_split_template.cu
 */
 

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
@@ -833,7 +833,7 @@ batch_index_select_dim0_codegen_forward_kernel(
 
 /*
     Explicitly instantiate the kernel function template.  The instantiations are
-    based on the types enumerated by DISPATCH_EMB_CACHE_TYPES macro used in
+    based on the types enumerated by dispatch_emb_cache_types function used in
     embedding_forward_split_template.cu
 */
 

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
@@ -1033,7 +1033,7 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
 
 /*
     Explicitly instantiate the kernel function template.  The instantiations are
-    based on the types enumerated by DISPATCH_EMB_CACHE_TYPES macro used in
+    based on the types enumerated by dispatch_emb_cache_types function used in
     embedding_forward_split_template.cu
 */
 

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
@@ -589,7 +589,7 @@ batch_index_select_dim0_codegen_forward_cuda(
 
 
     AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "batched_embedding{{ ndesc }}_forward_kernel_1", [&] {
-    DISPATCH_EMB_CACHE_OUTPUT_TYPES(
+    fbgemm_gpu::dispatch_emb_cache_output_types(
         dev_weights.scalar_type(),
         {%- if not dense %}
         lxu_cache_weights.scalar_type(),
@@ -597,7 +597,8 @@ batch_index_select_dim0_codegen_forward_cuda(
         dev_weights.scalar_type(),
         {%- endif %}
         output.scalar_type(),
-        "batched_embedding{{ ndesc }}_forward_kernel_2", [&] {
+        "batched_embedding{{ ndesc }}_forward_kernel_2",
+        [&]<typename emb_t, typename cache_t, typename output_t>() {
 
         {%- if dense %}
         [[maybe_unused]] bool use_lxu_cache = false;

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_template.cu
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_template.cu
@@ -148,11 +148,11 @@ void split_embedding_{{ optimizer }}_update(
     const auto& flatten_grad_dev_weights = grad_dev_weights.flatten();
     const auto& flatten_grad_dev_indices = grad_dev_indices.flatten();
 
-    DISPATCH_EMB_CACHE_TYPES(
+    fbgemm_gpu::dispatch_emb_cache_types(
         dev_weights.scalar_type(),
         lxu_cache_weights.scalar_type(),
         "split_embedding_{{ optimizer }}_update_kernel",
-        [&] {
+        [&]<typename emb_t, typename cache_t>() {
             TORCH_CHECK(!(std::is_same_v<emb_t, uint8_t>));
 
             at::PhiloxCudaState rng_engine_inputs;
@@ -216,6 +216,6 @@ void split_embedding_{{ optimizer }}_update(
             }
             {%- endif %}
             {%- endfor %}
-        } // DISPATCH_EMB_CACHE_TYPES
+        } // dispatch_emb_cache_types
     );
 }

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/dispatch_macros.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/dispatch_macros.h
@@ -8,276 +8,160 @@
 
 #pragma once
 
+#include <c10/core/ScalarType.h>
+#include <c10/util/Exception.h>
 // This is NECESSARY for the PT2_COMPLIANT_TAG macro to work.
 #include <torch/library.h>
 
-#define PRIVATE_CASE_TYPE_CACHE(enum_type, type, ...) \
-  case enum_type: {                                   \
-    using cache_t = type;                             \
-    return __VA_ARGS__();                             \
-  }
+////////////////////////////////////////////////////////////////////////////////
+/// Type Dispatch Functions
+///
+/// These functions dispatch runtime at::ScalarType values to compile-time
+/// types and invoke the given functor with the resolved types as explicit
+/// template arguments, e.g.:
+///
+///   dispatch_emb_cache_types(
+///       emb.scalar_type(), cache.scalar_type(), "op_name",
+///       [&]<typename emb_t, typename cache_t>() { ... });
+////////////////////////////////////////////////////////////////////////////////
 
-#define PRIVATE_CASE_TYPE_EMB(enum_type1, enum_type2, type1, NAME, ...)    \
-  case enum_type1: {                                                       \
-    using emb_t = type1;                                                   \
-    switch (enum_type2) {                                                  \
-      PRIVATE_CASE_TYPE_CACHE(at::ScalarType::Float, float, __VA_ARGS__)   \
-      PRIVATE_CASE_TYPE_CACHE(at::ScalarType::Half, at::Half, __VA_ARGS__) \
-      default:                                                             \
-        TORCH_CHECK(                                                       \
-            false,                                                         \
-            #NAME,                                                         \
-            " not implemented for cache_t '",                              \
-            toString(enum_type2),                                          \
-            "'");                                                          \
-    }                                                                      \
-  }
+namespace fbgemm_gpu {
+
 #if defined(USE_ROCM)
-
-#define _DISPATCH_EMB_CACHE_TYPES(emb_enum_type, cache_enum_type, NAME, ...) \
-  at::ScalarType _emb_t = emb_enum_type;                                     \
-  at::ScalarType _cache_t = cache_enum_type;                                 \
-  switch (_emb_t) {                                                          \
-    PRIVATE_CASE_TYPE_EMB(                                                   \
-        at::ScalarType::Float, _cache_t, float, NAME, __VA_ARGS__)           \
-    PRIVATE_CASE_TYPE_EMB(                                                   \
-        at::ScalarType::Half, _cache_t, at::Half, NAME, __VA_ARGS__)         \
-    PRIVATE_CASE_TYPE_EMB(                                                   \
-        at::ScalarType::Float8_e4m3fnuz,                                     \
-        _cache_t,                                                            \
-        at::Float8_e4m3fnuz,                                                 \
-        NAME,                                                                \
-        __VA_ARGS__)                                                         \
-    default:                                                                 \
-      TORCH_CHECK(                                                           \
-          false,                                                             \
-          #NAME,                                                             \
-          " not implemented for emb_t '",                                    \
-          toString(_emb_t),                                                  \
-          "'");                                                              \
-  }
-
+using fp8_e4m3_t = at::Float8_e4m3fnuz;
 #else
-
-#define _DISPATCH_EMB_CACHE_TYPES(emb_enum_type, cache_enum_type, NAME, ...) \
-  at::ScalarType _emb_t = emb_enum_type;                                     \
-  at::ScalarType _cache_t = cache_enum_type;                                 \
-  switch (_emb_t) {                                                          \
-    PRIVATE_CASE_TYPE_EMB(                                                   \
-        at::ScalarType::Float, _cache_t, float, NAME, __VA_ARGS__)           \
-    PRIVATE_CASE_TYPE_EMB(                                                   \
-        at::ScalarType::Half, _cache_t, at::Half, NAME, __VA_ARGS__)         \
-    PRIVATE_CASE_TYPE_EMB(                                                   \
-        at::ScalarType::Float8_e4m3fn,                                       \
-        _cache_t,                                                            \
-        at::Float8_e4m3fn,                                                   \
-        NAME,                                                                \
-        __VA_ARGS__)                                                         \
-    default:                                                                 \
-      TORCH_CHECK(                                                           \
-          false,                                                             \
-          #NAME,                                                             \
-          " not implemented for emb_t '",                                    \
-          toString(_emb_t),                                                  \
-          "'");                                                              \
-  }
-
+using fp8_e4m3_t = at::Float8_e4m3fn;
 #endif
 
-#define DISPATCH_EMB_CACHE_TYPES(EMB_TYPE, CACHE_TYPE, NAME, ...)      \
-  [&] {                                                                \
-    const auto& emb_type = EMB_TYPE;                                   \
-    const auto& cache_type = CACHE_TYPE;                               \
-    _DISPATCH_EMB_CACHE_TYPES(emb_type, cache_type, NAME, __VA_ARGS__) \
-  }()
-
-#define PRIVATE_CASE_TYPE_OUTPUT(                            \
-    output_enum_type1,                                       \
-    emb_enum_type1,                                          \
-    cache_enum_type1,                                        \
-    output_type1,                                            \
-    NAME,                                                    \
-    ...)                                                     \
-  case output_enum_type1: {                                  \
-    using output_t = output_type1;                           \
-    _DISPATCH_EMB_CACHE_TYPES(                               \
-        emb_enum_type1, cache_enum_type1, NAME, __VA_ARGS__) \
+template <typename F>
+decltype(auto) dispatch_emb_cache_types(
+    const at::ScalarType emb_type,
+    const at::ScalarType cache_type,
+    const char* const name,
+    F&& f) {
+  const auto dispatch_cache = [&]<typename emb_t>() -> decltype(auto) {
+    switch (cache_type) {
+      case at::ScalarType::Float:
+        return f.template operator()<emb_t, float>();
+      case at::ScalarType::Half:
+        return f.template operator()<emb_t, at::Half>();
+      default:
+        TORCH_CHECK(
+            false,
+            name,
+            " not implemented for cache_t '",
+            toString(cache_type),
+            "'");
+    }
+  };
+  switch (emb_type) {
+    case at::ScalarType::Float:
+      return dispatch_cache.template operator()<float>();
+    case at::ScalarType::Half:
+      return dispatch_cache.template operator()<at::Half>();
+    case c10::CppTypeToScalarType<fp8_e4m3_t>::value:
+      return dispatch_cache.template operator()<fp8_e4m3_t>();
+    default:
+      TORCH_CHECK(
+          false, name, " not implemented for emb_t '", toString(emb_type), "'");
   }
+}
 
-#define DISPATCH_EMB_CACHE_OUTPUT_TYPES(                           \
-    EMB_TYPE, CACHE_TYPE, OUTPUT_TYPE, NAME, ...)                  \
-  [&] {                                                            \
-    const at::ScalarType _output_t = OUTPUT_TYPE; /*            */ \
-    const auto& emb_type = EMB_TYPE;                               \
-    const auto& cache_type = CACHE_TYPE;                           \
-    switch (_output_t) {                                           \
-      PRIVATE_CASE_TYPE_OUTPUT(                                    \
-          at::ScalarType::Half,                                    \
-          emb_type,                                                \
-          cache_type,                                              \
-          at::Half,                                                \
-          NAME,                                                    \
-          __VA_ARGS__)                                             \
-      PRIVATE_CASE_TYPE_OUTPUT(                                    \
-          at::ScalarType::Float,                                   \
-          emb_type,                                                \
-          cache_type,                                              \
-          float,                                                   \
-          NAME,                                                    \
-          __VA_ARGS__)                                             \
-      PRIVATE_CASE_TYPE_OUTPUT(                                    \
-          at::ScalarType::BFloat16,                                \
-          emb_type,                                                \
-          cache_type,                                              \
-          at::BFloat16,                                            \
-          NAME,                                                    \
-          __VA_ARGS__)                                             \
-      default:                                                     \
-        TORCH_CHECK(                                               \
-            false,                                                 \
-            #NAME,                                                 \
-            " not implemented for output_t '",                     \
-            toString(_output_t),                                   \
-            "'");                                                  \
-    }                                                              \
-  }()
-
-#define PRIVATE_CASE_TYPE_OUTPUT2(enum_type, type, ...) \
-  case enum_type: {                                     \
-    using output_t = type;                              \
-    return __VA_ARGS__();                               \
+template <typename F>
+decltype(auto) dispatch_emb_cache_output_types(
+    const at::ScalarType emb_type,
+    const at::ScalarType cache_type,
+    const at::ScalarType output_type,
+    const char* const name,
+    F&& f) {
+  const auto dispatch_emb_cache = [&]<typename output_t>() -> decltype(auto) {
+    return dispatch_emb_cache_types(
+        emb_type,
+        cache_type,
+        name,
+        [&]<typename emb_t, typename cache_t>() -> decltype(auto) {
+          return f.template operator()<emb_t, cache_t, output_t>();
+        });
+  };
+  switch (output_type) {
+    case at::ScalarType::Half:
+      return dispatch_emb_cache.template operator()<at::Half>();
+    case at::ScalarType::Float:
+      return dispatch_emb_cache.template operator()<float>();
+    case at::ScalarType::BFloat16:
+      return dispatch_emb_cache.template operator()<at::BFloat16>();
+    default:
+      TORCH_CHECK(
+          false,
+          name,
+          " not implemented for output_t '",
+          toString(output_type),
+          "'");
   }
+}
 
+template <typename F>
+decltype(auto) dispatch_output_types(
+    const at::ScalarType output_type,
+    const char* const name,
+    F&& f) {
+  switch (output_type) {
+    case at::ScalarType::Half:
+      return f.template operator()<at::Half>();
+    case at::ScalarType::Float:
+      return f.template operator()<float>();
+    case at::ScalarType::Byte:
+      return f.template operator()<uint8_t>();
 #if !(defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
-
-#define DISPATCH_OUTPUT_TYPES(OUTPUT_TYPE, NAME, ...)                        \
-  [&] {                                                                      \
-    const at::ScalarType _output_t = OUTPUT_TYPE;                            \
-    switch (_output_t) {                                                     \
-      PRIVATE_CASE_TYPE_OUTPUT2(at::ScalarType::Half, at::Half, __VA_ARGS__) \
-      PRIVATE_CASE_TYPE_OUTPUT2(                                             \
-          at::ScalarType::BFloat16, at::BFloat16, __VA_ARGS__)               \
-      PRIVATE_CASE_TYPE_OUTPUT2(at::ScalarType::Float, float, __VA_ARGS__)   \
-      PRIVATE_CASE_TYPE_OUTPUT2(at::ScalarType::Byte, uint8_t, __VA_ARGS__)  \
-      PRIVATE_CASE_TYPE_OUTPUT2(                                             \
-          at::ScalarType::QUInt4x2, uint8_t, __VA_ARGS__)                    \
-      default:                                                               \
-        TORCH_CHECK(                                                         \
-            false,                                                           \
-            #NAME,                                                           \
-            " not implemented for output_t '",                               \
-            toString(_output_t),                                             \
-            "'");                                                            \
-    }                                                                        \
-  }()
-
-#else
-
-#define DISPATCH_OUTPUT_TYPES(OUTPUT_TYPE, NAME, ...)                        \
-  [&] {                                                                      \
-    const at::ScalarType _output_t = OUTPUT_TYPE;                            \
-    switch (_output_t) {                                                     \
-      PRIVATE_CASE_TYPE_OUTPUT2(at::ScalarType::Half, at::Half, __VA_ARGS__) \
-      PRIVATE_CASE_TYPE_OUTPUT2(at::ScalarType::Float, float, __VA_ARGS__)   \
-      PRIVATE_CASE_TYPE_OUTPUT2(at::ScalarType::Byte, uint8_t, __VA_ARGS__)  \
-      default:                                                               \
-        TORCH_CHECK(                                                         \
-            false,                                                           \
-            #NAME,                                                           \
-            " not implemented for output_t '",                               \
-            toString(_output_t),                                             \
-            "'");                                                            \
-    }                                                                        \
-  }()
-
+    case at::ScalarType::BFloat16:
+      return f.template operator()<at::BFloat16>();
+    case at::ScalarType::QUInt4x2:
+      return f.template operator()<uint8_t>();
 #endif
-
-#if defined(USE_ROCM)
-
-#define PRIVATE_CASE_TYPE_CACHE_EMB(                                   \
-    grad_enum_type, _cache_t, _emb_t, grad_cxx_type, NAME, ...)        \
-  case grad_enum_type: {                                               \
-    using grad_t = grad_cxx_type;                                      \
-    switch (_emb_t) {                                                  \
-      PRIVATE_CASE_TYPE_EMB(                                           \
-          at::ScalarType::Float, _cache_t, float, NAME, __VA_ARGS__)   \
-      PRIVATE_CASE_TYPE_EMB(                                           \
-          at::ScalarType::Half, _cache_t, at::Half, NAME, __VA_ARGS__) \
-      PRIVATE_CASE_TYPE_EMB(                                           \
-          at::ScalarType::Float8_e4m3fnuz,                             \
-          _cache_t,                                                    \
-          at::Float8_e4m3fnuz,                                         \
-          NAME,                                                        \
-          __VA_ARGS__)                                                 \
-      default:                                                         \
-        TORCH_CHECK(                                                   \
-            false,                                                     \
-            #NAME,                                                     \
-            " not implemented for emb_t '",                            \
-            toString(_emb_t),                                          \
-            "'");                                                      \
-    }                                                                  \
+    default:
+      TORCH_CHECK(
+          false,
+          name,
+          " not implemented for output_t '",
+          toString(output_type),
+          "'");
   }
+}
 
-#else
-
-#define PRIVATE_CASE_TYPE_CACHE_EMB(                                   \
-    grad_enum_type, _cache_t, _emb_t, grad_cxx_type, NAME, ...)        \
-  case grad_enum_type: {                                               \
-    using grad_t = grad_cxx_type;                                      \
-    switch (_emb_t) {                                                  \
-      PRIVATE_CASE_TYPE_EMB(                                           \
-          at::ScalarType::Float, _cache_t, float, NAME, __VA_ARGS__)   \
-      PRIVATE_CASE_TYPE_EMB(                                           \
-          at::ScalarType::Half, _cache_t, at::Half, NAME, __VA_ARGS__) \
-      PRIVATE_CASE_TYPE_EMB(                                           \
-          at::ScalarType::Float8_e4m3fn,                               \
-          _cache_t,                                                    \
-          at::Float8_e4m3fn,                                           \
-          NAME,                                                        \
-          __VA_ARGS__)                                                 \
-      default:                                                         \
-        TORCH_CHECK(                                                   \
-            false,                                                     \
-            #NAME,                                                     \
-            " not implemented for emb_t '",                            \
-            toString(_emb_t),                                          \
-            "'");                                                      \
-    }                                                                  \
+template <typename F>
+decltype(auto) dispatch_emb_grad_cache_types(
+    const at::ScalarType emb_type,
+    const at::ScalarType grad_type,
+    const at::ScalarType cache_type,
+    const char* const name,
+    F&& f) {
+  const auto dispatch_emb_cache = [&]<typename grad_t>() -> decltype(auto) {
+    return dispatch_emb_cache_types(
+        emb_type,
+        cache_type,
+        name,
+        [&]<typename emb_t, typename cache_t>() -> decltype(auto) {
+          return f.template operator()<emb_t, grad_t, cache_t>();
+        });
+  };
+  switch (grad_type) {
+    case at::ScalarType::Float:
+      return dispatch_emb_cache.template operator()<float>();
+    case at::ScalarType::Half:
+      return dispatch_emb_cache.template operator()<at::Half>();
+    case at::ScalarType::BFloat16:
+      return dispatch_emb_cache.template operator()<at::BFloat16>();
+    default:
+      TORCH_CHECK(
+          false,
+          name,
+          " not implemented for grad_t '",
+          toString(grad_type),
+          "'");
   }
+}
 
-#endif
-
-#define DISPATCH_EMB_GRAD_CACHE_TYPES(                                         \
-    EMB_TYPE, GRAD_TYPE, CACHE_TYPE, NAME, ...)                                \
-  [&] {                                                                        \
-    const auto& emb_type = EMB_TYPE;                                           \
-    const auto& grad_type = GRAD_TYPE;                                         \
-    const auto& cache_type = CACHE_TYPE;                                       \
-    at::ScalarType _emb_t = emb_type;                                          \
-    at::ScalarType _grad_t = grad_type;                                        \
-    at::ScalarType _cache_t = cache_type;                                      \
-    switch (_grad_t) {                                                         \
-      PRIVATE_CASE_TYPE_CACHE_EMB(                                             \
-          at::ScalarType::Float, _cache_t, _emb_t, float, NAME, __VA_ARGS__)   \
-      PRIVATE_CASE_TYPE_CACHE_EMB(                                             \
-          at::ScalarType::Half, _cache_t, _emb_t, at::Half, NAME, __VA_ARGS__) \
-      PRIVATE_CASE_TYPE_CACHE_EMB(                                             \
-          at::ScalarType::BFloat16,                                            \
-          _cache_t,                                                            \
-          _emb_t,                                                              \
-          at::BFloat16,                                                        \
-          NAME,                                                                \
-          __VA_ARGS__)                                                         \
-      default:                                                                 \
-        TORCH_CHECK(                                                           \
-            false,                                                             \
-            #NAME,                                                             \
-            " not implemented for grad_t '",                                   \
-            toString(_grad_t),                                                 \
-            "'");                                                              \
-    }                                                                          \
-  }()
+} // namespace fbgemm_gpu
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Dispatch Helper Macros

--- a/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate.cu
@@ -179,11 +179,11 @@ void lfu_cache_insert_cuda(
 
   const int32_t N = cache_set_sorted_unique_indices.numel();
 
-  DISPATCH_EMB_CACHE_TYPES(
+  fbgemm_gpu::dispatch_emb_cache_types(
       weights.scalar_type(),
       lxu_cache_weights.scalar_type(),
       "lfu_cache_insert_kernel_2",
-      ([&] {
+      ([&]<typename emb_t, typename cache_t>() {
         // Stochastic rounding is required only when emb_t and cache_t are
         // not the same type and emb_t is not float
         const bool stochastic_rounding_ = stochastic_rounding &&

--- a/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate.cu
@@ -201,11 +201,11 @@ void lru_cache_insert_cuda(
   CUDA_DEVICE_GUARD(weights);
 
   const int32_t N = cache_set_sorted_unique_indices.numel();
-  DISPATCH_EMB_CACHE_TYPES(
+  fbgemm_gpu::dispatch_emb_cache_types(
       weights.scalar_type(),
       lxu_cache_weights.scalar_type(),
       "lru_cache_insert_kernel_2",
-      ([&] {
+      ([&]<typename emb_t, typename cache_t>() {
         // Stochastic rounding is required only when emb_t and cache_t are
         // not the same type and emb_t is not float
         const bool stochastic_rounding_ = stochastic_rounding &&

--- a/fbgemm_gpu/src/split_embeddings_cache/lxu_cache.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lxu_cache.cu
@@ -131,11 +131,11 @@ DLL_PUBLIC void lxu_cache_flush_cuda(
           static_cast<uint64_t>(get_max_thread_blocks_for_cache_kernels_())));
   const dim3 blocks(static_cast<uint32_t>(capped_blocks));
 
-  DISPATCH_EMB_CACHE_TYPES(
+  fbgemm_gpu::dispatch_emb_cache_types(
       uvm_weights.scalar_type(),
       lxu_cache_weights.scalar_type(),
       "lxu_cache_flush_kernel_2",
-      ([&] {
+      ([&]<typename emb_t, typename cache_t>() {
         // Stochastic rounding is required only when emb_t and cache_t are
         // not the same type and emb_t is not float
         const bool stochastic_rounding_ = stochastic_rounding &&

--- a/fbgemm_gpu/src/split_embeddings_cache/reset_weight_momentum.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/reset_weight_momentum.cu
@@ -278,11 +278,11 @@ DLL_PUBLIC void reset_weight_momentum_cuda(
   }
 
   // Reset weight and momentum of pruned rows
-  DISPATCH_EMB_CACHE_TYPES(
+  fbgemm_gpu::dispatch_emb_cache_types(
       dev_weights.scalar_type(),
       lxu_cache_weights.scalar_type(),
       "reset_weight_momentum_kernel",
-      ([&] {
+      ([&]<typename emb_t, typename cache_t>() {
         FBGEMM_LAUNCH_KERNEL(
             (reset_weight_momentum_kernel<emb_t, cache_t>),
             num_pruned_tables * blocks_per_table,


### PR DESCRIPTION
Converts the four TBE type-dispatch macros into namespaced C++20 template functions that take a generic lambda with an explicit template-parameter list, instead of relying on macro-injected `using` aliases.

## Changes
- **`dispatch_macros.h`** — replace `DISPATCH_EMB_CACHE_TYPES`, `DISPATCH_EMB_CACHE_OUTPUT_TYPES`, `DISPATCH_OUTPUT_TYPES`, and `DISPATCH_EMB_GRAD_CACHE_TYPES` with `fbgemm_gpu::dispatch_emb_cache_types`, `dispatch_emb_cache_output_types`, `dispatch_output_types`, and `dispatch_emb_grad_cache_types`.
- **Call sites (16 files across `codegen/` and `src/split_embeddings_cache/`)** — `[&] { ... }` → `[&]<typename emb_t, typename cache_t>() { ... }`, with matching template-parameter arities.

## Why
- Type-safe dispatch via explicit template args on lambdas (C++20) instead of opaque macro expansion.
- The fp8 emb type is now resolved through `c10::CppTypeToScalarType<fp8_e4m3_t>`, removing the `USE_ROCM` `#ifdef` split on the emb-type case (the alias alone carries the backend-specific type).
- Net **−115 lines** (macros carried significant `USE_ROCM` duplication).

