### PR TITLE
Fix self-corrupting base conda in setup_miniconda (drop --update-deps) (#5967)

### DIFF
--- a/.github/scripts/utils_conda.bash
+++ b/.github/scripts/utils_conda.bash
@@ -85,8 +85,16 @@ setup_miniconda () {
     libmambapy \
     libarchive) || return 1
 
+  # NOTE: Do NOT pass --update-deps here. conda-forge periodically publishes a
+  # base `conda` whose --update-deps solve bumps base Python to a version that
+  # conda itself is not built against. This orphans conda's own package and
+  # breaks every subsequent `conda` invocation (including `conda clean` and the
+  # post-link scripts of later package installs) with:
+  #   ModuleNotFoundError: No module named 'conda'
+  # which takes down setup_miniconda and, downstream, the docs/lint/ci jobs.
+  # Updating conda without --update-deps keeps the base interpreter intact.
   echo "[SETUP] Updating Miniconda base packages ..."
-  (exec_with_retries 3 conda update -n base -c conda-forge --override-channels --update-deps -y conda) || return 1
+  (exec_with_retries 3 conda update -n base -c conda-forge --override-channels -y conda) || return 1
 
   # Clean up packages
   conda_cleanup

--- a/include/fbgemm/QuantUtilsAvx2.h
+++ b/include/fbgemm/QuantUtilsAvx2.h
@@ -80,8 +80,9 @@ void FusedQuantizeDequantizeAvx2(
 
 /// @ingroup fbgemm-quant-utils-avx2
 ///
-/// Random number generator in [0, 9] based on
-/// <a href="https://www.jstatsoft.org/v08/i14/paper">this paper</a>.
+/// Random number generator in [0, 9] based on Marsaglia's Xorshift RNG
+/// (G. Marsaglia, "Xorshift RNGs," Journal of Statistical Software, 8(14),
+/// 2003; doi:10.18637/jss.v008.i14).
 uint32_t FBGEMM_API Xor128();
 
 void RequantizeFixedPointAvx2(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2879


The OSS CI docs (build-docs) and lint (run-lint) jobs -- and any other job that calls setup_miniconda (ci_cpu, ci_cuda, integration) -- fail because the base conda destroys itself during environment setup. Every subsequent `conda` call dies with:

  ModuleNotFoundError: No module named 'conda'

surfacing as `conda clean` failing in setup_miniconda (lint), and as broken conda post-link scripts when installing graphviz/doxygen (docs):

  LinkError: post-link script failed for package conda-forge::gdk-pixbuf-...
  DirectoryNotACondaEnvironmentError: ... build_binary is not a conda environment

Root cause: setup_miniconda runs

  conda update -n base -c conda-forge --override-channels --update-deps -y conda

conda-forge periodically publishes a base `conda` whose --update-deps solve bumps base Python to a version conda itself is not built against. That orphans conda's own site-packages, so `conda` can no longer import its own module. This is independent of the job's matrix Python version -- it happens in the base env, before the matrix Python is ever used. (An earlier attempt to pin the docs/lint matrices to 3.13 was therefore a no-op and was reverted.)

Fix: drop --update-deps from the base conda update so the base interpreter is left intact while conda is still updated.

Note: the release wheel builds are unaffected -- they use test-infra's conda setup (setup-miniconda: false), not this function.

Reviewed By: q10

Differential Revision: D110251102


