### PR TITLE
Fix HIP grid overflow in jagged_dense_elementwise_mul_backward (#5985)

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_backward.cu
@@ -117,9 +117,21 @@ std::tuple<Tensor, Tensor> batched_dense_vec_jagged_2d_mul_backward(
                     div_round_up(max_L, kWarpSize) * kWarpSize, kMaxThreads);
                 int block_dim_y = kMaxThreads / block_dim_x;
 
+                // HIP enforces a hard limit of 2^32 total threads per launch
+                // (unlike CUDA, which silently wraps).
+                // dense_vec_jagged_2d_transposed_bmm grid-strides over `b_h`
+                // (`for (b_h = b_h_begin; b_h < B*H; b_h += b_h_step)`
+                // where `b_h_step = gridDim.x * blockDim.y`), so capping
+                // is correctness-preserving.
+                // See: https://github.com/ROCm/hip/issues/2253
+                const auto blocks_x_t = utils::cuda::cap_grid_dim_x(
+                    static_cast<uint32_t>(div_round_up(B * H, block_dim_y)),
+                    kMaxThreads,
+                    at::cuda::getCurrentCUDAStream());
+
                 FBGEMM_LAUNCH_KERNEL(
                     (dense_vec_jagged_2d_transposed_bmm<index_t, scalar_t>),
-                    div_round_up(B * H, block_dim_y),
+                    blocks_x_t,
                     dim3(block_dim_x, block_dim_y),
                     0,
                     at::cuda::getCurrentCUDAStream(),
@@ -132,9 +144,22 @@ std::tuple<Tensor, Tensor> batched_dense_vec_jagged_2d_mul_backward(
                     div_round_up(D, kWarpSize) * kWarpSize, kMaxThreads);
                 block_dim_y = kMaxThreads / block_dim_x;
 
+                // HIP 2^32 cap. outer_prod_jagged_2d_output grid-strides
+                // over the outer index
+                // (`for (auto outer = outer_begin; outer < B*H*max_L;
+                // outer += outer_step)` where
+                // `outer_step = gridDim.x * blockDim.y`), so capping is
+                // correctness-preserving.
+                // See: https://github.com/ROCm/hip/issues/2253
+                const auto blocks_x_o = utils::cuda::cap_grid_dim_x(
+                    static_cast<uint32_t>(
+                        div_round_up(B * H * max_L, block_dim_y)),
+                    kMaxThreads,
+                    at::cuda::getCurrentCUDAStream());
+
                 FBGEMM_LAUNCH_KERNEL(
                     (outer_prod_jagged_2d_output<index_t, scalar_t>),
-                    div_round_up(B * H * max_L, block_dim_y),
+                    blocks_x_o,
                     dim3(block_dim_x, block_dim_y),
                     0,
                     at::cuda::getCurrentCUDAStream(),

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_elementwise_mul_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_elementwise_mul_backward.cu
@@ -90,6 +90,18 @@ void jagged_jagged_elementwise_dense_output_(
   std::tie(threads, blocks, jagged_dims_tensor) =
       check_shape_and_partition_(x_values, x_offsets, output);
 
+  // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
+  // which silently wraps). jagged_jagged_elementwise_dense_output_kernel_
+  // grid-strides over the outer dim
+  // (`outer_stride = gridDim.x * blockDim.y`), so capping is
+  // correctness-preserving.
+  // See: https://github.com/ROCm/hip/issues/2253
+  blocks.x = utils::cuda::cap_grid_dim_x(
+      static_cast<uint32_t>(blocks.x),
+      static_cast<int64_t>(threads.x) * static_cast<int64_t>(threads.y) *
+          static_cast<int64_t>(threads.z),
+      at::cuda::getCurrentCUDAStream());
+
   // Canonicalize output to 3D, collapsing jagged dimensions.
   Tensor output_reshaped = output.view({output.size(0), -1, output.size(-1)});
 

--- a/fbgemm_gpu/test/jagged/batched_dense_vec_jagged_2d_mul_test.py
+++ b/fbgemm_gpu/test/jagged/batched_dense_vec_jagged_2d_mul_test.py
@@ -336,6 +336,106 @@ class BatchedDenseVecJagged2DMulTest(unittest.TestCase):
 
         torch.testing.assert_close(small_output_gpu.cpu(), small_output_cpu)
 
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(8))
+    def test_batched_dense_vec_jagged_2d_mul_backward_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in the backward kernels of
+        fbgemm.batched_dense_vec_jagged_2d_mul:
+          - dense_vec_jagged_2d_transposed_bmm: grid =
+              ceil(B*H / block_dim_y) * 1024.
+          - outer_prod_jagged_2d_output: grid =
+              ceil(B*H*max_L / block_dim_y) * 1024.
+
+        The production cap is `blocks_x_capped = min(blocks_x_uncapped,
+        get_max_thread_blocks(stream))` where `get_max_thread_blocks ~=
+        16384` on MI300/MI350. With max_L=1, D=4, block_dim_y=32 for
+        both kernels:
+            pre-fix:  ceil(B*H / 32) * 1024 > 2**32 ⇒ B*H > 2**27.
+            post-fix: 16384 * 1024 = 2**24 < 2**32 (always passes).
+
+        Verification strategy (downsampled-oracle):
+        1. Full-scale forward + backward to verify both backward kernels
+           launch successfully under the cap. Uses an empty jagged
+           tensor (offsets all zero) so per-segment work is zero;
+           backward grad shapes are asserted.
+        2. Small-scale forward + backward vs CPU dispatch to validate
+           kernel correctness end-to-end.
+        """
+
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+
+        # ---- Step 1: full-scale forward + backward launch survival. ----
+        B = (1 << 27) + 1
+        H = 1
+        max_L = 1
+        D = 4
+        a_values_large = torch.zeros(
+            (0, H * D), dtype=torch.float32, device=device, requires_grad=True
+        )
+        a_offsets_large = torch.zeros(B * H + 1, dtype=torch.int64, device=device)
+        v_large = torch.zeros(
+            (B * H, max_L),
+            dtype=torch.float32,
+            device=device,
+            requires_grad=True,
+        )
+
+        output_large = torch.ops.fbgemm.batched_dense_vec_jagged_2d_mul(
+            v_large, a_values_large, a_offsets_large
+        )
+        # Pre-fix, this backward call's two kernels both trip
+        # KernelLauncher::checkThreadCountNotExceeded on ROCm.
+        output_large.sum().backward()
+        # pyre-ignore[16]
+        self.assertEqual(v_large.grad.shape, v_large.shape)
+        # pyre-ignore[16]
+        self.assertEqual(a_values_large.grad.shape, a_values_large.shape)
+        del v_large, a_values_large, a_offsets_large, output_large
+        torch.cuda.empty_cache()
+
+        # ---- Step 2: downsampled CPU-oracle correctness check. ----
+        small_B = 2
+        small_H = 2
+        small_D = 4
+        small_max_L = 3
+        # Sparse jagged offsets. Total = 6 rows.
+        small_lengths = torch.tensor([1, 2, 0, 3], dtype=torch.int64)
+        small_offsets_cpu = torch.zeros(small_B * small_H + 1, dtype=torch.int64)
+        small_offsets_cpu[1:] = torch.cumsum(small_lengths, dim=0)
+        total_rows = int(small_offsets_cpu[-1].item())
+        a_values_init = torch.arange(
+            total_rows * small_H * small_D, dtype=torch.float32
+        ).reshape(total_rows, small_H * small_D)
+        v_init = (
+            torch.arange(small_B * small_H * small_max_L, dtype=torch.float32).reshape(
+                small_B * small_H, small_max_L
+            )
+            * 0.1
+        )
+
+        # CPU forward + backward.
+        a_values_cpu = a_values_init.detach().clone().requires_grad_(True)
+        v_cpu = v_init.detach().clone().requires_grad_(True)
+        output_cpu = torch.ops.fbgemm.batched_dense_vec_jagged_2d_mul(
+            v_cpu, a_values_cpu, small_offsets_cpu
+        )
+        output_cpu.sum().backward()
+
+        # GPU forward + backward.
+        a_values_gpu = a_values_init.detach().clone().to(device).requires_grad_(True)
+        v_gpu = v_init.detach().clone().to(device).requires_grad_(True)
+        output_gpu = torch.ops.fbgemm.batched_dense_vec_jagged_2d_mul(
+            v_gpu, a_values_gpu, small_offsets_cpu.to(device)
+        )
+        output_gpu.sum().backward()
+
+        torch.testing.assert_close(output_gpu.cpu(), output_cpu)
+        # pyre-ignore[16]
+        torch.testing.assert_close(v_gpu.grad.cpu(), v_cpu.grad)
+        # pyre-ignore[16]
+        torch.testing.assert_close(a_values_gpu.grad.cpu(), a_values_cpu.grad)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/fbgemm_gpu/test/jagged/elementwise_binary_test.py
+++ b/fbgemm_gpu/test/jagged/elementwise_binary_test.py
@@ -25,10 +25,17 @@ from .common import (
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import cpu_and_maybe_gpu, gpu_unavailable, gradcheck, optests
+    from test_utils import (
+        cpu_and_maybe_gpu,
+        gpu_memory_lt_gb,
+        gpu_unavailable,
+        gradcheck,
+        optests,
+    )
 else:
     from fbgemm_gpu.test.test_utils import (
         cpu_and_maybe_gpu,
+        gpu_memory_lt_gb,
         gpu_unavailable,
         gradcheck,
         optests,
@@ -270,6 +277,129 @@ class ElementwiseBinaryTest(unittest.TestCase):
             raise AssertionError(f"Unknown operation {operation}")
 
         assert output.size() == output_ref.size()
+
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(32))
+    def test_jagged_dense_elementwise_mul_backward_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in
+        jagged_jagged_elementwise_dense_output_kernel_ (the backward of
+        fbgemm.jagged_dense_elementwise_mul) and verifies output
+        correctness via a downsampled CPU oracle.
+
+        block = up to 1024 (dim3(threads_x<=32, threads_y=32) from
+            check_shape_and_partition_ at common.cuh:187)
+        grid.x = div_round_up(outer * jagged_folded, 32)
+        Total threads ~= outer * jagged_folded * 32.
+        For pre-fix to trip and post-fix to pass:
+            pre-fix:  outer * jagged_folded > 2**27 ⇒ trips.
+            post-fix: 16384 * 32 * 32 = 2**24 < 2**32 (always passes).
+
+        Verification strategy (downsampled-oracle):
+        1. Full-scale forward + backward to verify the backward kernel
+           launches successfully under the cap. Uses zero values so per-
+           element work is zero; backward grad shape is asserted.
+        2. Small-scale forward + backward vs CPU dispatch to validate
+           kernel correctness end-to-end.
+        """
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+
+        # ---- Step 1: full-scale forward + backward launch survival. ----
+        B = 1
+        max_L = (1 << 27) + 1
+        # D=8 keeps x_values.numel() = max_L*D < 2**31 (the kernel's
+        # int32_t accessor limit) while still leaving outer*jagged_folded
+        # = max_L > 2**27, which trips the cap pre-fix.
+        D = 8
+        nnz = max_L  # one segment of length max_L
+        x_values_large = torch.zeros(
+            (nnz, D), dtype=torch.float32, device=device, requires_grad=True
+        )
+        x_offsets_large = [torch.tensor([0, nnz], dtype=torch.int64, device=device)]
+        y_large = torch.zeros(
+            (B, max_L, D),
+            dtype=torch.float32,
+            device=device,
+            requires_grad=True,
+        )
+
+        output_large = torch.ops.fbgemm.jagged_dense_elementwise_mul(
+            x_values_large, x_offsets_large, y_large
+        )
+        # output is a tuple (output_jagged_values, output_offsets). Use the
+        # jagged values for backward.
+        if isinstance(output_large, (tuple, list)):
+            loss_large = output_large[0].sum()
+        else:
+            loss_large = output_large.sum()
+        # Pre-fix this trips KernelLauncher::checkThreadCountNotExceeded on
+        # ROCm.
+        loss_large.backward()
+        # pyre-ignore[16]
+        self.assertEqual(x_values_large.grad.shape, x_values_large.shape)
+        # pyre-ignore[16]
+        self.assertEqual(y_large.grad.shape, y_large.shape)
+        del x_values_large, x_offsets_large, y_large, output_large, loss_large
+        torch.cuda.empty_cache()
+
+        # ---- Step 2: downsampled CPU-oracle correctness check. ----
+        # Same kernel code path, smaller scale to keep the CPU oracle cheap.
+        # Distinct non-zero values so any "kernel addressed wrong row" bug
+        # surfaces in both the forward output and the backward grads.
+        small_B = 2
+        small_max_L = 4
+        small_D = 3
+        # Sparse jagged: segment 0 has 1 row, segment 1 has 3 rows.
+        small_lengths = torch.tensor([1, 3], dtype=torch.int64)
+        small_offsets_cpu = [torch.zeros(small_B + 1, dtype=torch.int64)]
+        small_offsets_cpu[0][1:] = torch.cumsum(small_lengths, dim=0)
+        small_nnz = int(small_offsets_cpu[0][-1].item())
+        x_values_init = torch.arange(small_nnz * small_D, dtype=torch.float32).reshape(
+            small_nnz, small_D
+        )
+        y_init = (
+            torch.arange(small_B * small_max_L * small_D, dtype=torch.float32).reshape(
+                small_B, small_max_L, small_D
+            )
+            * 0.1
+        )
+
+        # CPU forward + backward.
+        x_values_cpu = x_values_init.detach().clone().requires_grad_(True)
+        y_cpu = y_init.detach().clone().requires_grad_(True)
+        output_cpu = torch.ops.fbgemm.jagged_dense_elementwise_mul(
+            x_values_cpu, small_offsets_cpu, y_cpu
+        )
+        if isinstance(output_cpu, (tuple, list)):
+            loss_cpu = output_cpu[0].sum()
+        else:
+            loss_cpu = output_cpu.sum()
+        loss_cpu.backward()
+
+        # GPU forward + backward.
+        x_values_gpu = x_values_init.detach().clone().to(device).requires_grad_(True)
+        y_gpu = y_init.detach().clone().to(device).requires_grad_(True)
+        small_offsets_gpu = [t.to(device) for t in small_offsets_cpu]
+        output_gpu = torch.ops.fbgemm.jagged_dense_elementwise_mul(
+            x_values_gpu, small_offsets_gpu, y_gpu
+        )
+        if isinstance(output_gpu, (tuple, list)):
+            loss_gpu = output_gpu[0].sum()
+        else:
+            loss_gpu = output_gpu.sum()
+        loss_gpu.backward()
+
+        # Forward jagged values must match.
+        if isinstance(output_cpu, (tuple, list)) and isinstance(
+            output_gpu, (tuple, list)
+        ):
+            torch.testing.assert_close(output_gpu[0].cpu(), output_cpu[0])
+        else:
+            torch.testing.assert_close(output_gpu.cpu(), output_cpu)
+        # pyre-ignore[16]
+        torch.testing.assert_close(x_values_gpu.grad.cpu(), x_values_cpu.grad)
+        # pyre-ignore[16]
+        torch.testing.assert_close(y_gpu.grad.cpu(), y_cpu.grad)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2896


HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA, which
silently wraps; see https://github.com/ROCm/hip/issues/2253).
`jagged_jagged_elementwise_dense_output_` (the backward of
`fbgemm.jagged_dense_elementwise_mul`) launches
`jagged_jagged_elementwise_dense_output_kernel_` with grid `blocks` and
threads computed by `check_shape_and_partition_` (`common.cuh:187`):
block.x*block.y <= 1024 with block.y = 32, and grid.x =
`div_round_up(outer_dense_size * jagged_folded_size, 32)`. Total launch
threads ~= `outer * jagged_folded * 32`; saturation at
`outer * jagged_folded >= 2^27` trips
`KernelLauncher::checkThreadCountNotExceeded` on ROCm.

The kernel grid-strides over the outer dim at line 38 (`outer_stride =
gridDim.x * blockDim.y`), so capping `blocks.x` unconditionally on ROCm at
the call site (after `check_shape_and_partition_`, before
`JAGGED_TENSOR_DISPATCH_DIMS()`) is correctness-preserving. Per the audit
plan, the cap is applied at the call site rather than inside
`check_shape_and_partition_` to keep the diff scoped to one file. Same
`#ifdef USE_ROCM` cap pattern as parent fixes D104903707 / D104937969 in
`sparse_ops/`.

Audit: /home/bensonma415/.llms/plans/jagged_and_more_rocm_grid_overflow_audit.plan.md

Reviewed By: henrylhtsang

Differential Revision: D105098094


