### PR TITLE
Drop CUDA 13.2 (cu132) from all Linux wheel build matrices (#5966)

### DIFF
--- a/.github/workflows/build_wheels_genai_linux_aarch64.yml
+++ b/.github/workflows/build_wheels_genai_linux_aarch64.yml
@@ -50,11 +50,13 @@ jobs:
         MAT: ${{ needs.generate-matrix.outputs.matrix }}
       # Nova Coordinate Filters:
       # cuda/13.0-aarch64: Not supported in FBGEMM CI yet
+      # cuda 13.2 (cu132): not supported by FBGEMM yet; validate step fails with
+      #   "Unknown distribution". Drop until 13.2 is supported.
       run: |
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py )"
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_version:13.2' )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/build_wheels_genai_linux_x86.yml
+++ b/.github/workflows/build_wheels_genai_linux_x86.yml
@@ -52,12 +52,14 @@ jobs:
       # Nova Coordinate Filters:
       # cuda/11.8: No longer supported in FBGEMM
       # cuda/12.9: No longer supported in PyTorch
+      # cuda 13.2 (cu132): not supported by FBGEMM yet; validate step fails with
+      #   "Unknown distribution". Drop until 13.2 is supported.
       # rocm/3.13t: causes segfaults at runtime
       run: |
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter gpu_arch_version:11.8 --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' )"
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter gpu_arch_version:11.8 --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2' )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/build_wheels_linux_aarch64.yml
+++ b/.github/workflows/build_wheels_linux_aarch64.yml
@@ -49,11 +49,13 @@ jobs:
         MAT: ${{ needs.generate-matrix.outputs.matrix }}
       # Nova Coordinate Filters:
       # rocm/3.13t: causes segfaults at runtime
+      # cuda 13.2 (cu132): not supported by FBGEMM yet; validate step fails with
+      #   "Unknown distribution". Drop until 13.2 is supported.
       run: |
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' )"
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2' )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/build_wheels_linux_x86.yml
+++ b/.github/workflows/build_wheels_linux_x86.yml
@@ -51,11 +51,13 @@ jobs:
         MAT: ${{ needs.generate-matrix.outputs.matrix }}
       # Nova Coordinate Filters:
       # rocm/3.13t: causes segfaults at runtime
+      # cuda 13.2 (cu132): not supported by FBGEMM yet; test-infra emits it and the
+      #   validate step fails with "Unknown distribution". Drop until 13.2 is supported.
       run: |
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' )"
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2' )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2878


The pytorch/test-infra build matrix (generate_binary_build_matrix.yml@main) now emits
CUDA 13.2 (cu132) coordinates. FBGEMM does not support 13.2 yet, so every cu132 job in
build_wheels_linux_x86 fails in the test-infra validate step with
"ERROR: Unknown distribution ${DISTRIBUTION}".

Filter cu132 out in the filter-matrix step by adding a `gpu_arch_version:13.2` filter
group, until 13.2 is supported. Mirrors the intent of D104335566.

Differential Revision: D110247364


