### PR TITLE
Gate MTIA mx4 dep of quantize_utils behind ovr_config//gpu:mtia

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
@@ -32,10 +32,19 @@ except NotImplementedError:
 
 # pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
 if not open_source:
-    from mtia.kernels.triton.mx4.quantize import (
-        triton_dequantize_mx4 as mtia_dequantize_mx4,
-        triton_quantize_mx4 as mtia_quantize_mx4,
-    )
+    # The MTIA mx4 kernels dep is gated to MTIA builds (see BUCK), so on
+    # non-MTIA builds the module is entirely absent and the import raises
+    # ModuleNotFoundError. `except ImportError` guards it (ModuleNotFoundError
+    # is an ImportError subclass); the symbols are only ever called under
+    # `tensor.is_mtia` runtime checks, which never fire on non-MTIA builds.
+    try:
+        # pyre-ignore[21]: dep gated to MTIA builds, absent under DEFAULT config
+        from mtia.kernels.triton.mx4.quantize import (
+            triton_dequantize_mx4 as mtia_dequantize_mx4,
+            triton_quantize_mx4 as mtia_quantize_mx4,
+        )
+    except ImportError:
+        pass
 
 logger: logging.Logger = logging.getLogger()
 


### PR DESCRIPTION
Summary:
`//deeplearning/fbgemm/fbgemm_gpu:quantize_utils` unconditionally depended on `//mtia/kernels/triton:mx4`, so the MTIA mx4 kernels (and transitively `//mtia/kernels/triton:lookup_tables`) leaked into every non-MTIA consumer. This is the last source of MTIA deps reaching `//pytorch/tritonbench:run_lite`, arriving via `legokit/modules:hookable_linear` -> `fbgemm_gpu/.../triton_gemm:fp4_quantize` -> `quantize_utils` -> `mtia/kernels/triton:mx4`.

This gates the dep behind `ovr_config//gpu:mtia`. Because `quantize_utils.py` imported the mx4 kernels under an `if not open_source:` guard (true on all internal builds, not just MTIA), the import is now additionally wrapped in `try/except ImportError` so non-MTIA internal builds tolerate the absent dep. The imported `mtia_quantize_mx4` / `mtia_dequantize_mx4` symbols are only ever called under `tensor.is_mtia` runtime checks (in `fp32_to_mx4` and `mx4_to_fp32`), which never fire on non-MTIA, so dropping the dep off-MTIA is behavior-preserving. The `# pyre-ignore[21]` mirrors the existing pattern used for the `open_source` import in the same file.

This stacks on the ads_mkl gating diff; together they bring `run_lite` to zero MTIA targets.

Differential Revision: D109734335


