### PR TITLE
Fix use-after-free race between DramKV eviction and inplace updates

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -772,7 +772,6 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                       auto indices_data_ptr = indices.data_ptr<index_t>();
                       auto weights_data_ptr = weights.data_ptr<weight_type>();
                       {
-                        // 1st step, collect hit/miss per inplace update chunk
                         // [tensor_offset, weight_addr]
                         std::vector<std::tuple<int64_t, weight_type*>> hit_info;
                         // [id, tensor_offset]
@@ -781,37 +780,37 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                         miss_info.reserve(indexes.size() / 10);
                         // feature evict configured and active
                         const bool evict_enabled = is_eviction_enabled();
-                        auto rlmap = kv_store_.by(shard_id).rlock();
-                        for (const auto& idx : indexes) {
-                          auto id = int64_t(indices_data_ptr[idx]);
-                          auto it = rlmap->find(id);
-                          if (it != rlmap->end()) {
-                            hit_info.emplace_back(idx, it->second);
-                          } else {
-                            miss_info.emplace_back(id, idx);
+                        {
+                          // 1st step, collect hit/miss per inplace update chunk
+                          auto rlmap = kv_store_.by(shard_id).rlock();
+                          for (const auto& idx : indexes) {
+                            auto id = int64_t(indices_data_ptr[idx]);
+                            auto it = rlmap->find(id);
+                            if (it != rlmap->end()) {
+                              hit_info.emplace_back(idx, it->second);
+                            } else {
+                              miss_info.emplace_back(id, idx);
+                            }
                           }
-                        }
-                        rlmap.unlock();
-                        hit_cnt = hit_info.size();
-                        miss_cnt = miss_info.size();
-                        // 2nd step, no lock on update hits, it is possible that
-                        // inference read is accessing a weight being updated,
-                        // we assume it is fine for now, will iterate on it if
-                        // we find QE regress during inplace update
-                        for (auto& [tensor_offset, block] : hit_info) {
-                          auto* data_ptr =
-                              FixedBlockPool::data_ptr<weight_type>(block);
-                          std::copy(
-                              weights_data_ptr + tensor_offset * stride,
-                              weights_data_ptr + (tensor_offset + 1) * stride,
-                              data_ptr);
-
-                          // update provided ts for existing blocks
-                          if (evict_enabled && inplace_update_ts.has_value()) {
-                            FixedBlockPool::set_timestamp(
-                                block, inplace_update_ts.value());
+                          hit_cnt = hit_info.size();
+                          miss_cnt = miss_info.size();
+                          // 2nd step, update hits under the shard rlock; the
+                          // evict loop erases keys before freeing blocks, so
+                          // the held rlock keeps these pointers valid.
+                          for (auto& [tensor_offset, block] : hit_info) {
+                            auto* data_ptr =
+                                FixedBlockPool::data_ptr<weight_type>(block);
+                            std::copy(
+                                weights_data_ptr + tensor_offset * stride,
+                                weights_data_ptr + (tensor_offset + 1) * stride,
+                                data_ptr);
+                            // update provided ts for existing blocks
+                            if (evict_enabled && inplace_update_ts.has_value()) {
+                              FixedBlockPool::set_timestamp(
+                                  block, inplace_update_ts.value());
+                            }
                           }
-                        }
+                        }  // rlmap released here
 
                         // 3rd step, update misses in fixed block pool, we only
                         // need mempool lock at this stage to avoid race

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/feature_evict.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/feature_evict.h
@@ -14,7 +14,9 @@
 #include <cstddef>
 #include <functional>
 #include <memory_resource>
+#include <ranges>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 #include <ATen/ATen.h>
@@ -768,7 +770,6 @@ class FeatureEvict {
       std::vector<int64_t>& evicted_counts,
       std::vector<int64_t>& processed_counts) {
     auto* pool = kv_store_.pool_by(shard_id);
-    auto mem_pool_lock = pool->acquire_lock();
 
     // Capture the callback and SSD flag once into locals; see comment in
     // start_training_eviction_loop.
@@ -778,18 +779,41 @@ class FeatureEvict {
     // Collect dirty evicted blocks for writeback to SSD.
     std::vector<std::pair<int64_t, std::string>> writeback_batch;
 
-    std::vector<int64_t> evicting_keys;
-    evicting_keys.reserve(block_nums_snapshot_[shard_id] / 100);
-    while (!should_exit_evict_loop(shard_id)) {
-      auto* block =
-          pool->template get_block<weight_type>(block_cursors_[shard_id]++);
-      if (block == nullptr) {
-        continue;
+    // Erase keys from the map before freeing blocks; freeing first would leave
+    // the map pointing at freed memory a reader (holding rlock) could write to.
+    std::vector<std::pair<int64_t, weight_type*>> evicting_blocks;
+    {
+      // 1st step: pick victims under mempool lock, don't free yet.
+      auto mem_pool_lock = pool->acquire_lock();
+      evicting_blocks.reserve(block_nums_snapshot_[shard_id] / 100);
+      while (!should_exit_evict_loop(shard_id)) {
+        auto* block =
+            pool->template get_block<weight_type>(block_cursors_[shard_id]++);
+        if (block == nullptr) {
+          continue;
+        }
+        int64_t key = FixedBlockPool::get_key(block);
+        int sub_table_id = get_sub_table_id(key);
+        processed_counts[sub_table_id]++;
+        if (evict_block(block, sub_table_id, shard_id)) {
+          evicting_blocks.emplace_back(key, block);
+          evicted_counts[sub_table_id]++;
+        }
       }
-      int64_t key = FixedBlockPool::get_key(block);
-      int sub_table_id = get_sub_table_id(key);
-      processed_counts[sub_table_id]++;
-      if (evict_block(block, sub_table_id, shard_id)) {
+    }
+
+    // 2nd step: drop keys from the map under wlock (excludes readers).
+    {
+      auto shard_map_wlock = kv_store_.by(shard_id).wlock();
+      for (int64_t key : evicting_blocks | std::views::keys) {
+        shard_map_wlock->erase(key);
+      }
+    }
+
+    // 3rd step: keys unreachable and readers drained, now free the blocks.
+    {
+      auto mem_pool_lock = pool->acquire_lock();
+      for (auto& [key, block] : evicting_blocks) {
         // Serialize dirty block data before deallocate
         if (enable_ssd_writeback) {
           if (writeback_callback && pool->get_dirty(block)) {
@@ -800,20 +824,8 @@ class FeatureEvict {
           }
         }
         pool->template deallocate_t<weight_type>(block);
-        evicted_counts[sub_table_id]++;
-        evicting_keys.push_back(key);
       }
     }
-    mem_pool_lock.unlock();
-
-    // lock dram kv shard hash map to remove evicted blocks in the map
-    // dedicate map update in a wlock to reduce the blocking time for
-    // inference read
-    auto shard_map_wlock = kv_store_.by(shard_id).wlock();
-    for (auto& key : evicting_keys) {
-      shard_map_wlock->erase(key);
-    }
-    shard_map_wlock.unlock();
 
     // Invoke writeback callback after releasing all locks
     if (enable_ssd_writeback) {

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/inference_feature_evict.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/inference_feature_evict.h
@@ -63,33 +63,42 @@ class InferenceTimeThresholdBasedEvict
       std::vector<int64_t>& evicted_counts,
       std::vector<int64_t>& processed_counts) override {
     auto* pool = inference_kv_store_->pool_by(shard_id);
-    auto mem_pool_lock = pool->acquire_lock();
 
-    std::vector<int64_t> evicting_keys;
-    evicting_keys.reserve(this->block_nums_snapshot_[shard_id] / 100);
-    while (!this->should_exit_evict_loop(shard_id)) {
-      auto* block = pool->template get_block<weight_type>(
-          this->block_cursors_[shard_id]++);
-      if (block == nullptr) {
-        continue;
-      }
-      int64_t key = InferenceFixedBlockPool::get_key(block);
-      int sub_table_id = this->get_sub_table_id(key);
-      processed_counts[sub_table_id]++;
-      if (this->evict_block(block, sub_table_id, shard_id)) {
-        pool->template deallocate_t<weight_type>(block);
-        evicted_counts[sub_table_id]++;
-        evicting_keys.push_back(key);
+    // Erase keys from the map before freeing blocks; freeing first would leave
+    // the map pointing at freed memory a reader (holding rlock) could write to.
+    std::vector<std::pair<int64_t, weight_type*>> evicting_blocks;
+    {
+      // 1st step: pick victims under mempool lock, don't free yet.
+      auto mem_pool_lock = pool->acquire_lock();
+      evicting_blocks.reserve(this->block_nums_snapshot_[shard_id] / 100);
+      while (!this->should_exit_evict_loop(shard_id)) {
+        auto* block = pool->template get_block<weight_type>(
+            this->block_cursors_[shard_id]++);
+        if (block == nullptr) {
+          continue;
+        }
+        int64_t key = InferenceFixedBlockPool::get_key(block);
+        int sub_table_id = this->get_sub_table_id(key);
+        processed_counts[sub_table_id]++;
+        if (this->evict_block(block, sub_table_id, shard_id)) {
+          evicting_blocks.emplace_back(key, block);
+          evicted_counts[sub_table_id]++;
+        }
       }
     }
-    mem_pool_lock.unlock();
 
-    // lock dram kv shard hash map to remove evicted blocks in the map
-    // dedicate map update in a wlock to reduce the blocking time for
-    // inference read
-    auto shard_map_wlock = this->kv_store_.by(shard_id).wlock();
-    for (auto& key : evicting_keys) {
-      shard_map_wlock->erase(key);
+    // 2nd step: drop keys from the map under wlock (excludes readers).
+    {
+      auto shard_map_wlock = this->kv_store_.by(shard_id).wlock();
+      for (int64_t key : evicting_blocks | std::views::keys) {
+        shard_map_wlock->erase(key);
+      }
+    }
+
+    // 3rd step: keys unreachable and readers drained, now free the blocks.
+    auto mem_pool_lock = pool->acquire_lock();
+    for (auto* block : evicting_blocks | std::views::values) {
+      pool->template deallocate_t<weight_type>(block);
     }
   }
 


### PR DESCRIPTION
Fixes a use-after-free window between the eviction loop and inplace update
/ inference reads in the DramKV embedding cache.

## The bug
- Eviction **freed blocks first** (mempool lock), then **erased keys from the
  shard map** (`wlock`) — leaving a window where a freed block was still
  reachable via the map.
- Inplace update **dropped its shard `rlock` before writing** to weight blocks,
  so the evict loop could free a block mid-write.

## The fix (two coupled changes)
1. **Erase keys before freeing blocks**: pick victims (mempool lock) → erase
   keys (`wlock`, excludes readers) → free blocks once unreachable.
2. **Hold the shard `rlock` across the inplace hit writes** (lookup + write).

While a reader holds the `rlock`, it blocks the evict loop's `wlock`, so the
key cannot be erased and the block cannot be freed underneath an in-flight
write.