### PR TITLE
Drop CUDA 12.8 from release workflows (torch 2.13 ships no cu128)

### DIFF
--- a/.github/workflows/fbgemm_gpu_release_cuda.yml
+++ b/.github/workflows/fbgemm_gpu_release_cuda.yml
@@ -34,7 +34,7 @@ on:
         description: CUDA Version to Use for Building Artifact
         type: choice
         required: false
-        options: [ "12.6.3", "12.8.1", "13.0.2" ]
+        options: [ "12.6.3", "13.0.2" ]
         default: "13.0.2"
       publish-to-pypi:
         description: Publish Artifact to PyPI

--- a/.github/workflows/fbgemm_gpu_release_genai.yml
+++ b/.github/workflows/fbgemm_gpu_release_genai.yml
@@ -34,7 +34,7 @@ on:
         description: CUDA Version to Use for Building Artifact
         type: choice
         required: false
-        options: [ "12.6.3", "12.8.1", "13.0.2" ]
+        options: [ "12.6.3", "13.0.2" ]
         default: "13.0.2"
       publish-to-pypi:
         description: Publish Artifact to PyPI
@@ -72,7 +72,7 @@ jobs:
           { arch: x86, instance: "linux.12xlarge.memory" },
         ]
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        cuda-version: [ "12.6.3", "12.8.1", "13.0.2" ]
+        cuda-version: [ "12.6.3", "13.0.2" ]
 
     steps:
     - name: Setup Build Container
@@ -146,7 +146,7 @@ jobs:
           { arch: x86, instance: "linux.g5.4xlarge.nvidia.gpu" },
         ]
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        cuda-version: [ "12.6.3", "12.8.1", "13.0.2" ]
+        cuda-version: [ "12.6.3", "13.0.2" ]
     needs: build_artifact
 
     steps:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2888

PyTorch dropped CUDA 12.8 (cu128) starting with torch 2.12 -- 2.12 and 2.13 publish no cu128 wheels. Verified on download.pytorch.org (test channel): torch-2.13 has cu126=108 and cu130=108 wheels but cu128=0 (torch-2.12 cu128=0; cu128's last version was 2.11 with 42 wheels).

FBGEMM's release workflows still offered "12.8.1" as a CUDA option, a leftover from the CUDA-12.8 era. Building/publishing a cu128 FBGEMM wheel for the v1.8.0 release (torch 2.13) is impossible -- there is no torch cu128 to build against -- so the option can only ever fail. Remove it so the release matrix reflects PyTorch and nobody can trigger a dead cu128 build.

Changes (options + genai build/test matrices):
  - fbgemm_gpu_release_cuda.yml:  [ "12.6.3", "12.8.1", "13.0.2" ] -> [ "12.6.3", "13.0.2" ]
  - fbgemm_gpu_release_genai.yml: same drop in the cuda-version-publish option and both build/test cuda-version matrices.

Default stays 13.0.2. Net release CUDA set: cu126 (legacy) + cu130 (stable) -- matching torch 2.13's PyPI matrix.

PyTorch source (authoritative):
  - "Introducing CUDA 13.2 and Deprecating CUDA 12.8 (Release 2.12)", Andrey Talman (PyTorch Dev Infra), 2026-04-01:
    https://fb.workplace.com/groups/671272153461300/permalink/1976674139587755/
    "CUDA 12.8 is being deprecated and removed from CI/CD pipelines and binary build matrices ... CUDA 13.0 remains the stable variant published to PyPI ... CUDA 12.6 remains available as the legacy build."
  - RFC: pytorch/pytorch#178665 (CUDA support matrix for Release 2.12)
  - dev-discuss: https://dev-discuss.pytorch.org/t/introducing-cuda-13-2-and-deprecating-cuda-12-8-release-2-12/3337
  - Policy: pytorch/pytorch RELEASE.md#pytorch-cuda-support-matrix (legacy / stable / experimental tiers)

PyTorch's torch 2.13 CUDA tiers: 12.6 legacy, 13.0 stable, 13.2 experimental. FBGEMM v1.8.0 ships 12.6 + 13.0; 13.2 (experimental) is deferred until the FBGEMM cu132 build is nightly-green (tracked separately; cu132 was filtered in D110247364).

Differential Revision: D110492570


