### PR TITLE
Forward-compat sparse_type_to_int fallback for torch.package re-export version blends

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
@@ -19,7 +19,19 @@ import torch  # usort:skip
 from torch import nn, Tensor  # usort:skip
 
 from fbgemm_gpu.config import FeatureGate, FeatureGateName
-from fbgemm_gpu.split_embedding_configs import sparse_type_to_int, SparseType
+from fbgemm_gpu.split_embedding_configs import SparseType
+
+try:
+    from fbgemm_gpu.split_embedding_configs import sparse_type_to_int
+except ImportError:
+    # Forward-compat for torch.package re-export version blends: a model's frozen
+    # split_embedding_configs bundled alongside this (newer) module may predate the
+    # module-level sparse_type_to_int (extracted in D63000116). Delegate to
+    # SparseType.as_int(), which the older enum implements standalone.
+    def sparse_type_to_int(sparse_type: "SparseType") -> int:
+        return sparse_type.as_int()
+
+
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     BoundsCheckMode,
     CacheAlgorithm,


### PR DESCRIPTION
Summary:
The offline model-publish unittest `smallworld_offsite_cvr_ios_dedicated_model_gmpp_offline_model_publish_o1_unittest` has been failing since ~2026-06-10 with `ImportError: cannot import name 'IntNBitTableBatchedEmbeddingBagsCodegen'` during GMPP re-export deserialize.

Root cause: a torch.package re-export version blend inside fbgemm. The re-exported package bundles the current-trunk `split_table_batched_embeddings_ops_inference` (which since D63000116 does `from fbgemm_gpu.split_embedding_configs import sparse_type_to_int, SparseType`) next to the model's frozen, year-old `split_embedding_configs` that predates `sparse_type_to_int`, so that import raises `ImportError: cannot import name 'sparse_type_to_int'`. Because `ops_inference` is first imported inside `torchrec/distributed/types.py`'s `try/except ImportError` (via `from fbgemm_gpu.tbe.ssd import KVZCHTBEConfig` -> `tbe/ssd/__init__` eager `.inference` -> `ops_inference`), the error is swallowed and the half-initialized `ops_inference` is left cached in the `PackageImporter` (torch.package does not evict partial modules on a failed import). A later `torchrec/distributed/embedding_lookup.py` doing `from ...ops_inference import IntNBitTableBatchedEmbeddingBagsCodegen` then finds that poisoned partial and fails, which is the visible error.

Fix: import `sparse_type_to_int` defensively in `ops_inference` and fall back to `SparseType.as_int()` (which the older enum implements standalone) when it is absent, so `ops_inference` finishes initializing regardless of the bundled `split_embedding_configs` version and no poisoned partial is cached.

Reviewed By: henrylhtsang

Differential Revision: D110788115


