### PR TITLE
Add two-level prefetch into the NBit autovec kernel (#5971)

### DIFF
--- a/src/EmbeddingSpMDMAutovec.cc
+++ b/src/EmbeddingSpMDMAutovec.cc
@@ -9,10 +9,12 @@
 #define FBGEMM_EXPORTS
 #include "./EmbeddingSpMDMAutovec.h" // @manual
 #include <bit>
+#include "./EmbeddingSpMDMPrefetch.h"
 #include "./EmbeddingStatsTracker.h"
 #include "./RefImplementations.h" // @manual
 #include "fbgemm/FbgemmBuild.h"
 #include "fbgemm/FloatConversion.h"
+#include "fbgemm/Utils.h"
 
 #if defined(__clang__) && HAVE_SVE
 #include <arm_neon.h>
@@ -154,7 +156,6 @@ static bool ALWAYS_INLINE EmbeddingSpMDM8Bit_autovec(
   if (data_size < 0) {
     return false;
   }
-  constexpr int64_t CACHE_LINE_SIZE = 64;
   constexpr int64_t MAX_INITIAL_PREFETCH_ROWS = 16;
   const int64_t prefetch_stride =
       std::min(MAX_INITIAL_PREFETCH_ROWS, index_size);
@@ -356,29 +357,48 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
     return false;
   }
 
-  // more prefetch
-  // TODO: in the future we should adjust max_prefetch_bytes based on CPU cache
-  // size
-  constexpr int64_t max_prefetch_bytes = 4096;
-  // 16 is manually tuned for Neoverse-V2 for best performance
-  constexpr int64_t max_initial_prefetch_rows = 16;
-  constexpr int64_t CACHE_LINE_SIZE = 64;
-  const int64_t rows_to_prefetch =
-      std::min(max_initial_prefetch_rows, max_prefetch_bytes / input_stride);
-  const int64_t prefetch_stride = std::min(rows_to_prefetch, index_size);
+  const int64_t l1_distance = tbe_l1_prefetch_distance();
+  const int64_t l2_distance = tbe_l2_prefetch_distance();
+  const bool use_tuned_l1_prefetch = l1_distance > 0;
+  const bool use_l2_prefetch =
+      tbe_use_l2_prefetch(l2_distance, input_stride, data_size);
+  constexpr int64_t max_prefetch_bytes = 4096; // cap based on CPU cache size
+  // L1 look-ahead: tuned distance if set, default if unset, 0 if disabled.
+  const int64_t l1_prefetch_distance = std::min(
+      use_tuned_l1_prefetch ? l1_distance
+          : l1_distance == -1
+          ? std::min(
+                DEFAULT_L1_PREFETCH_DISTANCE, max_prefetch_bytes / input_stride)
+          : 0,
+      index_size);
+  const int64_t l2_prefetch_distance = std::min(l2_distance, index_size);
+  const int64_t last_index = std::max<int64_t>(index_size - 1, 0);
+
   const int num_elem_per_byte = 8 / input_bit_rate;
   const int64_t scale_bias_offset =
       scale_bias_last ? div_up(block_size, num_elem_per_byte) : 0;
   const size_t scale_bias_size = 2 * sizeof(float16);
   const int64_t input_row_offset = scale_bias_last ? 0 : scale_bias_size;
-  // The following prefetch loop is written in this way for better performance.
-  // My understanding is that manually separating the case of input_stride being
-  // greater or not greater than cache line size will make the branch predictor
-  // work better. Same for line 113-126.
-  for (int64_t pf_idx = 0; pf_idx < prefetch_stride; ++pf_idx) {
-    const uint8_t* prefetch_addr = input + input_stride * indices[pf_idx];
-    for (int64_t offset = 0; offset < input_stride; offset += CACHE_LINE_SIZE) {
-      do_prefetch(prefetch_addr + offset, 0, 0);
+
+  for (int64_t pf_idx = 0; pf_idx < l1_prefetch_distance; ++pf_idx) {
+    const int64_t idx = indices[pf_idx];
+    if (use_tuned_l1_prefetch) {
+      prefetch_row_l1(input + input_stride * idx, input_stride);
+    } else {
+      for (int64_t offset = 0; offset < input_stride;
+           offset += CACHE_LINE_SIZE) {
+        do_prefetch(input + input_stride * idx + offset, 0, 0);
+      }
+    }
+  }
+  if (use_l2_prefetch && index_size <= MAX_TLB_PRIME_INDEX_SIZE) {
+    for (int64_t pf_idx = l1_prefetch_distance; pf_idx < l2_prefetch_distance;
+         ++pf_idx) {
+      const int64_t idx = indices[pf_idx];
+      if (idx < 0 || idx >= data_size) {
+        continue;
+      }
+      do_tlb_prime(input + input_stride * idx);
     }
   }
 
@@ -459,9 +479,6 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
         }
         return false;
       }
-      int64_t prefetch_idx =
-          indices[std::min(current + prefetch_stride, index_size - 1)];
-
       const uint8_t* input_row_base = input + input_stride * idx;
       const uint8_t* scale_bias_addr = input_row_base + scale_bias_offset;
       const uint8_t* input_row = input_row_base + input_row_offset;
@@ -527,10 +544,36 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
         }
       }
 
-      const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
-      for (int64_t offset = 0; offset < input_stride;
-           offset += CACHE_LINE_SIZE) {
-        do_prefetch(prefetch_addr + offset, 0, 0);
+      if (use_tuned_l1_prefetch) {
+        tbe_prefetch_row<prefetch_row_l1>(
+            input,
+            indices,
+            current,
+            last_index,
+            input_stride,
+            data_size,
+            l1_prefetch_distance);
+      } else if (l1_distance == -1) {
+        const int64_t prefetch_idx =
+            indices[std::min(current + l1_prefetch_distance, last_index)];
+        // Prefetch of an out-of-range address is a harmless no-op, so the
+        // default path issues it unconditionally (matching the
+        // pre-prefetch-diff behavior) to keep the hot loop free of a per-row
+        // bounds branch.
+        for (int64_t offset = 0; offset < input_stride;
+             offset += CACHE_LINE_SIZE) {
+          do_prefetch(input + input_stride * prefetch_idx + offset, 0, 0);
+        }
+      }
+      if (use_l2_prefetch) {
+        tbe_prefetch_row<prefetch_row_l2>(
+            input,
+            indices,
+            current,
+            last_index,
+            input_stride,
+            data_size,
+            l2_prefetch_distance);
       }
     }
 
@@ -817,7 +860,6 @@ static bool ALWAYS_INLINE EmbeddingSpMDM_autovec(
   constexpr int64_t max_prefetch_bytes = 4096;
   // 16 is manually tuned for Neoverse-V2 for best performance
   constexpr int64_t max_initial_prefetch_rows = 8;
-  constexpr int64_t CACHE_LINE_SIZE = 64;
   const int64_t rows_to_prefetch =
       std::min(max_initial_prefetch_rows, max_prefetch_bytes / input_stride);
   const int64_t prefetch_stride = std::min(rows_to_prefetch, index_size);
@@ -1175,7 +1217,6 @@ static bool ALWAYS_INLINE EmbeddingSpMDMFP8_autovec(
   constexpr int64_t max_prefetch_bytes = 4096;
   // 16 is manually tuned for Neoverse-V2 for best performance
   constexpr int64_t max_initial_prefetch_rows = 16;
-  constexpr int64_t CACHE_LINE_SIZE = 64;
   const int64_t rows_to_prefetch =
       std::min(max_initial_prefetch_rows, max_prefetch_bytes / input_stride);
   const int64_t prefetch_stride = std::min(rows_to_prefetch, index_size);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2883


Third diff in the CPU two-level software-prefetch stack (base: D109340258 shared helpers +
env knobs; SVE kernels: D110107817). Wires the shared prefetch stack into the NBit autovec
embedding-gather kernel EmbeddingSpMDMNBit_autovec (EmbeddingSpMDMAutovec.cc) 

Gated by the env knobs (FBGEMM_TBE_L1_PREFETCH_DISTANCE / FBGEMM_TBE_L2_PREFETCH_DISTANCE, both
default 0 = off):
- Initial L1 warm-up burst (prefetch_row_l1, L1-KEEP) over the first l1_prefetch_distance rows.
- A single TLB-prime burst (do_tlb_prime, ldrb) over rows [l1_distance, l2_distance) when the
  table is L2-eligible (tbe_use_l2_prefetch) and index_size <= MAX_TLB_PRIME_INDEX_SIZE (PRFM is
  silently dropped on TLB-cold pages).
- Steady state: whole-row L1 prefetch l1_distance rows ahead + a farther L2 tier
  (prefetch_row_l2) l2_distance rows ahead, gated by tbe_use_l2_prefetch.

When the tuned env is unset it reproduces the prior trunk prefetch exactly: L1 distance is the
4096-byte-budget-capped min(DEFAULT_L1_PREFETCH_DISTANCE, 4096/input_stride, index_size), the
trunk L1 hint, no L2 tier and no TLB prime. Prefetch is a pure memory hint, so numerics are
unchanged whether it is on or off.

Reviewed By: helloguo

Differential Revision: D110107818


