### PR TITLE
Apply stochastic rounding in the optimized HIP TBE backward kernel (#5972)

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -672,7 +672,12 @@ hip_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vd
                max_segment_length_per_warp,
                emb_dim,
                T,
-               opt_karg
+               opt_karg,
+               // Pass SR state as kernel params (not via opt_karg) so the
+               // broadly-included rocm/split_embeddings_common.h need not
+               // depend on ATen. Both are in scope from the kernel signature.
+               stochastic_rounding,
+               stochastic_rounding_philox_args
                {%- if weighted %}
                , p_indice_weights_sorted
                {%- endif %});

--- a/fbgemm_gpu/codegen/training/backward/rocm/embedding_backward_split_device_kernel_template.hip
+++ b/fbgemm_gpu/codegen/training/backward/rocm/embedding_backward_split_device_kernel_template.hip
@@ -32,10 +32,145 @@
 #include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
 
+#include <cstdint>
+#include <type_traits>
+
 #include <ATen/AccumulateType.h>
+// Provides at::PhiloxCudaState + at::cuda::philox::unpack. This is a raw .hip
+// translation unit, and the OSS hipify pipeline does NOT rewrite #includes
+// inside .hip files. So we must include the ROCm (ATen/hip) header path
+// directly: an ATen/cuda/... include would (a) resolve to the CUDA header that
+// pulls <cuda.h> (absent in the ROCm toolchain) and (b) define a second,
+// CUDA-flavored at::PhiloxCudaState that clashes with the HIP one already in the
+// enclosing warp TU. PhiloxUtils.cuh is header-guarded, so it de-dups with the
+// warp's copy. (The namespace stays at::cuda::philox even under ROCm.)
+#ifdef USE_ROCM
+#include <ATen/hip/PhiloxUtils.cuh>
+#else
+#include <ATen/cuda/PhiloxUtils.cuh>
+#endif
 #include "fbgemm_gpu/rocm/split_embeddings_common.h"
 
 namespace fbgemm_gpu::rocm {
+
+// Stochastic-rounding primitives, defined locally in fbgemm_gpu::rocm rather
+// than pulled from stochastic_rounding.cuh (directly or via
+// rocm/stochastic_rounding.h). This device kernel is compiled both standalone
+// (gen_..._device_kernel_hip.hip.o) and #included into the warp kernel, and
+// neither of those headers is usable from a raw .hip TU:
+//   (a) they transitively include cuda_prelude.cuh -> <cuda.h> and
+//       <curand_kernel.h>, which do not exist on the raw ROCm compile, and
+//   (b) in the #included build they would re-define
+//       fbgemm_gpu::StochasticRoundingRNGState against the hipified copy already
+//       present in the warp TU.
+// Keeping our own copy in the fbgemm_gpu::rocm namespace sidesteps both: it is
+// self-contained for the standalone compile and does not collide with the
+// fbgemm_gpu:: symbols in the #included compile.
+
+// xorshift* RNG state seeded from a philox state; mirrors
+// fbgemm_gpu::StochasticRoundingRNGState.
+struct StochasticRoundingRNGState {
+  uint64_t state = 0;
+
+  // From https://github.com/lemire/testingRNG/blob/master/source/splitmix64.h
+  __device__ __forceinline__ uint64_t splitmix64_stateless(uint64_t index) {
+    uint64_t z = (index + UINT64_C(0x9E3779B97F4A7C15));
+    z = (z ^ (z >> 30)) * UINT64_C(0xBF58476D1CE4E5B9);
+    z = (z ^ (z >> 27)) * UINT64_C(0x94D049BB133111EB);
+    return z ^ (z >> 31);
+  }
+
+  // salt_value should differ for every run and every thread.
+  __device__ __forceinline__ void init(
+      const at::PhiloxCudaState& philox_state,
+      const uint64_t salt_value) {
+    const auto [s0, s1] = at::cuda::philox::unpack(philox_state);
+    state = splitmix64_stateless(s0 ^ s1) ^ splitmix64_stateless(salt_value);
+    // Never allow a zero state (astronomically unlikely, but still).
+    if (state == 0) {
+      state = 1;
+    }
+  }
+
+  // xorshift* -- see https://en.wikipedia.org/wiki/Xorshift#xorshift*
+  __device__ __forceinline__ uint4 rand4() {
+    uint4 random_bits = {0, 0, 0, 0};
+    uint64_t x = state; // must be seeded nonzero
+    x ^= x >> 12;
+    x ^= x << 25;
+    x ^= x >> 27;
+    random_bits.x = (x * UINT64_C(0x2545F4914F6CDD1D)) >> 32;
+    x ^= x >> 12;
+    x ^= x << 25;
+    x ^= x >> 27;
+    random_bits.y = (x * UINT64_C(0x2545F4914F6CDD1D)) >> 32;
+    x ^= x >> 12;
+    x ^= x << 25;
+    x ^= x >> 27;
+    random_bits.z = (x * UINT64_C(0x2545F4914F6CDD1D)) >> 32;
+    x ^= x >> 12;
+    x ^= x << 25;
+    x ^= x >> 27;
+    random_bits.w = (x * UINT64_C(0x2545F4914F6CDD1D)) >> 32;
+    state = x;
+    return random_bits;
+  }
+};
+
+// Correct for cases where x is not subnormal; mirrors
+// fbgemm_gpu::stochastic_rounding_scalar.
+__device__ __forceinline__ __half
+stochastic_rounding_scalar(float x, uint32_t random_value) {
+  uint32_t w_int = __float_as_uint(x);
+  unsigned assembles = (w_int & 0xff800000) | (random_value >> 19);
+  unsigned subtract = (w_int & 0xff800000);
+  float assemble_float = __uint_as_float(assembles) - __uint_as_float(subtract);
+  return __float2half_rz(x + assemble_float);
+}
+
+// Writes `thread_length` fp32 accumulator values into reduced-precision `output`
+// with stochastic rounding. SR is only representable for at::Half on this scalar
+// path (stochastic_rounding_scalar yields __half); any other emb_t falls back to
+// a plain round-to-nearest cast.
+template <typename emb_t, typename cache_t, int32_t thread_length>
+__device__ __forceinline__ void stochastic_rounding_store_vector(
+    emb_t* output,
+    const cache_t* value,
+    StochasticRoundingRNGState& state) {
+  if constexpr (std::is_same_v<emb_t, at::Half>) {
+#pragma unroll
+    for (int32_t i = 0; i < thread_length; i += 4) {
+      const uint4 random_bits = state.rand4();
+      const uint32_t bits[4] = {
+          random_bits.x, random_bits.y, random_bits.z, random_bits.w};
+#pragma unroll
+      for (int32_t j = 0; j < 4; j++) {
+        if (i + j < thread_length) {
+          output[i + j] = stochastic_rounding_scalar(
+              static_cast<float>(value[i + j]), bits[j]);
+        }
+      }
+    }
+  } else {
+#pragma unroll
+    for (int32_t i = 0; i < thread_length; i++) {
+      output[i] = static_cast<emb_t>(value[i]);
+    }
+  }
+}
+
+// Scalar-array weight write with plain round-to-nearest (no SR). Used for the
+// SR-disabled case and for fp32 weights (where SR is a no-op).
+template <typename emb_t, typename cache_t, int32_t thread_length>
+__device__ __forceinline__ void nearest_rounding_store_vector(
+    emb_t* output,
+    const cache_t* value) {
+#pragma unroll
+  for (int32_t i = 0; i < thread_length; i++) {
+    output[i] = static_cast<emb_t>(value[i]);
+  }
+}
+
 template <typename cache_t, typename emb_t, typename index_t, int32_t embedding_dim, int32_t weight_decay_mode>
 struct rowwise_adagrad_optimizer_t
 {
@@ -45,7 +180,11 @@ struct rowwise_adagrad_optimizer_t
     }
 
     template <int32_t thread_length, int32_t segment_split>
-    __device__ void update(cache_t* acc, emb_t* weight, index_t row_index)
+    __device__ void update(
+        cache_t* acc,
+        emb_t* weight,
+        index_t row_index,
+        StochasticRoundingRNGState* sr_state = nullptr)
     {
         if constexpr(segment_split == 0)
         {
@@ -97,13 +236,29 @@ struct rowwise_adagrad_optimizer_t
             }
 
 // update new weight value
+            cache_t updated_weight[thread_length];
 #pragma unroll
             for(auto i = 0; i < thread_length; i++)
             {
                 cache_t w = static_cast<cache_t>(weight[i]);
                 cache_t a = acc[i];
-                w         = correction * w - multiplier * a;
-                weight[i] = static_cast<emb_t>(w);
+                updated_weight[i] = correction * w - multiplier * a;
+            }
+            // Write the fp32 accumulator back to the emb_t weights. When SR is
+            // armed (sr_state != nullptr; only the case for at::Half), copy the
+            // RNG state into a register-local and apply stochastic rounding;
+            // otherwise use plain round-to-nearest. The on/off branch lives here
+            // (per row, warp-uniform); the helpers themselves are branch-free.
+            if (sr_state != nullptr)
+            {
+                StochasticRoundingRNGState local_state = *sr_state;
+                stochastic_rounding_store_vector<emb_t, cache_t, thread_length>(
+                    weight, updated_weight, local_state);
+            }
+            else
+            {
+                nearest_rounding_store_vector<emb_t, cache_t, thread_length>(
+                    weight, updated_weight);
             }
 
             p_momentum[row_index] = momentum_new;
@@ -139,6 +294,8 @@ __device__ void split_tbe_backward_hip_kernel_{{ kdesc }}(
     uint32_t emb_dim,
     uint32_t num_tables,
     optimizer_karg_t opt_karg,
+    bool stochastic_rounding,
+    at::PhiloxCudaState stochastic_rounding_philox_args,
     const float * p_sorted_indice_weights = nullptr)
 {
     constexpr uint32_t dword_per_row   = (embedding_dim + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
@@ -419,7 +576,24 @@ L_tail_grad_acc:
     load_row_per_warp<emb_t, embedding_dim, index_t>::run(
         &emb_data[0], emb_idx, p_emb_table, lane_id);
     optimizer_t optimizer(opt_karg);
-    optimizer.template update<dword_per_row, segment_split>(grad_acc, emb_data, emb_idx);
+
+    // Seed a per-thread, per-run stochastic-rounding RNG state when SR is
+    // enabled and the weights are at::Half (SR is a no-op for fp32 and is only
+    // supported for Half on this scalar write path). The salt mirrors the
+    // generic path's per-thread/per-run convention. The philox state is passed
+    // as a kernel parameter (rather than via opt_karg) so the broadly-included
+    // rocm/split_embeddings_common.h need not depend on ATen.
+    StochasticRoundingRNGState sr_state;
+    StochasticRoundingRNGState* sr_state_ptr = nullptr;
+    if constexpr (std::is_same_v<emb_t, at::Half>) {
+        if (stochastic_rounding) {
+            sr_state.init(
+                stochastic_rounding_philox_args,
+                static_cast<uint64_t>(run_id) * AMDGCN_WAVE_SIZE + lane_id);
+            sr_state_ptr = &sr_state;
+        }
+    }
+    optimizer.template update<dword_per_row, segment_split>(grad_acc, emb_data, emb_idx, sr_state_ptr);
 
     store_row_per_warp<emb_t, embedding_dim>::run(&emb_data[0], p_emb_table + emb_idx * embedding_dim, lane_id);
 }

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_test.py
@@ -522,6 +522,156 @@ class BackwardAdagradTest(unittest.TestCase):
                 )
 
     @unittest.skipIf(*gpu_unavailable)
+    @skipIfNotRocm("Validates stochastic rounding in the optimized HIP backward kernel")
+    def test_backward_adagrad_rocm_hip_stochastic_rounding_seeded(self) -> None:
+        """
+        Validates that the optimized HIP TBE backward kernel threads stochastic
+        rounding (SR) correctly. Before SR was plumbed into the HIP optimizer the
+        kernel always used round-to-nearest, so the updated weights were
+        independent of the RNG seed. With identical weights/inputs and only the
+        SR seed varying, we expect:
+          - same seed -> bit-identical updated weights (seed threaded correctly)
+          - diff seed -> different updated weights (SR is actually applied)
+        """
+        E: int = 1000
+        T, B, L = 1, 64, 10
+        D: int = 128
+        lr: float = 0.5
+        eps: float = 0.1
+        device = torch.accelerator.current_accelerator()
+
+        # Fixed weights + inputs so SR is the only source of randomness.
+        torch.manual_seed(0)
+        init_weights: torch.Tensor = torch.randn(E, D, device=device).to(torch.float16)
+        indices: torch.Tensor = torch.randint(
+            0, E, (T * B * L,), dtype=torch.long, device=device
+        )
+        offsets: torch.Tensor = torch.arange(
+            0, T * B * L + 1, L, dtype=torch.long, device=device
+        )
+
+        def run_update(sr_seed: int) -> torch.Tensor:
+            with updated_env(
+                {"FBGEMM_NO_JK": "1", "FBGEMM_TBE_ROCM_HIP_BACKWARD_KERNEL": "1"}
+            ):
+                cc = SplitTableBatchedEmbeddingBagsCodegen(
+                    embedding_specs=[
+                        (E, D, EmbeddingLocation.DEVICE, ComputeDevice.CUDA)
+                    ],
+                    weights_precision=SparseType.FP16,
+                    output_dtype=SparseType.FP16,
+                    optimizer=OptimType.EXACT_ROWWISE_ADAGRAD,
+                    learning_rate=lr,
+                    eps=eps,
+                    weight_decay=0.0,
+                    weight_decay_mode=WeightDecayMode.NONE,
+                    stochastic_rounding=True,
+                ).cuda()
+                with torch.no_grad():
+                    cc.split_embedding_weights()[0].copy_(init_weights)
+                # Seed the default generator that supplies the SR philox state,
+                # immediately before the backward so the offset is deterministic.
+                torch.manual_seed(sr_seed)
+                output = cc(indices, offsets)
+                output.backward(torch.ones_like(output))
+                return cc.split_embedding_weights()[0].detach().clone()
+
+        w_same_a = run_update(1234)
+        w_same_b = run_update(1234)
+        w_diff = run_update(5678)
+
+        self.assertTrue(
+            torch.equal(w_same_a, w_same_b),
+            "Same SR seed produced different weights — the SR seed is not "
+            "threaded deterministically through the HIP backward kernel.",
+        )
+        self.assertFalse(
+            torch.equal(w_same_a, w_diff),
+            "Different SR seeds produced identical weights — stochastic rounding "
+            "is not being applied by the HIP backward kernel (round-to-nearest).",
+        )
+
+    @unittest.skipIf(*gpu_unavailable)
+    @skipIfNotRocm(
+        "Validates stochastic rounding is unbiased in the HIP backward kernel"
+    )
+    def test_backward_adagrad_rocm_hip_stochastic_rounding_unbiased(self) -> None:
+        """
+        Stochastic rounding is unbiased: E[SR(x)] == x. Averaging the FP16 SR'd
+        weight updates from the optimized HIP kernel over many runs should
+        converge to the exact FP32 optimizer update, while any single run does
+        not match it (it rounds to the FP16 grid). This is the property that
+        recovers NE parity vs. round-to-nearest.
+        """
+        E: int = 200
+        B, L = 32, 8
+        D: int = 128
+        lr: float = 0.5
+        eps: float = 0.1
+        n_runs = 50
+        device = torch.accelerator.current_accelerator()
+
+        torch.manual_seed(0)
+        init_weights_fp16 = torch.randn(E, D, device=device).to(torch.float16)
+        indices = torch.randint(0, E, (B * L,), dtype=torch.long, device=device)
+        offsets = torch.arange(0, B * L + 1, L, dtype=torch.long, device=device)
+        accessed = indices.unique().cpu()
+
+        def build(
+            precision: SparseType, stochastic: bool
+        ) -> SplitTableBatchedEmbeddingBagsCodegen:
+            return SplitTableBatchedEmbeddingBagsCodegen(
+                embedding_specs=[(E, D, EmbeddingLocation.DEVICE, ComputeDevice.CUDA)],
+                weights_precision=precision,
+                output_dtype=precision,
+                optimizer=OptimType.EXACT_ROWWISE_ADAGRAD,
+                learning_rate=lr,
+                eps=eps,
+                weight_decay=0.0,
+                weight_decay_mode=WeightDecayMode.NONE,
+                stochastic_rounding=stochastic,
+            ).cuda()
+
+        with updated_env(
+            {"FBGEMM_NO_JK": "1", "FBGEMM_TBE_ROCM_HIP_BACKWARD_KERNEL": "1"}
+        ):
+            # FP32 oracle: exact update with no rounding. The gradient into the
+            # table is a scatter of grad_output and is independent of weight
+            # precision, so this is the unbiased target for the FP16 SR updates.
+            cc_ref = build(SparseType.FP32, False)
+            with torch.no_grad():
+                cc_ref.split_embedding_weights()[0].copy_(init_weights_fp16.float())
+            out = cc_ref(indices, offsets)
+            out.backward(torch.ones_like(out))
+            w_ref = cc_ref.split_embedding_weights()[0].detach().float().cpu()[accessed]
+
+            # FP16 + SR: average accessed-row updates across many runs.
+            acc_sum = torch.zeros_like(w_ref)
+            single_run = None
+            for r in range(n_runs):
+                cc = build(SparseType.FP16, True)
+                with torch.no_grad():
+                    cc.split_embedding_weights()[0].copy_(init_weights_fp16)
+                torch.manual_seed(1000 + r)
+                out = cc(indices, offsets)
+                out.backward(torch.ones_like(out))
+                w_run = cc.split_embedding_weights()[0].detach().float().cpu()[accessed]
+                acc_sum += w_run
+                if single_run is None:
+                    single_run = w_run
+            w_sr_mean = acc_sum / n_runs
+
+        # Mean of SR updates converges to the exact FP32 update (unbiased).
+        torch.testing.assert_close(w_sr_mean, w_ref, atol=5e-3, rtol=5e-3)
+        # A single SR run does not match the exact update bit-for-bit — i.e. SR
+        # genuinely rounds to the FP16 grid rather than being a no-op.
+        self.assertIsNotNone(single_run)
+        self.assertFalse(
+            torch.equal(single_run, w_ref),
+            "A single SR run exactly matched the FP32 update — SR not applied.",
+        )
+
+    @unittest.skipIf(*gpu_unavailable)
     @unittest.skipIf(*gpu_memory_lt_gb(40))
     def test_backward_adagrad_from_config_file(self) -> None:
         """


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2885


The optimized ROCm HIP backward kernel for TBE training (rowwise_adagrad, gated by
`FBGEMM_TBE_ROCM_HIP_BACKWARD_KERNEL`) wrote updated fp16 embedding weights with a
plain round-to-nearest cast and dropped stochastic rounding (SR) entirely, while the
generic CUDA/ROCm path applies SR via `WeightRow::quantize_store`. For fp16 weights
this biases convergence: disabling the kernel restored SR and closed an
H100<->MI350x NE gap, but gave up the kernel's ~3% QPS win. NE and QPS are
orthogonal axes here; this restores SR inside the optimized kernel so we keep the
QPS and recover NE parity with the generic path.

The SR args (`stochastic_rounding` + `at::PhiloxCudaState`) already flow into the
host warp kernel for all non-dense optimizers; the ROCm branch simply discarded
them. This diff threads them through:

- Add `optimizer_kernel_arg_base_t` carrying the SR flag + philox args;
  `rowwise_adagrad_kernel_arg_t` derives from it so future ROCm optimizers reuse the
  same plumbing.
- Populate the SR fields in the host `opt_karg` builder (no upstream ABI change).
- Seed a per-thread `StochasticRoundingRNGState` in the kernel
  (salt = run_id * AMDGCN_WAVE_SIZE + lane_id) and pass it into the optimizer update.
- Replace the round-to-nearest write with a reusable `stochastic_rounding_store_vector`
  helper that applies SR for `at::Half` (reusing the existing
  `StochasticRoundingRNGState` / `stochastic_rounding_scalar`) and falls back to a
  plain cast otherwise (fp32 no-op, matching the generic path).

Scope: rowwise_adagrad / warp-per-row only (the only path the optimized HIP kernel
covers today); SR applies for fp16 weights.

Reviewed By: henrylhtsang

Differential Revision: D109792155


