### PR TITLE
Fix assertion failure during snapshot reads in DRAM_SSD

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -576,9 +576,10 @@ at::Tensor KVTensorWrapper::narrow(int64_t dim, int64_t start, int64_t length) {
     CHECK_GE(
         db_->get_max_D() + db_->get_metaheader_width_in_front(), shape_[1]);
     TORCH_CHECK(
-        (snapshot_handle_ == nullptr) ==
-            (std::dynamic_pointer_cast<EmbeddingRocksDB>(db_).get() == nullptr),
-        "snapshot handler must be valid for rocksdb and nullptr for emb kvdb");
+        (snapshot_handle_ != nullptr) ==
+            (std::dynamic_pointer_cast<EmbeddingRocksDB>(db_) != nullptr ||
+             rocksdb_for_serialization_ != nullptr),
+        "snapshot handler must be valid for rocksdb (incl. DRAM_SSD) and nullptr for emb kvdb");
     if (!sorted_indices_.has_value()) {
       auto t = at::empty(c10::IntArrayRef({length, shape_[1]}), options_);
       db_->get_range_from_snapshot(
@@ -788,9 +789,10 @@ at::Tensor KVTensorWrapper::get_weights_by_ids(const at::Tensor& ids) {
       db_->get_max_D() + db_->get_metaheader_width_in_front(),
       shape_[1] + width_offset_);
   TORCH_CHECK(
-      (snapshot_handle_ == nullptr) ==
-          (std::dynamic_pointer_cast<EmbeddingRocksDB>(db_).get() == nullptr),
-      "snapshot handler must be valid for rocksdb and nullptr for emb kvdb");
+      (snapshot_handle_ != nullptr) ==
+          (std::dynamic_pointer_cast<EmbeddingRocksDB>(db_) != nullptr ||
+           rocksdb_for_serialization_ != nullptr),
+      "snapshot handler must be valid for rocksdb (incl. DRAM_SSD) and nullptr for emb kvdb");
   auto weights =
       at::empty(c10::IntArrayRef({ids.size(0), shape_[1]}), options_);
   auto linearized_ids = ids + row_offset_;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2897

Fixes an assertion failure during snapshot reads in the SSD embedding cache when using the `DRAM_SSD` composite backend. The validation logic was updated to correctly identify composite cache structures as RocksDB-backed, ensuring that snapshot handlers are appropriately required and validated.

Reviewed By: EddyLXJ

Differential Revision: D110791419


