### PR TITLE
Add DRAM_SSD backend to training.py (#5958)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -379,9 +379,10 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             if self.enable_optimizer_offloading:
                 logging.info("Optimizer state offloading is enabled")
             if self.backend_return_whole_row:
-                assert (
-                    self.backend_type == BackendType.DRAM
-                ), f"Only DRAM backend supports backend_return_whole_row, but got {self.backend_type}"
+                assert self.backend_type in (
+                    BackendType.DRAM,
+                    BackendType.DRAM_SSD,
+                ), f"Only DRAM and DRAM_SSD backends support backend_return_whole_row, but got {self.backend_type}"
                 logging.info(
                     "Backend will return whole row including metaheader, weight and optimizer for checkpoint"
                 )
@@ -1017,6 +1018,152 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 self.res_params.table_sizes,
                 enrichment_config,  # enrichment_config
             )
+        elif self.backend_type == BackendType.DRAM_SSD:
+            logging.info(
+                f"Logging DRAM_SSD offloading setup, tbe_unique_id:{tbe_unique_id}, "
+                f"num_shards={ssd_rocksdb_shards},num_threads={ssd_rocksdb_shards},"
+                f"max_D={self.max_D},"
+                f"uniform_init_lower={ssd_uniform_init_lower},uniform_init_upper={ssd_uniform_init_upper},"
+                f"row_storage_bitwidth={weights_precision.bit_rate()},"
+                f"self.cache_row_dim={self.cache_row_dim},"
+                f"enable_optimizer_offloading={self.enable_optimizer_offloading},"
+                f"feature_dims={self.feature_dims},"
+                f"hash_size_cumsum={self.hash_size_cumsum},"
+                f"backend_return_whole_row={self.backend_return_whole_row},"
+                f"ssd_directory={ssd_directory}"
+            )
+
+            assert (
+                self.backend_return_whole_row
+            ), "DRAM_SSD only supports backend_return_whole_row=True"
+
+            table_dims = (
+                tensor_pad4(self.table_dims)
+                if self.enable_optimizer_offloading
+                else None
+            )  # table_dims
+            eviction_config = None
+            if self.kv_zch_params and self.kv_zch_params.eviction_policy:
+                eviction_mem_threshold_gb = (
+                    self.kv_zch_params.eviction_policy.eviction_mem_threshold_gb
+                    if self.kv_zch_params.eviction_policy.eviction_mem_threshold_gb
+                    else self.l2_cache_size
+                )
+                kv_zch_params = self.kv_zch_params
+                eviction_policy = self.kv_zch_params.eviction_policy
+                if eviction_policy.eviction_trigger_mode == 5:
+                    self.set_free_mem_eviction_trigger_config(eviction_policy)
+
+                enable_eviction_for_feature_score_eviction_policy = (
+                    [
+                        int(x)
+                        for x in eviction_policy.enable_eviction_for_feature_score_eviction_policy
+                    ]
+                    if eviction_policy.enable_eviction_for_feature_score_eviction_policy
+                    is not None
+                    else None
+                )
+                eviction_config = torch.classes.fbgemm.FeatureEvictConfig(
+                    eviction_policy.eviction_trigger_mode,
+                    eviction_policy.eviction_strategy,
+                    eviction_policy.eviction_step_intervals,
+                    eviction_mem_threshold_gb,
+                    eviction_policy.ttls_in_mins,
+                    eviction_policy.counter_thresholds,
+                    eviction_policy.counter_decay_rates,
+                    eviction_policy.feature_score_counter_decay_rates,
+                    eviction_policy.training_id_eviction_trigger_count,
+                    eviction_policy.training_id_keep_count,
+                    enable_eviction_for_feature_score_eviction_policy,
+                    eviction_policy.l2_weight_thresholds,
+                    table_dims.tolist() if table_dims is not None else None,
+                    eviction_policy.threshold_calculation_bucket_stride,
+                    eviction_policy.threshold_calculation_bucket_num,
+                    eviction_policy.interval_for_insufficient_eviction_s,
+                    eviction_policy.interval_for_sufficient_eviction_s,
+                    eviction_policy.interval_for_feature_statistics_decay_s,
+                    eviction_policy.enable_ssd_writeback,
+                )
+            enrichment_config = None
+            if (
+                self.kv_zch_params
+                and self.kv_zch_params.enrichment_policy is not None
+                and self._embedding_cache_mode
+            ):
+                ep = self.kv_zch_params.enrichment_policy
+                if ep.enrichment_type is None:
+                    raise ValueError(
+                        "enrichment_policy is set but enrichment_type is None. "
+                        "Please specify a valid EnrichmentType."
+                    )
+                enrichment_config = torch.classes.fbgemm.EnrichmentConfig(
+                    ep.enrichment_type.value,
+                    ep.provider_name,
+                    ep.client_id,
+                    ep.enrichment_dim,
+                    ep.response_format.value,
+                    ep.opentab_tier_name,
+                    ep.opentab_payload_ids,
+                    ep.opentab_payload_types,
+                    ep.opentab_column_group_ids,
+                    ep.opentab_vec_payload_indexes,
+                    ep.opentab_timeout_ms,
+                    ep.opentab_batch_size,
+                    ep.fs_tier,
+                    ep.fs_caller_id,
+                    ep.fs_timeout_ms,
+                    ep.fs_batch_size,
+                    ep.fs_feature_group_id,
+                    ep.fs_feature_group_name,
+                    ep.fs_feature_name,
+                    ep.laser_batch_size,
+                )
+            # Create the composite DRAM+SSD wrapper. The wrapper is the sole
+            # initializer of the DRAM+SSD backend: it builds the RocksDB (L3)
+            # tier internally (including the MetaHeader-adjusted max_D /
+            # table_dims) and assembles the composite, so rocksdb_impl_ is
+            # always set for checkpoint/snapshot paths.
+            self._ssd_db = torch.classes.fbgemm.DramSsdKVEmbeddingCacheWrapper(
+                max_D=self.cache_row_dim,
+                uniform_init_lower=ssd_uniform_init_lower,
+                uniform_init_upper=ssd_uniform_init_upper,
+                feature_evict_config=eviction_config,
+                num_shards=ssd_rocksdb_shards,
+                num_threads=ssd_rocksdb_shards,
+                row_storage_bitwidth=weights_precision.bit_rate(),
+                table_dims=table_dims,
+                hash_size_cumsum=(
+                    self.table_hash_size_cumsum.cpu()
+                    if self.enable_optimizer_offloading
+                    else None
+                ),
+                backend_return_whole_row=self.backend_return_whole_row,
+                enable_async_update=False,  # DRAM L2 cache
+                disable_random_init=self._embedding_cache_mode,
+                enable_raw_embedding_streaming=self.enable_raw_embedding_streaming,
+                res_store_shards=self.res_params.res_store_shards,
+                res_server_port=self.res_params.res_server_port,
+                table_names=self.res_params.table_names,
+                table_offsets=self.res_params.table_offsets,
+                table_sizes=self.res_params.table_sizes,
+                enrichment_config=enrichment_config,
+                # SSD (RocksDB L3 tier) construction params
+                ssd_path=ssd_directory,
+                memtable_flush_period=ssd_memtable_flush_period,
+                memtable_flush_offset=ssd_memtable_flush_offset,
+                l0_files_per_compact=ssd_l0_files_per_compact,
+                rate_limit_mbps=ssd_rate_limit_mbps,
+                size_ratio=ssd_size_ratio,
+                compaction_ratio=ssd_compaction_trigger,
+                write_buffer_size=ssd_rocksdb_write_buffer_size,
+                max_write_buffer_num=ssd_max_write_buffer_num,
+                block_cache_size=ssd_block_cache_size_per_tbe,
+                use_passed_in_path=use_passed_in_path,
+                tbe_unique_id=tbe_unique_id,
+                l2_cache_size_gb=l2_cache_size,
+                ssd_enable_async_update=enable_async_update,
+                flushing_block_size=flushing_block_size,
+            )
         else:
             raise AssertionError(f"Invalid backend type {self.backend_type}")
 
@@ -1332,6 +1479,25 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             f"eviction.tbe_id.{tbe_unique_id}.evict_rate"
         )
 
+        self.dram_ssd_kv_ssd_num_lookups_stats_name: str = (
+            f"dram_ssd_kv.perf.tbe_id{tbe_unique_id}.ssd_num_lookups"
+        )
+        self.dram_ssd_kv_ssd_num_hits_stats_name: str = (
+            f"dram_ssd_kv.perf.tbe_id{tbe_unique_id}.ssd_num_hits"
+        )
+        self.dram_ssd_kv_ssd_num_writes_stats_name: str = (
+            f"dram_ssd_kv.perf.tbe_id{tbe_unique_id}.ssd_num_writes"
+        )
+        self.dram_ssd_kv_ssd_num_ids_stats_name: str = (
+            f"dram_ssd_kv.perf.tbe_id{tbe_unique_id}.ssd_num_ids"
+        )
+        self.dram_ssd_kv_ssd_total_rows_written_stats_name: str = (
+            f"dram_ssd_kv.perf.tbe_id{tbe_unique_id}.ssd_total_rows_written"
+        )
+        self.dram_ssd_kv_ssd_hit_rate_stats_name: str = (
+            f"dram_ssd_kv.perf.tbe_id{tbe_unique_id}.ssd_hit_rate"
+        )
+
         if self.stats_reporter:
             self.ssd_prefetch_read_timer = AsyncSeriesTimer(
                 functools.partial(
@@ -1375,6 +1541,18 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             self.stats_reporter.register_stats(self.enrichment_success_rate_stats_name)
             self.stats_reporter.register_stats(self.l1_hit_rate_stats_name)
             self.stats_reporter.register_stats(self.overall_hit_rate_stats_name)
+            self.stats_reporter.register_stats(
+                self.dram_ssd_kv_ssd_num_lookups_stats_name
+            )
+            self.stats_reporter.register_stats(self.dram_ssd_kv_ssd_num_hits_stats_name)
+            self.stats_reporter.register_stats(
+                self.dram_ssd_kv_ssd_num_writes_stats_name
+            )
+            self.stats_reporter.register_stats(self.dram_ssd_kv_ssd_num_ids_stats_name)
+            self.stats_reporter.register_stats(
+                self.dram_ssd_kv_ssd_total_rows_written_stats_name
+            )
+            self.stats_reporter.register_stats(self.dram_ssd_kv_ssd_hit_rate_stats_name)
             for t in self.feature_table_map:
                 self.stats_reporter.register_stats(
                     f"eviction.feature_table.{t}.evicted_counts"
@@ -2510,7 +2688,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                         is_bwd=False,
                     )
                 if (
-                    self.backend_type == BackendType.DRAM
+                    self.backend_type in (BackendType.DRAM, BackendType.DRAM_SSD)
                     and weights is not None
                     and linear_cache_indices.numel() > 0
                 ):
@@ -3083,11 +3261,12 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 sorted_indices=sorted_ids[t],
                 width_offset=pad4(d),
             )
-            (
+            if self.backend_type == BackendType.SSD:
                 tensor_wrapper.set_embedding_rocks_dp_wrapper(self.ssd_db)
-                if self.backend_type == BackendType.SSD
-                else tensor_wrapper.set_dram_db_wrapper(self.ssd_db)
-            )
+            elif self.backend_type == BackendType.DRAM_SSD:
+                tensor_wrapper.set_dram_ssd_db_wrapper(self.ssd_db)
+            else:
+                tensor_wrapper.set_dram_db_wrapper(self.ssd_db)
 
             # Fetch the state size table for the given weights domension
             state_size_table = self.optimizer.state_size_table(d)
@@ -3286,11 +3465,12 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     # Optimizer written to DB with weights, so skip write here
                     read_only=True,
                 )
-                (
+                if self.backend_type == BackendType.SSD:
                     tensor_wrapper.set_embedding_rocks_dp_wrapper(self.ssd_db)
-                    if self.backend_type == BackendType.SSD
-                    else tensor_wrapper.set_dram_db_wrapper(self.ssd_db)
-                )
+                elif self.backend_type == BackendType.DRAM_SSD:
+                    tensor_wrapper.set_dram_ssd_db_wrapper(self.ssd_db)
+                else:
+                    tensor_wrapper.set_dram_db_wrapper(self.ssd_db)
 
                 optimizer_states.append(
                     PartiallyMaterializedTensor(tensor_wrapper, True)
@@ -3473,6 +3653,66 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 f"state_dict wait for ongoing eviction: {time.time() - evict_wait_start_time} s"
             )
             self.flush(force=should_flush)
+        elif self.backend_type == BackendType.DRAM_SSD:
+            # Flush is unconditional: checkpoint reads come from SSD only, so an
+            # unflushed SSD would produce 0-byte weights.
+            evict_wait_start_time = time.time()
+            self.ssd_db.wait_until_eviction_done()
+            evict_wait_ms = (time.time() - evict_wait_start_time) * 1000
+
+            # Flush L1 GPU cache (may return early when enrichment is enabled).
+            l1_flush_start = time.time()
+            self.flush(force=should_flush)
+            l1_flush_ms = (time.time() - l1_flush_start) * 1000
+
+            # Explicitly flush L2 DRAM -> SSD, since self.flush() skips it when
+            # enrichment is enabled. Double-flush is a safe no-op.
+            l2_flush_start = time.time()
+            self.ssd_db.flush()
+            l2_flush_ms = (time.time() - l2_flush_start) * 1000
+
+            logging.info(
+                f"DRAM_SSD flush total latency for weight states: "
+                f"{(time.time() - start_time) * 1000:.1f} ms "
+                f"(evict_wait={evict_wait_ms:.1f}ms, "
+                f"l1_flush={l1_flush_ms:.1f}ms, "
+                f"l2_flush={l2_flush_ms:.1f}ms)"
+            )
+            if not no_snapshot:
+                with record_function(
+                    f"## DRAM_SSD_create_snapshot_{self.step}_{self.tbe_unique_id} ##"
+                ):
+                    # Release previous snapshot; stale ones pin SST files.
+                    prev_snapshot = getattr(self, "_prev_dram_ssd_snapshot", None)
+                    if prev_snapshot is not None:
+                        logging.info(
+                            "DRAM_SSD: releasing previous snapshot reference "
+                            f"(snapshot_count={self.ssd_db.get_snapshot_count()})"
+                        )
+                        self._prev_dram_ssd_snapshot = None  # type: ignore[assignment]
+                        del prev_snapshot
+                        logging.info(
+                            "DRAM_SSD: after release, "
+                            f"snapshot_count={self.ssd_db.get_snapshot_count()}"
+                        )
+
+                    # Create RocksDB snapshot for consistent checkpoint reads
+                    snapshot_handle = self.ssd_db.create_snapshot()
+                    # Store reference so we can release it next checkpoint
+                    self._prev_dram_ssd_snapshot = snapshot_handle
+                    # TODO: enable checkpoint_handle for DRAM_SSD via
+                    # self.ssd_db.get_active_checkpoint_uuid(self.step).
+                    # Also, KVTensorWrapper's to_json()/serialize(), logs() and
+                    # get_kvtensor_serializable_metadata() must support DRAM_SSD
+                    # (fall back to rocksdb_for_serialization_ since db_ is a
+                    # DramSsdKVEmbeddingCache, not EmbeddingRocksDB).
+                    checkpoint_handle = None
+                    logging.info(
+                        f"DRAM_SSD created snapshot: {snapshot_handle}, "
+                        f"checkpoint_handle: {checkpoint_handle}, "
+                        f"snapshot_count={self.ssd_db.get_snapshot_count()}, "
+                        f"latency: {(time.time() - start_time) * 1000} ms"
+                    )
         return snapshot_handle, checkpoint_handle
 
     def get_embedding_dim_for_kvt(
@@ -3674,11 +3914,12 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     else False
                 ),
             )
-            (
+            if self.backend_type == BackendType.SSD:
                 tensor_wrapper.set_embedding_rocks_dp_wrapper(self.ssd_db)
-                if self.backend_type == BackendType.SSD
-                else tensor_wrapper.set_dram_db_wrapper(self.ssd_db)
-            )
+            elif self.backend_type == BackendType.DRAM_SSD:
+                tensor_wrapper.set_dram_ssd_db_wrapper(self.ssd_db)
+            else:
+                tensor_wrapper.set_dram_db_wrapper(self.ssd_db)
 
             # When rocksdb snapshot and checkpoint handle are available, serialize and
             # deserialize the KVTensor to create a ReadOnlyEmbeddingKVDB-backed
@@ -3873,11 +4114,12 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             snapshot_handle=None,
             sorted_indices=id_tensor,
         )
-        (
+        if self.backend_type == BackendType.SSD:
             kvt.set_embedding_rocks_dp_wrapper(self.ssd_db)
-            if self.backend_type == BackendType.SSD
-            else kvt.set_dram_db_wrapper(self.ssd_db)
-        )
+        elif self.backend_type == BackendType.DRAM_SSD:
+            kvt.set_dram_ssd_db_wrapper(self.ssd_db)
+        else:
+            kvt.set_dram_db_wrapper(self.ssd_db)
 
         # TODO: make chunk_size configurable or dynamic
         chunk_size = 10000
@@ -4081,11 +4323,11 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         """
         Create a rocksdb hard link snapshot to provide cross procs access to the underlying data
         """
-        if self.backend_type == BackendType.SSD:
+        if self.backend_type in (BackendType.SSD, BackendType.DRAM_SSD):
             self.ssd_db.create_rocksdb_hard_link_snapshot(self.step)
         else:
             logging.warning(
-                "create_rocksdb_hard_link_snapshot is only supported for SSD backend"
+                "create_rocksdb_hard_link_snapshot is only supported for SSD and DRAM_SSD backends"
             )
 
     def prepare_inputs(
@@ -4143,7 +4385,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             self._report_ssd_io_stats()
             self._report_ssd_mem_usage()
             self._report_l2_cache_perf_stats()
-        if self.backend_type == BackendType.DRAM:
+        if self.backend_type in (BackendType.DRAM, BackendType.DRAM_SSD):
             self._report_dram_kv_perf_stats()
             if self.kv_zch_params and self.kv_zch_params.eviction_policy:
                 self._report_eviction_stats()

--- a/fbgemm_gpu/test/tbe/ssd/kv_backend_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/kv_backend_test.py
@@ -69,6 +69,7 @@ class SSDCheckpointTest(unittest.TestCase):
         eviction_policy: EvictionPolicy | None = None,
         disable_random_init: bool = False,
         enable_blob_db: bool = False,
+        backend_return_whole_row: bool = False,
     ) -> object:
         if backend_type == BackendType.SSD:
             assert ssd_directory
@@ -140,7 +141,72 @@ class SSDCheckpointTest(unittest.TestCase):
                 weight_precision.bit_rate(),  # row_storage_bitwidth
                 table_dims=feature_dims,
                 hash_size_cumsum=hash_size_cumsum,
+                backend_return_whole_row=backend_return_whole_row,
                 disable_random_init=disable_random_init,
+            )
+        elif backend_type == BackendType.DRAM_SSD:
+            eviction_config = None
+            if eviction_policy:
+                enable_eviction_for_feature_score_eviction_policy = (
+                    [
+                        int(x)
+                        for x in eviction_policy.enable_eviction_for_feature_score_eviction_policy
+                    ]
+                    if eviction_policy.enable_eviction_for_feature_score_eviction_policy
+                    is not None
+                    else None
+                )
+                eviction_config = torch.classes.fbgemm.FeatureEvictConfig(
+                    eviction_policy.eviction_trigger_mode,
+                    eviction_policy.eviction_strategy,
+                    eviction_policy.eviction_step_intervals,
+                    None,  # mem_util_threshold_in_GB
+                    eviction_policy.ttls_in_mins,
+                    eviction_policy.counter_thresholds,
+                    eviction_policy.counter_decay_rates,
+                    eviction_policy.feature_score_counter_decay_rates,
+                    eviction_policy.training_id_eviction_trigger_count,
+                    eviction_policy.training_id_keep_count,
+                    enable_eviction_for_feature_score_eviction_policy,
+                    eviction_policy.l2_weight_thresholds,
+                    feature_dims.tolist() if feature_dims is not None else None,
+                    eviction_policy.threshold_calculation_bucket_stride,
+                    eviction_policy.threshold_calculation_bucket_num,
+                    eviction_policy.interval_for_insufficient_eviction_s,
+                    eviction_policy.interval_for_sufficient_eviction_s,
+                    eviction_policy.interval_for_feature_statistics_decay_s,
+                )
+            # Create the composite DRAM+SSD wrapper. Mirror the production setup
+            # in training.py: the wrapper builds its own internal RocksDB (L3 SSD
+            # tier) from the ssd_path + RocksDB construction params. There is no
+            # separate backend to wire in.
+            assert ssd_directory
+            return torch.classes.fbgemm.DramSsdKVEmbeddingCacheWrapper(
+                max_D,
+                -0.01,  # uniform_init_lower
+                0.01,  # uniform_init_upper
+                eviction_config,
+                8,  # num_shards
+                8,  # num_threads
+                weight_precision.bit_rate(),  # row_storage_bitwidth
+                table_dims=feature_dims,
+                hash_size_cumsum=hash_size_cumsum,
+                backend_return_whole_row=backend_return_whole_row,
+                disable_random_init=disable_random_init,
+                # SSD (RocksDB L3 tier) construction params
+                ssd_path=ssd_directory,
+                memtable_flush_period=0,
+                memtable_flush_offset=0,
+                l0_files_per_compact=4,
+                rate_limit_mbps=0,
+                size_ratio=1,
+                compaction_ratio=8,
+                write_buffer_size=536870912,  # 512MB
+                max_write_buffer_num=8,
+                block_cache_size=0,
+                use_passed_in_path=True,
+                l2_cache_size_gb=0,
+                flushing_block_size=flushing_block_size,
             )
 
     def generate_fbgemm_kv_tbe(
@@ -1260,7 +1326,10 @@ class SSDCheckpointTest(unittest.TestCase):
             row_offset += E
 
     @given(
-        **default_st, backend_type=st.sampled_from([BackendType.SSD, BackendType.DRAM])
+        **default_st,
+        backend_type=st.sampled_from(
+            [BackendType.SSD, BackendType.DRAM, BackendType.DRAM_SSD]
+        ),
     )
     @settings(**default_settings)
     def test_disable_random_init_functionality(
@@ -1287,9 +1356,15 @@ class SSDCheckpointTest(unittest.TestCase):
                 enable_l2=False,
                 backend_type=backend_type,
                 ssd_directory=(
-                    ssd_directory if backend_type == BackendType.SSD else None
+                    ssd_directory
+                    if (
+                        backend_type == BackendType.SSD
+                        or backend_type == BackendType.DRAM_SSD
+                    )
+                    else None
                 ),
                 disable_random_init=True,  # This is the key parameter we're testing
+                backend_return_whole_row=True,
             )
 
             # Generate some random indices that don't exist in the backend
@@ -1316,7 +1391,10 @@ class SSDCheckpointTest(unittest.TestCase):
             )
 
     @given(
-        **default_st, backend_type=st.sampled_from([BackendType.SSD, BackendType.DRAM])
+        **default_st,
+        backend_type=st.sampled_from(
+            [BackendType.SSD, BackendType.DRAM, BackendType.DRAM_SSD]
+        ),
     )
     @settings(**default_settings)
     def test_disable_random_init_vs_enable_random_init(
@@ -1343,9 +1421,15 @@ class SSDCheckpointTest(unittest.TestCase):
                 enable_l2=False,
                 backend_type=backend_type,
                 ssd_directory=(
-                    ssd_directory1 if backend_type == BackendType.SSD else None
+                    ssd_directory1
+                    if (
+                        backend_type == BackendType.SSD
+                        or backend_type == BackendType.DRAM_SSD
+                    )
+                    else None
                 ),
                 disable_random_init=False,  # Default behavior (random init enabled)
+                backend_return_whole_row=True,
             )
 
             # Create backend with disable_random_init=True using the helper method
@@ -1355,9 +1439,15 @@ class SSDCheckpointTest(unittest.TestCase):
                 enable_l2=False,
                 backend_type=backend_type,
                 ssd_directory=(
-                    ssd_directory2 if backend_type == BackendType.SSD else None
+                    ssd_directory2
+                    if (
+                        backend_type == BackendType.SSD
+                        or backend_type == BackendType.DRAM_SSD
+                    )
+                    else None
                 ),
                 disable_random_init=True,  # Disable random init
+                backend_return_whole_row=True,
             )
 
             # Generate some random indices that don't exist in either backend
@@ -1448,3 +1538,223 @@ class SSDCheckpointTest(unittest.TestCase):
                 atol=1e-8,
                 rtol=1e-8,
             )
+
+    def test_dram_ssd_backend_construction(self) -> None:
+        """Test that BackendType.DRAM_SSD can construct a composite backend."""
+        max_D = 132
+        E = 20
+        weight_precision = SparseType.FP32
+        T = 4
+        feature_dims = torch.tensor([64, 32, 128, 64], dtype=torch.int64)
+        hash_size_cumsum = torch.tensor(
+            [0, E // T, 2 * E // T, 3 * E // T, E + 10], dtype=torch.int64
+        )
+        with tempfile.TemporaryDirectory() as ssd_directory:
+            dram_ssd_backend = self.generate_fbgemm_kv_backend(
+                max_D=max_D,
+                weight_precision=weight_precision,
+                enable_l2=False,
+                feature_dims=feature_dims,
+                hash_size_cumsum=hash_size_cumsum,
+                backend_type=BackendType.DRAM_SSD,
+                flushing_block_size=1000,
+                ssd_directory=ssd_directory,
+                backend_return_whole_row=True,
+            )
+            self.assertIsNotNone(dram_ssd_backend)
+
+            # Write data and read it back
+            indices = torch.arange(E, dtype=torch.int64)
+            weights = torch.randn(E, max_D, dtype=weight_precision.as_dtype())
+            weights_out = torch.empty_like(weights)
+            count = torch.as_tensor([E])
+
+            dram_ssd_backend.set(indices, weights, count)  # pyre-ignore
+            dram_ssd_backend.get(indices.clone(), weights_out, count)  # pyre-ignore
+
+            torch.testing.assert_close(weights, weights_out, atol=1e-8, rtol=1e-8)
+
+    def test_dram_ssd_flush_and_read(self) -> None:
+        """Test that flush writes dirty DRAM blocks to SSD and data is recoverable."""
+        max_D = 132
+        E = 20
+        weight_precision = SparseType.FP32
+        T = 4
+        feature_dims = torch.tensor([64, 32, 128, 64], dtype=torch.int64)
+        hash_size_cumsum = torch.tensor(
+            [0, E // T, 2 * E // T, 3 * E // T, E + 10], dtype=torch.int64
+        )
+        with tempfile.TemporaryDirectory() as ssd_directory:
+            dram_ssd_backend = self.generate_fbgemm_kv_backend(
+                max_D=max_D,
+                weight_precision=weight_precision,
+                enable_l2=False,
+                feature_dims=feature_dims,
+                hash_size_cumsum=hash_size_cumsum,
+                backend_type=BackendType.DRAM_SSD,
+                flushing_block_size=1000,
+                ssd_directory=ssd_directory,
+                backend_return_whole_row=True,
+            )
+
+            # Write data
+            indices = torch.arange(E, dtype=torch.int64)
+            weights = torch.randn(E, max_D, dtype=weight_precision.as_dtype())
+            count = torch.as_tensor([E])
+            dram_ssd_backend.set(indices, weights, count)  # pyre-ignore
+
+            # Flush dirty DRAM blocks to SSD
+            dram_ssd_backend.flush()  # pyre-ignore
+
+            # Read back after flush
+            weights_out = torch.empty_like(weights)
+            dram_ssd_backend.get(indices.clone(), weights_out, count)  # pyre-ignore
+            torch.testing.assert_close(weights, weights_out, atol=1e-8, rtol=1e-8)
+
+    def test_dram_ssd_get_keys_in_range(self) -> None:
+        """Test get_keys_in_range_by_snapshot for DRAM_SSD backend."""
+        max_D = 132
+        E = 20
+        weight_precision = SparseType.FP32
+        T = 4
+        feature_dims = torch.tensor([64, 32, 128, 64], dtype=torch.int64)
+        hash_size_cumsum = torch.tensor(
+            [0, E // T, 2 * E // T, 3 * E // T, E + 10], dtype=torch.int64
+        )
+        with tempfile.TemporaryDirectory() as ssd_directory:
+            dram_ssd_backend = self.generate_fbgemm_kv_backend(
+                max_D=max_D,
+                weight_precision=weight_precision,
+                enable_l2=False,
+                feature_dims=feature_dims,
+                hash_size_cumsum=hash_size_cumsum,
+                backend_type=BackendType.DRAM_SSD,
+                flushing_block_size=1000,
+                ssd_directory=ssd_directory,
+                backend_return_whole_row=True,
+            )
+
+            # Build whole rows with the key embedded in the MetaHeader. The
+            # MetaHeader occupies the first 16 bytes of each row: int64 key
+            # (bytes 0-7), then timestamp/count/used. For FP32 that is the first
+            # 4 floats; the key is the first 2 floats bit-cast from int64.
+            keys = torch.arange(E, dtype=torch.int64)
+            rows = torch.randn(E, max_D, dtype=weight_precision.as_dtype())
+            rows[:, :2] = keys.view(torch.int64).view(E, 1).view(torch.float32)
+            # Mark each block used (used = highest bit of the uint32 at byte 12).
+            rows[:, 3] = (
+                torch.full((E,), 0x80000000, dtype=torch.int64)
+                .to(torch.int32)
+                .view(torch.float32)
+            )
+
+            # Write whole rows directly to the SSD tier.
+            dram_ssd_backend.set_range_to_storage(rows, 0, E)  # pyre-ignore
+
+            keys_out = dram_ssd_backend.get_keys_in_range_by_snapshot(  # pyre-ignore
+                0, E, 0, None
+            )
+            self.assertEqual(keys_out.numel(), E)
+            self.assertEqual(sorted(keys_out.flatten().tolist()), list(range(E)))
+
+    def test_dram_ssd_tbe_construction(self) -> None:
+        """Test that SSDTableBatchedEmbeddingBags can be constructed with BackendType.DRAM_SSD."""
+        T = 2
+        D = 16
+        E = 100
+        bucket_size = 50
+        kv_zch_params = KVZCHParams(
+            bucket_offsets=[(0, E // bucket_size)] * T,
+            bucket_sizes=[bucket_size] * T,
+            enable_optimizer_offloading=True,
+            backend_return_whole_row=True,
+            eviction_policy=EvictionPolicy(
+                eviction_trigger_mode=0,
+                meta_header_lens=[16 // (SparseType.FP32.bit_rate() // 8)] * T,
+            ),
+        )
+        with tempfile.TemporaryDirectory() as ssd_directory:
+            emb = SSDTableBatchedEmbeddingBags(
+                embedding_specs=[(E, D)] * T,
+                feature_table_map=list(range(T)),
+                ssd_storage_directory=ssd_directory,
+                cache_sets=1,
+                ssd_uniform_init_lower=-0.1,
+                ssd_uniform_init_upper=0.1,
+                weights_precision=SparseType.FP32,
+                kv_zch_params=kv_zch_params,
+                backend_type=BackendType.DRAM_SSD,
+                use_passed_in_path=True,
+            )
+            self.assertIsNotNone(emb.ssd_db)
+
+    def _build_dram_ssd_tbe(
+        self,
+        ssd_directory: str,
+        T: int = 2,
+        D: int = 16,
+        E: int = 100,
+        bucket_size: int = 50,
+    ) -> SSDTableBatchedEmbeddingBags:
+        kv_zch_params = KVZCHParams(
+            bucket_offsets=[(0, E // bucket_size)] * T,
+            bucket_sizes=[bucket_size] * T,
+            enable_optimizer_offloading=True,
+            backend_return_whole_row=True,
+            eviction_policy=EvictionPolicy(
+                eviction_trigger_mode=0,
+                meta_header_lens=[16 // (SparseType.FP32.bit_rate() // 8)] * T,
+            ),
+        )
+        return SSDTableBatchedEmbeddingBags(
+            embedding_specs=[(E, D)] * T,
+            feature_table_map=list(range(T)),
+            ssd_storage_directory=ssd_directory,
+            cache_sets=1,
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            weights_precision=SparseType.FP32,
+            kv_zch_params=kv_zch_params,
+            backend_type=BackendType.DRAM_SSD,
+            use_passed_in_path=True,
+        )
+
+    def test_dram_ssd_split_embedding_weights_creates_snapshot(self) -> None:
+        """DRAM_SSD: split_embedding_weights(no_snapshot=False) creates a RocksDB
+        snapshot and returns one partially-materialized tensor per table."""
+        T = 2
+        with tempfile.TemporaryDirectory() as ssd_directory:
+            emb: SSDTableBatchedEmbeddingBags = self._build_dram_ssd_tbe(
+                ssd_directory, T=T
+            )
+
+            pmt_splits, _, _, _ = emb.split_embedding_weights(
+                no_snapshot=False, should_flush=True
+            )
+
+            self.assertEqual(len(pmt_splits), T)
+            self.assertEqual(emb.ssd_db.get_snapshot_count(), 1)
+
+    def test_dram_ssd_split_embedding_weights_no_snapshot(self) -> None:
+        """DRAM_SSD: split_embedding_weights(no_snapshot=True) flushes but does
+        not create a snapshot."""
+        with tempfile.TemporaryDirectory() as ssd_directory:
+            emb = self._build_dram_ssd_tbe(ssd_directory)
+
+            emb.split_embedding_weights(no_snapshot=True, should_flush=True)
+
+            self.assertEqual(emb.ssd_db.get_snapshot_count(), 0)
+
+    def test_dram_ssd_snapshot_released_across_calls(self) -> None:
+        """DRAM_SSD: each checkpoint releases the previous snapshot, so the live
+        snapshot count stays at 1 across repeated split_embedding_weights calls."""
+        with tempfile.TemporaryDirectory() as ssd_directory:
+            emb = self._build_dram_ssd_tbe(ssd_directory)
+
+            # Discard the returned tensors so the only live snapshot reference is
+            # the one the module stores internally for release on the next call.
+            emb.split_embedding_weights(no_snapshot=False, should_flush=True)
+            self.assertEqual(emb.ssd_db.get_snapshot_count(), 1)
+
+            emb.split_embedding_weights(no_snapshot=False, should_flush=True)
+            self.assertEqual(emb.ssd_db.get_snapshot_count(), 1)


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2870


Wire the DRAM+SSD composite backend into SSDTableBatchedEmbeddingBags:
- Add DRAM_SSD backend initialization creating both DramSsdKVEmbeddingCacheWrapper and EmbeddingRocksDBWrapper, then wiring them together
- Update checkpoint state_dict to flush dirty DRAM blocks to SSD before snapshot
- Update split_embedding_weights to use DRAM_SSD-aware KVTensorWrapper wiring
- Update _apply_state_dict paths for DRAM_SSD backend type
- Add record_function instrumentation for checkpoint latency debugging
- Extend _report_dram_kv_perf_stats to report SSD-tier metrics (lookups, hits, writes, hit rate) when available

Differential Revision: D109774910


