### PR TITLE
Add DRAM_SSD support to KVTensorWrapper (#5957)

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
@@ -11,6 +11,10 @@
 #include "kv_tensor_wrapper.h"
 #include "ssd_table_batched_embeddings.h"
 
+namespace kv_mem {
+class DramSsdKVEmbeddingCacheWrapper;
+} // namespace kv_mem
+
 namespace ssd {
 
 class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
@@ -266,6 +270,7 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
 
  private:
   friend class KVTensorWrapper;
+  friend class kv_mem::DramSsdKVEmbeddingCacheWrapper;
 
   // shared pointer since we use shared_from_this() in callbacks.
   std::shared_ptr<ssd::EmbeddingRocksDB> impl_;

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
@@ -14,7 +14,8 @@
 
 namespace kv_mem {
 class DramKVEmbeddingCacheWrapper;
-}
+class DramSsdKVEmbeddingCacheWrapper;
+} // namespace kv_mem
 
 namespace kv_db {
 class EmbeddingKVDB;
@@ -90,6 +91,14 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
   void set_dram_db_wrapper(
       c10::intrusive_ptr<kv_mem::DramKVEmbeddingCacheWrapper> db);
 
+  /// @brief if the backend storage is DramSsdKV (composite DRAM+SSD), use this
+  /// function to set db_ inside KVTensorWrapper
+  /// this function should be called right after KVTensorWrapper
+  /// initialization
+  /// @param db: the DB wrapper
+  void set_dram_ssd_db_wrapper(
+      c10::intrusive_ptr<kv_mem::DramSsdKVEmbeddingCacheWrapper> db);
+
   void set_range(
       int64_t dim,
       const int64_t start,
@@ -127,8 +136,19 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
   friend void to_json(json& j, const KVTensorWrapper& kvt);
   friend void from_json(const json& j, KVTensorWrapper& kvt);
 
+  // Test-only: allow setting db_ directly for unit tests
+  friend void setKVTensorWrapperDb(
+      const c10::intrusive_ptr<KVTensorWrapper>& kvt,
+      std::shared_ptr<kv_db::EmbeddingKVDB> db);
+
  private:
   std::shared_ptr<kv_db::EmbeddingKVDB> db_;
+  // For DRAM_SSD backend: stores the underlying EmbeddingRocksDB separately
+  // because db_ holds the composite DramSsdKVEmbeddingCache (inherits
+  // EmbeddingKVDB, not EmbeddingRocksDB). to_json() and
+  // delete_rocksdb_checkpoint_dir() need EmbeddingRocksDB for serialization
+  // and checkpoint cleanup.
+  std::shared_ptr<EmbeddingRocksDB> rocksdb_for_serialization_;
   c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper> snapshot_handle_;
   at::TensorOptions options_;
   std::vector<int64_t> shape_;

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
@@ -55,6 +55,11 @@ void KVTensorWrapper::set_dram_db_wrapper(
   FBEXCEPTION("Not implemented");
 }
 
+void KVTensorWrapper::set_dram_ssd_db_wrapper(
+    c10::intrusive_ptr<kv_mem::DramSsdKVEmbeddingCacheWrapper> db) {
+  FBEXCEPTION("Not implemented");
+}
+
 at::Tensor KVTensorWrapper::narrow(
     int64_t dim [[maybe_unused]],
     int64_t start [[maybe_unused]],

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -423,6 +423,9 @@ void KVTensorWrapper::delete_rocksdb_checkpoint_dir() const {
     if (db != nullptr) {
       LOG(INFO) << "embedding delete";
       db->delete_rocksdb_checkpoint_dir();
+    } else if (rocksdb_for_serialization_ != nullptr) {
+      LOG(INFO) << "DRAM_SSD embedding delete via rocksdb_for_serialization_";
+      rocksdb_for_serialization_->delete_rocksdb_checkpoint_dir();
     } else {
       LOG(INFO) << "Skipping delete_rocksdb_checkpoint_dir: "
                 << "db_ is not EmbeddingRocksDB (likely DRAM backend)";
@@ -541,6 +544,15 @@ void KVTensorWrapper::set_embedding_rocks_dp_wrapper(
 void KVTensorWrapper::set_dram_db_wrapper(
     c10::intrusive_ptr<kv_mem::DramKVEmbeddingCacheWrapper> db) {
   db_ = db->impl_;
+}
+
+void KVTensorWrapper::set_dram_ssd_db_wrapper(
+    c10::intrusive_ptr<kv_mem::DramSsdKVEmbeddingCacheWrapper> db) {
+  db_ = db->impl_;
+  rocksdb_for_serialization_ = db->rocksdb_impl_;
+  LOG(INFO) << "[DRAM_SSD] set_dram_ssd_db_wrapper: db_=" << db_.get()
+            << ", rocksdb_for_serialization_="
+            << rocksdb_for_serialization_.get();
 }
 void KVTensorWrapper::logss() {
   if (snapshot_handle_) {
@@ -1499,6 +1511,11 @@ static auto kv_tensor_wrapper =
         .def(
             "set_dram_db_wrapper",
             &KVTensorWrapper::set_dram_db_wrapper,
+            "",
+            {torch::arg("db")})
+        .def(
+            "set_dram_ssd_db_wrapper",
+            &KVTensorWrapper::set_dram_ssd_db_wrapper,
             "",
             {torch::arg("db")})
         .def(


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2869

Add set_dram_ssd_db_wrapper() to KVTensorWrapper for the composite DRAM+SSD backend. Store the underlying EmbeddingRocksDB separately for serialization and checkpoint cleanup. Update narrow() to handle non-snapshot reads via get_kv_db_async for DRAM-backed paths. Add friend declarations for DramSsdKVEmbeddingCacheWrapper and test helpers.

Reviewed By: EddyLXJ

Differential Revision: D109749276


