### PR TITLE
Shared CPU two-level prefetch helpers + env knobs (#5969)

### DIFF
--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -416,6 +416,11 @@ FBGEMM_API bool is_asmjit_disabled();
 FBGEMM_API bool is_stats_enabled();
 FBGEMM_API bool is_sve_fp16_enabled();
 
+// Tuned Prefetch on CG1, only apply to SVE and Autovec kernels on ARM
+FBGEMM_API int64_t tbe_l1_prefetch_distance();
+FBGEMM_API int64_t tbe_l2_prefetch_distance();
+FBGEMM_API int64_t tbe_l2_large_table_bytes();
+
 FBGEMM_API void set_autovec_disabled(bool val);
 FBGEMM_API void set_autovec_forced(bool val);
 FBGEMM_API void set_asmjit_disabled(bool val);

--- a/src/EmbeddingSpMDMPrefetch.h
+++ b/src/EmbeddingSpMDMPrefetch.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+#include "fbgemm/Utils.h"
+
+// Shared software-prefetch helpers for the TBE CPU kernels (SVE + autovec)
+
+namespace fbgemm {
+
+// Tuning constants (Neoverse-V2 / CG1).
+constexpr int64_t CACHE_LINE_SIZE = 64;
+constexpr int64_t DEFAULT_L1_PREFETCH_DISTANCE = 16;
+constexpr int64_t MAX_TLB_PRIME_INDEX_SIZE = 256;
+constexpr int64_t DEFAULT_L2_LARGE_TABLE_MB = 64;
+
+// Enable the farther L2 tier only when its per-row overhead can pay off: the
+// row spans multiple cache lines (small-dim rows likely already fit L1) and the
+// table is too big to stay cached (> tbe_l2_large_table_bytes(), default 64 MiB
+// via FBGEMM_TBE_L2_LARGE_TABLE_MB).
+inline bool tbe_use_l2_prefetch(
+    int64_t l2_distance,
+    int64_t input_stride, // row size in byte
+    int64_t data_size // number of rows in the embedding table
+) {
+  int64_t table_size = data_size * input_stride;
+  int64_t threshold_bytes = tbe_l2_large_table_bytes();
+  if (threshold_bytes == 0) {
+    threshold_bytes = DEFAULT_L2_LARGE_TABLE_MB * (int64_t{1} << 20);
+  }
+  return l2_distance > 0 && input_stride > CACHE_LINE_SIZE &&
+      table_size > threshold_bytes;
+}
+
+#ifdef _WIN32
+inline void prefetch_row_l1(const uint8_t*, int64_t) {}
+inline void prefetch_row_l2(const uint8_t*, int64_t) {}
+inline void do_tlb_prime(const void*) {}
+
+#else
+
+inline void prefetch_row_l1(const uint8_t* addr, int64_t input_stride) {
+  for (int64_t off = 0; off < input_stride; off += CACHE_LINE_SIZE)
+    __builtin_prefetch(addr + off, 0, 3);
+}
+
+inline void prefetch_row_l2(const uint8_t* addr, int64_t input_stride) {
+  for (int64_t off = 0; off < input_stride; off += CACHE_LINE_SIZE)
+    __builtin_prefetch(addr + off, 0, 2);
+}
+
+inline void do_tlb_prime([[maybe_unused]] const void* addr) {
+#ifdef __aarch64__
+  asm volatile("ldrb wzr, [%0]" : : "r"(addr) : "memory");
+#endif
+}
+#endif
+
+template <void (*PrefetchRow)(const uint8_t*, int64_t), typename IndexType>
+inline void tbe_prefetch_row(
+    const uint8_t* input,
+    const IndexType* indices,
+    int64_t pos,
+    int64_t last_index,
+    int64_t input_stride,
+    int64_t data_size,
+    int64_t prefetch_distance) {
+  const IndexType idx = indices[std::min(pos + prefetch_distance, last_index)];
+  if (idx >= 0 && idx < data_size) {
+    PrefetchRow(input + input_stride * idx, input_stride);
+  }
+}
+
+} // namespace fbgemm

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -11,17 +11,21 @@
 #define FBGEMM_EXPORTS
 #include "fbgemm/Utils.h"
 #include <cpuinfo.h>
+#include <algorithm>
 #include <bit>
 #include <cassert>
+#include <charconv>
 #include <cinttypes>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <limits>
 #include <new>
 #include <optional>
 #include <stdexcept>
+#include <system_error>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -830,6 +834,45 @@ bool is_sve_fp16_enabled() {
     char* env_val = std::getenv("FBGEMM_TBE_SVE_FP16_ACCUMULATOR");
     return env_val != nullptr;
   }();
+  return res;
+}
+
+static int64_t read_non_negative_int_env(const char* env_name) {
+  const char* env_val = std::getenv(env_name);
+  if (env_val == nullptr) {
+    return -1;
+  }
+  int64_t val = 0;
+  const char* const end = env_val + std::strlen(env_val);
+  const std::from_chars_result r = std::from_chars(env_val, end, val);
+  if (r.ec != std::errc() || r.ptr != end || val < 0) {
+    std::cerr << "[fbgemm] " << env_name << "='" << env_val
+              << "' is not a non-negative integer; ignoring it.\n";
+    return -1;
+  }
+  return val;
+}
+
+int64_t tbe_l1_prefetch_distance() {
+  static const int64_t res =
+      read_non_negative_int_env("FBGEMM_TBE_L1_PREFETCH_DISTANCE");
+  return res;
+}
+
+int64_t tbe_l2_prefetch_distance() {
+  static const int64_t res =
+      read_non_negative_int_env("FBGEMM_TBE_L2_PREFETCH_DISTANCE");
+  return res;
+}
+
+int64_t tbe_l2_large_table_bytes() {
+  // FBGEMM_TBE_L2_LARGE_TABLE_MB in bytes; 0 when unset/non-positive (caller
+  // applies the default). std::min guards the MiB->bytes overflow.
+  constexpr int64_t kMaxMiB = std::numeric_limits<int64_t>::max() >> 20;
+  static const int64_t mb =
+      read_non_negative_int_env("FBGEMM_TBE_L2_LARGE_TABLE_MB");
+  static const int64_t res =
+      mb <= 0 ? 0 : std::min(mb, kMaxMiB) * (int64_t{1} << 20);
   return res;
 }
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2881


Base of a 3-diff stack that tunes the TBE CPU embedding-gather software prefetch
on CG1 (Neoverse V2), gated behind two env vars so prod is unchanged unless
explicitly opted in. fbgemm-only.

This first diff adds only the shared infrastructure -- the new helper header and
the two env-var accessors. No kernel is wired up yet; the SVE and NBit-autovec
call sites land in the two follow-up diffs in this stack (D110107817, D110107818),
so this change is inert on its own.

Reviewed By: helloguo

Differential Revision: D109340258


