### PR TITLE
Add visibility("hidden") to KernelLauncher to fix cross-module TLS mismatch

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
@@ -93,7 +93,7 @@ template <
     bool EnableBarrierIsolation = false,
     bool EnableNaNChecks = false,
     bool EnableExecutionTimer = false>
-struct KernelLauncher {
+struct __attribute__((visibility("hidden"))) KernelLauncher {
   const SourceContext context;
 
   constexpr inline KernelLauncher(const SourceContext& ctx) noexcept


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2875

Add `__attribute__((visibility("hidden")))` to the `KernelLauncher` struct in `kernel_launcher.cuh`. This prevents the dynamic linker from exporting `launch_kernel` weak symbols, forcing each `.so` to use its own copy.

**Root cause:** On CUDA 12.8 with sm_90+, the dynamic linker resolves `index_select_ops.so`'s `launch_kernel` to the main binary's copy (from `embedding_ops_training_gpu` via `embedding_ops`). This causes `__cudaPushCallConfiguration` (in the main binary) and `__cudaPopCallConfiguration` (in `index_select_ops.so`) to use different statically-linked CUDA runtime copies with separate TLS stacks. Pop finds an empty stack, returns non-zero, and `find_long_segments` kernel is silently skipped — causing zero gradients for runs >= 32 in `batch_index_select_dim0` backward.

**Why this fix works:** `visibility("hidden")` prevents `launch_kernel` from being exported, so the dynamic linker cannot resolve it cross-module. Each `.so` uses its own copy — push and pop stay in the same TLS. This is structurally guaranteed regardless of the dependency tree or compiler inlining behavior.

**Why not the other fixes:**
- D103575890 (pre-build args at call site): Targeted fix for `find_long_segments` only — other kernels with the same pattern would need similar fixes.
- D103575878 (`launch_kernel_with_transform`): Works empirically but depends on compiler inlining `launch_kernel<..., PackedTensorAccessor32...>` — not structurally guaranteed.

Reviewed By: q10

Differential Revision: D104175840


