### PR TITLE
Add two-level prefetch into the SVE kernels (#5970)

### DIFF
--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -416,6 +416,11 @@ FBGEMM_API bool is_asmjit_disabled();
 FBGEMM_API bool is_stats_enabled();
 FBGEMM_API bool is_sve_fp16_enabled();
 
+// Tuned Prefetch on CG1, only apply to SVE and Autovec kernels on ARM
+FBGEMM_API int64_t tbe_l1_prefetch_distance();
+FBGEMM_API int64_t tbe_l2_prefetch_distance();
+FBGEMM_API int64_t tbe_l2_large_table_bytes();
+
 FBGEMM_API void set_autovec_disabled(bool val);
 FBGEMM_API void set_autovec_forced(bool val);
 FBGEMM_API void set_asmjit_disabled(bool val);

--- a/src/EmbeddingSpMDMPrefetch.h
+++ b/src/EmbeddingSpMDMPrefetch.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+#include "fbgemm/Utils.h"
+
+// Shared software-prefetch helpers for the TBE CPU kernels (SVE + autovec)
+
+namespace fbgemm {
+
+// Tuning constants (Neoverse-V2 / CG1).
+constexpr int64_t CACHE_LINE_SIZE = 64;
+constexpr int64_t DEFAULT_L1_PREFETCH_DISTANCE = 16;
+constexpr int64_t MAX_TLB_PRIME_INDEX_SIZE = 256;
+constexpr int64_t DEFAULT_L2_LARGE_TABLE_MB = 64;
+
+// Enable the farther L2 tier only when its per-row overhead can pay off: the
+// row spans multiple cache lines (small-dim rows likely already fit L1) and the
+// table is too big to stay cached (> tbe_l2_large_table_bytes(), default 64 MiB
+// via FBGEMM_TBE_L2_LARGE_TABLE_MB).
+inline bool tbe_use_l2_prefetch(
+    int64_t l2_distance,
+    int64_t input_stride, // row size in byte
+    int64_t data_size // number of rows in the embedding table
+) {
+  int64_t table_size = data_size * input_stride;
+  int64_t threshold_bytes = tbe_l2_large_table_bytes();
+  if (threshold_bytes == 0) {
+    threshold_bytes = DEFAULT_L2_LARGE_TABLE_MB * (int64_t{1} << 20);
+  }
+  return l2_distance > 0 && input_stride > CACHE_LINE_SIZE &&
+      table_size > threshold_bytes;
+}
+
+#ifdef _WIN32
+inline void prefetch_row_l1(const uint8_t*, int64_t) {}
+inline void prefetch_row_l2(const uint8_t*, int64_t) {}
+inline void do_tlb_prime(const void*) {}
+
+#else
+
+inline void prefetch_row_l1(const uint8_t* addr, int64_t input_stride) {
+  for (int64_t off = 0; off < input_stride; off += CACHE_LINE_SIZE)
+    __builtin_prefetch(addr + off, 0, 3);
+}
+
+inline void prefetch_row_l2(const uint8_t* addr, int64_t input_stride) {
+  for (int64_t off = 0; off < input_stride; off += CACHE_LINE_SIZE)
+    __builtin_prefetch(addr + off, 0, 2);
+}
+
+inline void do_tlb_prime([[maybe_unused]] const void* addr) {
+#ifdef __aarch64__
+  asm volatile("ldrb wzr, [%0]" : : "r"(addr) : "memory");
+#endif
+}
+#endif
+
+template <void (*PrefetchRow)(const uint8_t*, int64_t), typename IndexType>
+inline void tbe_prefetch_row(
+    const uint8_t* input,
+    const IndexType* indices,
+    int64_t pos,
+    int64_t last_index,
+    int64_t input_stride,
+    int64_t data_size,
+    int64_t prefetch_distance) {
+  const IndexType idx = indices[std::min(pos + prefetch_distance, last_index)];
+  if (idx >= 0 && idx < data_size) {
+    PrefetchRow(input + input_stride * idx, input_stride);
+  }
+}
+
+} // namespace fbgemm

--- a/src/EmbeddingSpMDMSve.h
+++ b/src/EmbeddingSpMDMSve.h
@@ -17,6 +17,8 @@
 #include "fbgemm/FbgemmBuild.h"
 #include "fbgemm/FloatConversion.h"
 
+#include "./EmbeddingSpMDMPrefetch.h"
+
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -354,17 +356,44 @@ bool EmbeddingSpMDM8Bit_Sve(
     assert(input_stride == output_stride);
   }
 
-  constexpr int64_t CACHE_LINE_SIZE = 64;
-  constexpr int64_t MAX_INITIAL_PREFETCH_ROWS = 16;
-  const int64_t prefetch_stride =
-      std::min(MAX_INITIAL_PREFETCH_ROWS, index_size);
+  const int64_t l1_distance = tbe_l1_prefetch_distance();
+  const int64_t l2_distance = tbe_l2_prefetch_distance();
+  const bool use_tuned_l1_prefetch = l1_distance > 0;
+  const bool use_l2_prefetch =
+      tbe_use_l2_prefetch(l2_distance, input_stride, data_size);
+  // L1 look-ahead: tuned distance if set, default if unset, 0 if disabled.
+  const int64_t l1_prefetch_distance = std::min(
+      use_tuned_l1_prefetch   ? l1_distance
+          : l1_distance == -1 ? DEFAULT_L1_PREFETCH_DISTANCE
+                              : 0,
+      index_size);
+  const int64_t l2_prefetch_distance = std::min(l2_distance, index_size);
+  const int64_t last_index = std::max<int64_t>(index_size - 1, 0);
 
   if constexpr (EnablePrefetching) {
-    for (int64_t pf_idx = 0; pf_idx < prefetch_stride; ++pf_idx) {
-      const uint8_t* prefetch_addr = input + input_stride * indices[pf_idx];
-      for (int64_t offset = 0; offset < input_stride;
-           offset += CACHE_LINE_SIZE) {
-        do_prefetch(prefetch_addr + offset, 0, 0);
+    for (int64_t pf_idx = 0; pf_idx < l1_prefetch_distance; ++pf_idx) {
+      const IndexType idx = indices[pf_idx];
+      if (idx < 0 || idx >= data_size) {
+        continue;
+      }
+      const uint8_t* prefetch_addr = input + input_stride * idx;
+      if (use_tuned_l1_prefetch) {
+        prefetch_row_l1(prefetch_addr, input_stride);
+      } else {
+        for (int64_t offset = 0; offset < input_stride;
+             offset += CACHE_LINE_SIZE) {
+          do_prefetch(prefetch_addr + offset, 0, 0);
+        }
+      }
+    }
+    if (use_l2_prefetch && index_size <= MAX_TLB_PRIME_INDEX_SIZE) {
+      for (int64_t pf_idx = l1_prefetch_distance; pf_idx < l2_prefetch_distance;
+           ++pf_idx) {
+        const IndexType idx = indices[pf_idx];
+        if (idx < 0 || idx >= data_size) {
+          continue;
+        }
+        do_tlb_prime(input + input_stride * idx);
       }
     }
   }
@@ -490,12 +519,33 @@ bool EmbeddingSpMDM8Bit_Sve(
       IndexType idx = indices[current];
 
       if constexpr (EnablePrefetching) {
-        IndexType prefetch_idx =
-            indices[std::min(current + prefetch_stride, index_size - 1)];
-        const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
-        for (int64_t offset = 0; offset < input_stride;
-             offset += CACHE_LINE_SIZE) {
-          do_prefetch(prefetch_addr + offset, 1);
+        if (use_tuned_l1_prefetch) {
+          tbe_prefetch_row<prefetch_row_l1>(
+              input,
+              indices,
+              current,
+              last_index,
+              input_stride,
+              data_size,
+              l1_prefetch_distance);
+        } else if (l1_distance == -1) {
+          const IndexType prefetch_idx =
+              indices[std::min(current + l1_prefetch_distance, last_index)];
+          const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
+          for (int64_t offset = 0; offset < input_stride;
+               offset += CACHE_LINE_SIZE) {
+            do_prefetch(prefetch_addr + offset, 1);
+          }
+        }
+        if (use_l2_prefetch) {
+          tbe_prefetch_row<prefetch_row_l2>(
+              input,
+              indices,
+              current,
+              last_index,
+              input_stride,
+              data_size,
+              l2_prefetch_distance);
         }
       }
 
@@ -549,12 +599,33 @@ bool EmbeddingSpMDM8Bit_Sve(
       IndexType idx = indices[current];
 
       if constexpr (EnablePrefetching) {
-        IndexType prefetch_idx =
-            indices[std::min(current + prefetch_stride, index_size - 1)];
-        const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
-        for (int64_t offset = 0; offset < input_stride;
-             offset += CACHE_LINE_SIZE) {
-          do_prefetch(prefetch_addr + offset, 1);
+        if (use_tuned_l1_prefetch) {
+          tbe_prefetch_row<prefetch_row_l1>(
+              input,
+              indices,
+              current,
+              last_index,
+              input_stride,
+              data_size,
+              l1_prefetch_distance);
+        } else if (l1_distance == -1) {
+          const IndexType prefetch_idx =
+              indices[std::min(current + l1_prefetch_distance, last_index)];
+          const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
+          for (int64_t offset = 0; offset < input_stride;
+               offset += CACHE_LINE_SIZE) {
+            do_prefetch(prefetch_addr + offset, 1);
+          }
+        }
+        if (use_l2_prefetch) {
+          tbe_prefetch_row<prefetch_row_l2>(
+              input,
+              indices,
+              current,
+              last_index,
+              input_stride,
+              data_size,
+              l2_prefetch_distance);
         }
       }
 
@@ -771,17 +842,44 @@ bool EmbeddingSpMDM8Bit_Sve_Fp16(
     return false;
   }
 
-  constexpr int64_t CACHE_LINE_SIZE = 64;
-  constexpr int64_t MAX_INITIAL_PREFETCH_ROWS = 16;
-  const int64_t prefetch_stride =
-      std::min(MAX_INITIAL_PREFETCH_ROWS, index_size);
+  const int64_t l1_distance = tbe_l1_prefetch_distance();
+  const int64_t l2_distance = tbe_l2_prefetch_distance();
+  const bool use_tuned_l1_prefetch = l1_distance > 0;
+  const bool use_l2_prefetch =
+      tbe_use_l2_prefetch(l2_distance, input_stride, data_size);
+  // L1 look-ahead: tuned distance if set, default if unset, 0 if disabled.
+  const int64_t l1_prefetch_distance = std::min(
+      use_tuned_l1_prefetch   ? l1_distance
+          : l1_distance == -1 ? DEFAULT_L1_PREFETCH_DISTANCE
+                              : 0,
+      index_size);
+  const int64_t l2_prefetch_distance = std::min(l2_distance, index_size);
+  const int64_t last_index = std::max<int64_t>(index_size - 1, 0);
 
   if constexpr (EnablePrefetching) {
-    for (int64_t pf_idx = 0; pf_idx < prefetch_stride; ++pf_idx) {
-      const uint8_t* prefetch_addr = input + input_stride * indices[pf_idx];
-      for (int64_t offset = 0; offset < input_stride;
-           offset += CACHE_LINE_SIZE) {
-        do_prefetch(prefetch_addr + offset, 0, 0);
+    for (int64_t pf_idx = 0; pf_idx < l1_prefetch_distance; ++pf_idx) {
+      const IndexType idx = indices[pf_idx];
+      if (idx < 0 || idx >= data_size) {
+        continue;
+      }
+      const uint8_t* prefetch_addr = input + input_stride * idx;
+      if (use_tuned_l1_prefetch) {
+        prefetch_row_l1(prefetch_addr, input_stride);
+      } else {
+        for (int64_t offset = 0; offset < input_stride;
+             offset += CACHE_LINE_SIZE) {
+          do_prefetch(prefetch_addr + offset, 0, 0);
+        }
+      }
+    }
+    if (use_l2_prefetch && index_size <= MAX_TLB_PRIME_INDEX_SIZE) {
+      for (int64_t pf_idx = l1_prefetch_distance; pf_idx < l2_prefetch_distance;
+           ++pf_idx) {
+        const IndexType idx = indices[pf_idx];
+        if (idx < 0 || idx >= data_size) {
+          continue;
+        }
+        do_tlb_prime(input + input_stride * idx);
       }
     }
   }
@@ -922,12 +1020,34 @@ bool EmbeddingSpMDM8Bit_Sve_Fp16(
             const IndexType idx = indices[tile_current];
 
             if constexpr (EnablePrefetching) {
-              const IndexType pidx = indices[std::min(
-                  tile_current + prefetch_stride, index_size - 1)];
-              const uint8_t* paddr = input + input_stride * pidx;
-              for (int64_t off = 0; off < input_stride;
-                   off += CACHE_LINE_SIZE) {
-                do_prefetch(paddr + off, 0, 0);
+              if (use_tuned_l1_prefetch) {
+                tbe_prefetch_row<prefetch_row_l1>(
+                    input,
+                    indices,
+                    tile_current,
+                    last_index,
+                    input_stride,
+                    data_size,
+                    l1_prefetch_distance);
+              } else if (l1_distance == -1) {
+                const IndexType prefetch_idx = indices[std::min(
+                    tile_current + l1_prefetch_distance, last_index)];
+                const uint8_t* prefetch_addr =
+                    input + input_stride * prefetch_idx;
+                for (int64_t offset = 0; offset < input_stride;
+                     offset += CACHE_LINE_SIZE) {
+                  do_prefetch(prefetch_addr + offset, 0, 0);
+                }
+              }
+              if (use_l2_prefetch) {
+                tbe_prefetch_row<prefetch_row_l2>(
+                    input,
+                    indices,
+                    tile_current,
+                    last_index,
+                    input_stride,
+                    data_size,
+                    l2_prefetch_distance);
               }
             }
 
@@ -1045,12 +1165,34 @@ bool EmbeddingSpMDM8Bit_Sve_Fp16(
 
           if constexpr (EnablePrefetching) {
             auto prefetch_row = [&](int64_t cur) {
-              const IndexType pidx =
-                  indices[std::min(cur + prefetch_stride, index_size - 1)];
-              const uint8_t* paddr = input + input_stride * pidx;
-              for (int64_t off = 0; off < input_stride;
-                   off += CACHE_LINE_SIZE) {
-                do_prefetch(paddr + off, 0, 0);
+              if (use_tuned_l1_prefetch) {
+                tbe_prefetch_row<prefetch_row_l1>(
+                    input,
+                    indices,
+                    cur,
+                    last_index,
+                    input_stride,
+                    data_size,
+                    l1_prefetch_distance);
+              } else if (l1_distance == -1) {
+                const IndexType prefetch_idx =
+                    indices[std::min(cur + l1_prefetch_distance, last_index)];
+                const uint8_t* prefetch_addr =
+                    input + input_stride * prefetch_idx;
+                for (int64_t offset = 0; offset < input_stride;
+                     offset += CACHE_LINE_SIZE) {
+                  do_prefetch(prefetch_addr + offset, 0, 0);
+                }
+              }
+              if (use_l2_prefetch) {
+                tbe_prefetch_row<prefetch_row_l2>(
+                    input,
+                    indices,
+                    cur,
+                    last_index,
+                    input_stride,
+                    data_size,
+                    l2_prefetch_distance);
               }
             };
             prefetch_row(current);
@@ -1131,12 +1273,33 @@ bool EmbeddingSpMDM8Bit_Sve_Fp16(
         IndexType idx = indices[current];
 
         if constexpr (EnablePrefetching) {
-          IndexType prefetch_idx =
-              indices[std::min(current + prefetch_stride, index_size - 1)];
-          const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
-          for (int64_t offset = 0; offset < input_stride;
-               offset += CACHE_LINE_SIZE) {
-            do_prefetch(prefetch_addr + offset, 0, 0);
+          if (use_tuned_l1_prefetch) {
+            tbe_prefetch_row<prefetch_row_l1>(
+                input,
+                indices,
+                current,
+                last_index,
+                input_stride,
+                data_size,
+                l1_prefetch_distance);
+          } else if (l1_distance == -1) {
+            const IndexType prefetch_idx =
+                indices[std::min(current + l1_prefetch_distance, last_index)];
+            const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
+            for (int64_t offset = 0; offset < input_stride;
+                 offset += CACHE_LINE_SIZE) {
+              do_prefetch(prefetch_addr + offset, 0, 0);
+            }
+          }
+          if (use_l2_prefetch) {
+            tbe_prefetch_row<prefetch_row_l2>(
+                input,
+                indices,
+                current,
+                last_index,
+                input_stride,
+                data_size,
+                l2_prefetch_distance);
           }
         }
 
@@ -1382,12 +1545,33 @@ bool EmbeddingSpMDM8Bit_Sve_Fp16(
       IndexType idx = indices[current];
 
       if constexpr (EnablePrefetching) {
-        IndexType prefetch_idx =
-            indices[std::min(current + prefetch_stride, index_size - 1)];
-        const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
-        for (int64_t offset = 0; offset < input_stride;
-             offset += CACHE_LINE_SIZE) {
-          do_prefetch(prefetch_addr + offset, 1);
+        if (use_tuned_l1_prefetch) {
+          tbe_prefetch_row<prefetch_row_l1>(
+              input,
+              indices,
+              current,
+              last_index,
+              input_stride,
+              data_size,
+              l1_prefetch_distance);
+        } else if (l1_distance == -1) {
+          const IndexType prefetch_idx =
+              indices[std::min(current + l1_prefetch_distance, last_index)];
+          const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
+          for (int64_t offset = 0; offset < input_stride;
+               offset += CACHE_LINE_SIZE) {
+            do_prefetch(prefetch_addr + offset, 1);
+          }
+        }
+        if (use_l2_prefetch) {
+          tbe_prefetch_row<prefetch_row_l2>(
+              input,
+              indices,
+              current,
+              last_index,
+              input_stride,
+              data_size,
+              l2_prefetch_distance);
         }
       }
 
@@ -1462,12 +1646,33 @@ bool EmbeddingSpMDM8Bit_Sve_Fp16(
       IndexType idx = indices[current];
 
       if constexpr (EnablePrefetching) {
-        IndexType prefetch_idx =
-            indices[std::min(current + prefetch_stride, index_size - 1)];
-        const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
-        for (int64_t offset = 0; offset < input_stride;
-             offset += CACHE_LINE_SIZE) {
-          do_prefetch(prefetch_addr + offset, 1);
+        if (use_tuned_l1_prefetch) {
+          tbe_prefetch_row<prefetch_row_l1>(
+              input,
+              indices,
+              current,
+              last_index,
+              input_stride,
+              data_size,
+              l1_prefetch_distance);
+        } else if (l1_distance == -1) {
+          const IndexType prefetch_idx =
+              indices[std::min(current + l1_prefetch_distance, last_index)];
+          const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
+          for (int64_t offset = 0; offset < input_stride;
+               offset += CACHE_LINE_SIZE) {
+            do_prefetch(prefetch_addr + offset, 1);
+          }
+        }
+        if (use_l2_prefetch) {
+          tbe_prefetch_row<prefetch_row_l2>(
+              input,
+              indices,
+              current,
+              last_index,
+              input_stride,
+              data_size,
+              l2_prefetch_distance);
         }
       }
 
@@ -1648,29 +1853,55 @@ bool EmbeddingSpMDMNBit_Sve_Fp16(
     return false;
   }
 
-  constexpr int64_t CACHE_LINE_SIZE = 64;
-  constexpr int64_t MAX_INITIAL_PREFETCH_ROWS = 16;
-  const int64_t prefetch_stride =
-      std::min(MAX_INITIAL_PREFETCH_ROWS, index_size);
+  const int64_t l1_distance = tbe_l1_prefetch_distance();
+  const int64_t l2_distance = tbe_l2_prefetch_distance();
+  const bool use_tuned_l1_prefetch = l1_distance > 0;
+  const bool use_l2_prefetch =
+      tbe_use_l2_prefetch(l2_distance, input_stride, data_size);
+  // L1 look-ahead: tuned distance if set, default if unset, 0 if disabled.
+  const int64_t l1_prefetch_distance = std::min(
+      use_tuned_l1_prefetch   ? l1_distance
+          : l1_distance == -1 ? DEFAULT_L1_PREFETCH_DISTANCE
+                              : 0,
+      index_size);
+  const int64_t l2_prefetch_distance = std::min(l2_distance, index_size);
+  const int64_t last_index = std::max<int64_t>(index_size - 1, 0);
 
   if constexpr (EnablePrefetching) {
-    for (int64_t pf_idx = 0; pf_idx < prefetch_stride; ++pf_idx) {
+    for (int64_t pf_idx = 0; pf_idx < l1_prefetch_distance; ++pf_idx) {
       const IndexType idx = indices[pf_idx];
       if (idx < 0 || idx >= data_size) {
         continue;
       }
       const uint8_t* prefetch_addr = input + input_stride * idx;
-      for (int64_t offset = 0; offset < input_stride;
-           offset += CACHE_LINE_SIZE) {
-        do_prefetch(prefetch_addr + offset, 0, 0);
+      if (use_tuned_l1_prefetch) {
+        prefetch_row_l1(prefetch_addr, input_stride);
+      } else {
+        for (int64_t offset = 0; offset < input_stride;
+             offset += CACHE_LINE_SIZE) {
+          do_prefetch(prefetch_addr + offset, 0, 0);
+        }
+      }
+    }
+    if (use_l2_prefetch && index_size <= MAX_TLB_PRIME_INDEX_SIZE) {
+      for (int64_t pf_idx = l1_prefetch_distance; pf_idx < l2_prefetch_distance;
+           ++pf_idx) {
+        const IndexType idx = indices[pf_idx];
+        if (idx < 0 || idx >= data_size) {
+          continue;
+        }
+        do_tlb_prime(input + input_stride * idx);
       }
     }
   }
 
+  // for 4bit, 2 elements per byte; for 2bit, 4 elements per byte
   const int num_elem_per_byte = 8 / bit_rate;
+
   constexpr int64_t scale_bias_fp16_size =
       2 * sizeof(float16_t); // only used when scale and bias is at the
                              // beginning, in which case, they are fp16
+
   const int64_t scale_bias_offset = scale_bias_last
       ? ((block_size + num_elem_per_byte - 1) / num_elem_per_byte)
       : 0;
@@ -1806,14 +2037,36 @@ bool EmbeddingSpMDMNBit_Sve_Fp16(
           const IndexType idx = indices[current];
 
           if constexpr (EnablePrefetching) {
-            const IndexType pidx =
-                indices[std::min(current + prefetch_stride, index_size - 1)];
-            if (pidx >= 0 && pidx < data_size) {
-              const uint8_t* paddr = input + input_stride * pidx;
-              for (int64_t off = 0; off < input_stride;
-                   off += CACHE_LINE_SIZE) {
-                do_prefetch(paddr + off, 0, 0);
+            if (use_tuned_l1_prefetch) {
+              tbe_prefetch_row<prefetch_row_l1>(
+                  input,
+                  indices,
+                  current,
+                  last_index,
+                  input_stride,
+                  data_size,
+                  l1_prefetch_distance);
+            } else if (l1_distance == -1) {
+              const IndexType prefetch_idx =
+                  indices[std::min(current + l1_prefetch_distance, last_index)];
+              if (prefetch_idx >= 0 && prefetch_idx < data_size) {
+                const uint8_t* prefetch_addr =
+                    input + input_stride * prefetch_idx;
+                for (int64_t offset = 0; offset < input_stride;
+                     offset += CACHE_LINE_SIZE) {
+                  do_prefetch(prefetch_addr + offset, 0, 0);
+                }
               }
+            }
+            if (use_l2_prefetch) {
+              tbe_prefetch_row<prefetch_row_l2>(
+                  input,
+                  indices,
+                  current,
+                  last_index,
+                  input_stride,
+                  data_size,
+                  l2_prefetch_distance);
             }
           }
 
@@ -1964,14 +2217,36 @@ bool EmbeddingSpMDMNBit_Sve_Fp16(
 
           if constexpr (EnablePrefetching) {
             auto prefetch_row = [&](int64_t cur) {
-              const IndexType pidx =
-                  indices[std::min(cur + prefetch_stride, index_size - 1)];
-              if (pidx >= 0 && pidx < data_size) {
-                const uint8_t* paddr = input + input_stride * pidx;
-                for (int64_t off = 0; off < input_stride;
-                     off += CACHE_LINE_SIZE) {
-                  do_prefetch(paddr + off, 0, 0);
+              if (use_tuned_l1_prefetch) {
+                tbe_prefetch_row<prefetch_row_l1>(
+                    input,
+                    indices,
+                    cur,
+                    last_index,
+                    input_stride,
+                    data_size,
+                    l1_prefetch_distance);
+              } else if (l1_distance == -1) {
+                const IndexType prefetch_idx =
+                    indices[std::min(cur + l1_prefetch_distance, last_index)];
+                if (prefetch_idx >= 0 && prefetch_idx < data_size) {
+                  const uint8_t* prefetch_addr =
+                      input + input_stride * prefetch_idx;
+                  for (int64_t offset = 0; offset < input_stride;
+                       offset += CACHE_LINE_SIZE) {
+                    do_prefetch(prefetch_addr + offset, 0, 0);
+                  }
                 }
+              }
+              if (use_l2_prefetch) {
+                tbe_prefetch_row<prefetch_row_l2>(
+                    input,
+                    indices,
+                    cur,
+                    last_index,
+                    input_stride,
+                    data_size,
+                    l2_prefetch_distance);
               }
             };
             prefetch_row(current);
@@ -2103,14 +2378,36 @@ bool EmbeddingSpMDMNBit_Sve_Fp16(
 
           if constexpr (EnablePrefetching) {
             auto prefetch_row = [&](int64_t cur) {
-              const IndexType pidx =
-                  indices[std::min(cur + prefetch_stride, index_size - 1)];
-              if (pidx >= 0 && pidx < data_size) {
-                const uint8_t* paddr = input + input_stride * pidx;
-                for (int64_t off = 0; off < input_stride;
-                     off += CACHE_LINE_SIZE) {
-                  do_prefetch(paddr + off, 0, 0);
+              if (use_tuned_l1_prefetch) {
+                tbe_prefetch_row<prefetch_row_l1>(
+                    input,
+                    indices,
+                    cur,
+                    last_index,
+                    input_stride,
+                    data_size,
+                    l1_prefetch_distance);
+              } else if (l1_distance == -1) {
+                const IndexType prefetch_idx =
+                    indices[std::min(cur + l1_prefetch_distance, last_index)];
+                if (prefetch_idx >= 0 && prefetch_idx < data_size) {
+                  const uint8_t* prefetch_addr =
+                      input + input_stride * prefetch_idx;
+                  for (int64_t offset = 0; offset < input_stride;
+                       offset += CACHE_LINE_SIZE) {
+                    do_prefetch(prefetch_addr + offset, 0, 0);
+                  }
                 }
+              }
+              if (use_l2_prefetch) {
+                tbe_prefetch_row<prefetch_row_l2>(
+                    input,
+                    indices,
+                    cur,
+                    last_index,
+                    input_stride,
+                    data_size,
+                    l2_prefetch_distance);
               }
             };
             prefetch_row(current);
@@ -2194,14 +2491,36 @@ bool EmbeddingSpMDMNBit_Sve_Fp16(
         IndexType idx = indices[current];
 
         if constexpr (EnablePrefetching) {
-          IndexType prefetch_idx =
-              indices[std::min(current + prefetch_stride, index_size - 1)];
-          if (prefetch_idx >= 0 && prefetch_idx < data_size) {
-            const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
-            for (int64_t offset = 0; offset < input_stride;
-                 offset += CACHE_LINE_SIZE) {
-              do_prefetch(prefetch_addr + offset, 0, 0);
+          if (use_tuned_l1_prefetch) {
+            tbe_prefetch_row<prefetch_row_l1>(
+                input,
+                indices,
+                current,
+                last_index,
+                input_stride,
+                data_size,
+                l1_prefetch_distance);
+          } else if (l1_distance == -1) {
+            const IndexType prefetch_idx =
+                indices[std::min(current + l1_prefetch_distance, last_index)];
+            if (prefetch_idx >= 0 && prefetch_idx < data_size) {
+              const uint8_t* prefetch_addr =
+                  input + input_stride * prefetch_idx;
+              for (int64_t offset = 0; offset < input_stride;
+                   offset += CACHE_LINE_SIZE) {
+                do_prefetch(prefetch_addr + offset, 0, 0);
+              }
             }
+          }
+          if (use_l2_prefetch) {
+            tbe_prefetch_row<prefetch_row_l2>(
+                input,
+                indices,
+                current,
+                last_index,
+                input_stride,
+                data_size,
+                l2_prefetch_distance);
           }
         }
 
@@ -2438,14 +2757,35 @@ bool EmbeddingSpMDMNBit_Sve_Fp16(
       IndexType idx = indices[current];
 
       if constexpr (EnablePrefetching) {
-        IndexType prefetch_idx =
-            indices[std::min(current + prefetch_stride, index_size - 1)];
-        if (prefetch_idx >= 0 && prefetch_idx < data_size) {
-          const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
-          for (int64_t offset = 0; offset < input_stride;
-               offset += CACHE_LINE_SIZE) {
-            do_prefetch(prefetch_addr + offset, 1);
+        if (use_tuned_l1_prefetch) {
+          tbe_prefetch_row<prefetch_row_l1>(
+              input,
+              indices,
+              current,
+              last_index,
+              input_stride,
+              data_size,
+              l1_prefetch_distance);
+        } else if (l1_distance == -1) {
+          const IndexType prefetch_idx =
+              indices[std::min(current + l1_prefetch_distance, last_index)];
+          if (prefetch_idx >= 0 && prefetch_idx < data_size) {
+            const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
+            for (int64_t offset = 0; offset < input_stride;
+                 offset += CACHE_LINE_SIZE) {
+              do_prefetch(prefetch_addr + offset, 1);
+            }
           }
+        }
+        if (use_l2_prefetch) {
+          tbe_prefetch_row<prefetch_row_l2>(
+              input,
+              indices,
+              current,
+              last_index,
+              input_stride,
+              data_size,
+              l2_prefetch_distance);
         }
       }
 

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -11,17 +11,21 @@
 #define FBGEMM_EXPORTS
 #include "fbgemm/Utils.h"
 #include <cpuinfo.h>
+#include <algorithm>
 #include <bit>
 #include <cassert>
+#include <charconv>
 #include <cinttypes>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <limits>
 #include <new>
 #include <optional>
 #include <stdexcept>
+#include <system_error>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -830,6 +834,45 @@ bool is_sve_fp16_enabled() {
     char* env_val = std::getenv("FBGEMM_TBE_SVE_FP16_ACCUMULATOR");
     return env_val != nullptr;
   }();
+  return res;
+}
+
+static int64_t read_non_negative_int_env(const char* env_name) {
+  const char* env_val = std::getenv(env_name);
+  if (env_val == nullptr) {
+    return -1;
+  }
+  int64_t val = 0;
+  const char* const end = env_val + std::strlen(env_val);
+  const std::from_chars_result r = std::from_chars(env_val, end, val);
+  if (r.ec != std::errc() || r.ptr != end || val < 0) {
+    std::cerr << "[fbgemm] " << env_name << "='" << env_val
+              << "' is not a non-negative integer; ignoring it.\n";
+    return -1;
+  }
+  return val;
+}
+
+int64_t tbe_l1_prefetch_distance() {
+  static const int64_t res =
+      read_non_negative_int_env("FBGEMM_TBE_L1_PREFETCH_DISTANCE");
+  return res;
+}
+
+int64_t tbe_l2_prefetch_distance() {
+  static const int64_t res =
+      read_non_negative_int_env("FBGEMM_TBE_L2_PREFETCH_DISTANCE");
+  return res;
+}
+
+int64_t tbe_l2_large_table_bytes() {
+  // FBGEMM_TBE_L2_LARGE_TABLE_MB in bytes; 0 when unset/non-positive (caller
+  // applies the default). std::min guards the MiB->bytes overflow.
+  constexpr int64_t kMaxMiB = std::numeric_limits<int64_t>::max() >> 20;
+  static const int64_t mb =
+      read_non_negative_int_env("FBGEMM_TBE_L2_LARGE_TABLE_MB");
+  static const int64_t res =
+      mb <= 0 ? 0 : std::min(mb, kMaxMiB) * (int64_t{1} << 20);
   return res;
 }
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2882

Wires the shared two-level CPU software-prefetch stack (from the base diff) into the three
ARM SVE TBE kernels: EmbeddingSpMDM8Bit_Sve (fp32), EmbeddingSpMDM8Bit_Sve_Fp16, and
EmbeddingSpMDMNBit_Sve_Fp16.

Per kernel, gated by the env knobs (FBGEMM_TBE_L1_PREFETCH_DISTANCE /
FBGEMM_TBE_L2_PREFETCH_DISTANCE, both default 0 = off):
- Initial L1 warm-up burst (prefetch_row_l1) over the first l1_prefetch_distance rows.
- A single TLB-prime burst (do_tlb_prime, ldrb) over rows [l1_distance, l2_distance) when the
  table is L2-eligible and index_size <= MAX_TLB_PRIME_INDEX_SIZE (PRFM is silently dropped on
  TLB-cold pages).
- In each steady-state loop phase: whole-row L1 prefetch l1_distance rows ahead, plus a farther
  L2 tier (prefetch_row_l2) l2_distance rows ahead, gated by tbe_use_l2_prefetch.
- When the tuned env is unset, retains the original trunk single-level L1 prefetch.

Prefetch is a pure memory hint, so numerics are unchanged whether it is on or off.

Reviewed By: q10

Differential Revision: D110107817


