### PR TITLE
Add opt-in whole-run multi-stream timing (#5988)

### DIFF
--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -10,11 +10,130 @@ import copy
 import logging
 import threading
 import time
+from typing import Any, List
 
 import torch
 
 logger: logging.Logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
+
+
+def _multi_stream_legacy_timing(
+    # pyre-fixme[2]: Parameter must be annotated.
+    f_list: List[Any],
+    # pyre-fixme[2]: Parameter must be annotated.
+    args: Any,
+    num_threads: int,
+    per_thread_iters: int,
+    iters: int,
+    flush_gpu_cache_size_mb: int,
+    device: str,
+    name: str,
+) -> float:
+    """Legacy event-amortized multi-stream timing path."""
+    cache = torch.empty(
+        int(flush_gpu_cache_size_mb * 1024 * 1024 // 4),
+        dtype=torch.float,
+        device=device,
+    )
+    duration_ms_list: list[float] = []
+
+    @torch.inference_mode()
+    # pyre-ignore[53]
+    def forward(idx: int) -> None:
+        stream = torch.cuda.Stream()
+        f_temp = f_list[idx]
+        start_event = [
+            torch.cuda.Event(enable_timing=True) for i in range(per_thread_iters)
+        ]
+        end_event = [
+            torch.cuda.Event(enable_timing=True) for i in range(per_thread_iters)
+        ]
+        torch.cuda.synchronize(device)
+        with torch.cuda.stream(stream):
+            for i in range(per_thread_iters):
+                if flush_gpu_cache_size_mb:
+                    cache.zero_()
+                start_event[i].record()
+                with torch.cuda.nvtx.range(f"RunCudaModule_{name}"):
+                    _ = f_temp(*args)
+                end_event[i].record()
+            torch.cuda.synchronize(device)
+            times = torch.tensor(
+                [s.elapsed_time(e) for s, e in zip(start_event, end_event)]
+            )
+            duration_ms_list.append(torch.sum(times).item())
+
+    threads = [
+        threading.Thread(target=forward, args=(idx,)) for idx in range(num_threads)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    return sum(duration_ms_list) * 1.0e-3 / num_threads / iters
+
+
+def _multi_stream_wall_clock_timing(
+    # pyre-fixme[2]: Parameter must be annotated.
+    f_list: List[Any],
+    # pyre-fixme[2]: Parameter must be annotated.
+    args: Any,
+    num_threads: int,
+    per_thread_iters: int,
+    num_warmups: int,
+    flush_gpu_cache_size_mb: int,
+    device: str,
+    name: str,
+) -> float:
+    """Wall-clock multi-stream timing with per-stream warmup."""
+    start_barrier = threading.Barrier(num_threads + 1)
+
+    @torch.inference_mode()
+    # pyre-ignore[53]
+    def forward(idx: int) -> None:
+        stream = torch.cuda.Stream()
+        f_temp = f_list[idx]
+        # Citrine C3: allocate the flush buffer directly on device.
+        # Per-stream (not shared) to avoid cross-stream contention.
+        cache = (
+            torch.empty(
+                int(flush_gpu_cache_size_mb * 1024 * 1024 // 4),
+                dtype=torch.float,
+                device=device,
+            )
+            if flush_gpu_cache_size_mb
+            else None
+        )
+        with torch.cuda.stream(stream):
+            for _ in range(num_warmups):
+                _ = f_temp(*args)
+            stream.synchronize()
+        start_barrier.wait()
+        with torch.cuda.stream(stream):
+            for _ in range(per_thread_iters):
+                if cache is not None:
+                    cache.zero_()
+                with torch.cuda.nvtx.range(f"RunCudaModule_{name}"):
+                    _ = f_temp(*args)
+            stream.synchronize()
+
+    threads = [
+        threading.Thread(target=forward, args=(idx,)) for idx in range(num_threads)
+    ]
+    for thread in threads:
+        thread.start()
+    # Set the start AFTER workers reach the barrier (post-warmup) so the
+    # timed window excludes warmup; the barrier release is the t0.
+    start_barrier.wait()
+    start_time = time.perf_counter()
+    for thread in threads:
+        thread.join()
+    torch.cuda.synchronize(device)
+    wall_s = time.perf_counter() - start_time
+    # Achieved concurrent throughput as per-iter wall time: caller's
+    # batch/elapsed = (per_thread_iters*num_threads*batch)/wall.
+    return wall_s / (per_thread_iters * num_threads)
 
 
 def benchmark_torch_function(  # noqa: C901
@@ -31,6 +150,7 @@ def benchmark_torch_function(  # noqa: C901
     name: str = "",
     num_threads: int = 1,
     copy_f_for_multi_thread_test: bool = False,
+    legacy_multi_stream_timing: bool = False,
 ) -> tuple[float, torch.Tensor]:
     logging.debug(f"Start to benchmark {name}...")
     if device != "cpu" and device != "" and device != "cuda":
@@ -62,56 +182,49 @@ def benchmark_torch_function(  # noqa: C901
         )
         elapsed_time = torch.mean(times).item() * 1.0e-3
     elif device != "cpu" and torch.cuda.is_available() and (num_threads > 1):
-        cache = torch.empty(
-            int(flush_gpu_cache_size_mb * 1024 * 1024 // 4),
-            dtype=torch.float,
-            device=device,
-        )
-        duration_ms_list: list[float] = []
+        # Multi-stream throughput. Each thread runs its own non-default stream.
+        # Defaults are tuned for stable cross-run measurement:
+        #  (1) warm up EACH stream before timing -- the timed iters run on
+        #      non-default streams, so the default-stream warmup above leaves
+        #      cold first-iters that inflate and destabilize the result; and
+        #  (2) time the whole concurrent run with a single wall clock + one
+        #      final sync, reporting achieved throughput as per-iter wall time
+        #      (wall / total_iters). The older approach summed each stream's
+        #      per-iter CUDA-event times and divided by num_threads, which
+        #      reconstructs throughput under an idealized-overlap assumption
+        #      that fluctuates run-to-run (large T=2 variance). Set
+        #      legacy_multi_stream_timing=True to restore it.
+        # The returned value keeps the same "seconds per iter" contract either
+        # way, so callers computing batch/elapsed are unaffected.
+        per_thread_iters = max(1, iters // num_threads)
 
         f_list = [f]
         # make deepcopy of f if necessary
         for _ in range(num_threads - 1):
             f_list.append(copy.deepcopy(f) if copy_f_for_multi_thread_test else f)
 
-        @torch.inference_mode()
-        # pyre-ignore[53]
-        def forward(idx: int) -> None:
-            stream = torch.cuda.Stream()
-            f_temp = f_list[idx]
-            start_event = [
-                torch.cuda.Event(enable_timing=True)
-                for i in range(iters // num_threads)
-            ]
-            end_event = [
-                torch.cuda.Event(enable_timing=True)
-                for i in range(iters // num_threads)
-            ]
-            torch.cuda.synchronize(device)
-            with torch.cuda.stream(stream):
-                for i in range(iters // num_threads):
-                    # flush the cache
-                    if flush_gpu_cache_size_mb:
-                        cache.zero_()
-                    start_event[i].record()
-                    with torch.cuda.nvtx.range(f"RunCudaModule_{name}"):
-                        _ = f_temp(*args)
-                    end_event[i].record()
-                torch.cuda.synchronize(device)
-                times = torch.tensor(
-                    [s.elapsed_time(e) for s, e in zip(start_event, end_event)]
-                )
-                duration_ms = torch.sum(times).item()
-                duration_ms_list.append(duration_ms)
-
-        threads = [
-            threading.Thread(target=forward, args=(idx,)) for idx in range(num_threads)
-        ]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
-        elapsed_time = sum(duration_ms_list) * 1.0e-3 / num_threads / iters
+        if legacy_multi_stream_timing:
+            elapsed_time = _multi_stream_legacy_timing(
+                f_list=f_list,
+                args=args,
+                num_threads=num_threads,
+                per_thread_iters=per_thread_iters,
+                iters=iters,
+                flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
+                device=device,
+                name=name,
+            )
+        else:
+            elapsed_time = _multi_stream_wall_clock_timing(
+                f_list=f_list,
+                args=args,
+                num_threads=num_threads,
+                per_thread_iters=per_thread_iters,
+                num_warmups=num_warmups,
+                flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
+                device=device,
+                name=name,
+            )
 
         torch.cuda.synchronize(device)
         if copy_f_for_multi_thread_test:

--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -6,10 +6,15 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 import copy
 import logging
+import queue
 import threading
 import time
+from functools import partial
+from typing import Any, TypedDict
 
 import torch
 
@@ -17,7 +22,499 @@ logger: logging.Logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-def benchmark_torch_function(  # noqa: C901
+class BenchmarkWorkerDiagnostics(TypedDict):
+    stream_handle: int
+    device_span_ms: float
+
+
+class BenchmarkDiagnostics(TypedDict, total=False):
+    timing_method: str
+    uses_provided_streams: bool
+    per_thread_iters: int
+    wall_s: float
+    workers: list[BenchmarkWorkerDiagnostics]
+    max_device_span_ms: float
+    min_device_span_ms: float
+    event_mean_ms: float
+    device_span_ms: float
+
+
+def _multi_stream_event_amortized_timing(
+    # pyre-fixme[2]: Parameter must be annotated.
+    f_list: list[Any],
+    # pyre-fixme[2]: Parameter must be annotated.
+    args: Any,
+    num_threads: int,
+    per_thread_iters: int,
+    iters: int,
+    flush_gpu_cache_size_mb: int,
+    device: str,
+    name: str,
+) -> float:
+    """Estimate concurrent throughput from per-call device event durations."""
+    cache = torch.empty(
+        int(flush_gpu_cache_size_mb * 1024 * 1024 // 4),
+        dtype=torch.float,
+        device=device,
+    )
+    duration_ms_list: list[float] = []
+
+    @torch.inference_mode()
+    # pyre-ignore[53]
+    def forward(idx: int) -> None:
+        stream = torch.cuda.Stream()
+        f_temp = f_list[idx]
+        start_event = [
+            torch.cuda.Event(enable_timing=True) for i in range(per_thread_iters)
+        ]
+        end_event = [
+            torch.cuda.Event(enable_timing=True) for i in range(per_thread_iters)
+        ]
+        torch.cuda.synchronize(device)
+        with torch.cuda.stream(stream):
+            for i in range(per_thread_iters):
+                if flush_gpu_cache_size_mb:
+                    cache.zero_()
+                start_event[i].record()
+                with torch.cuda.nvtx.range(f"RunCudaModule_{name}"):
+                    _ = f_temp(*args)
+                end_event[i].record()
+            torch.cuda.synchronize(device)
+            times = torch.tensor(
+                [s.elapsed_time(e) for s, e in zip(start_event, end_event)]
+            )
+            duration_ms_list.append(torch.sum(times).item())
+
+    threads = [
+        threading.Thread(target=forward, args=(idx,)) for idx in range(num_threads)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    return sum(duration_ms_list) * 1.0e-3 / num_threads / iters
+
+
+def _run_wall_clock_worker(
+    f: Any,
+    args: Any,
+    kwargs: Any,
+    stream: Any,
+    start_barrier: threading.Barrier,
+    per_thread_iters: int,
+    num_warmups: int,
+    flush_gpu_cache_size_mb: int,
+    device: str,
+    name: str,
+    collect_diagnostics: bool,
+) -> tuple[Any, BenchmarkWorkerDiagnostics | None]:
+    torch.cuda.set_device(stream.device)
+    span_start = torch.cuda.Event(enable_timing=True) if collect_diagnostics else None
+    span_end = torch.cuda.Event(enable_timing=True) if collect_diagnostics else None
+    # Citrine C3: allocate the flush buffer directly on device.
+    cache = (
+        torch.empty(
+            int(flush_gpu_cache_size_mb * 1024 * 1024 // 4),
+            dtype=torch.float,
+            device=device,
+        )
+        if flush_gpu_cache_size_mb
+        else None
+    )
+    output = None
+    with torch.cuda.stream(stream):
+        for _ in range(num_warmups):
+            output = f(*args, **kwargs)
+        if cache is not None:
+            cache.zero_()
+        stream.synchronize()
+
+    start_barrier.wait()
+    with torch.cuda.stream(stream):
+        if span_start is not None:
+            span_start.record()
+        for _ in range(per_thread_iters):
+            with torch.cuda.nvtx.range(f"RunCudaModule_{name}"):
+                output = f(*args, **kwargs)
+        if span_end is not None:
+            span_end.record()
+        stream.synchronize()
+
+    if span_start is None or span_end is None:
+        return output, None
+    return output, {
+        "stream_handle": int(stream.cuda_stream),
+        "device_span_ms": span_start.elapsed_time(span_end),
+    }
+
+
+def _record_wall_clock_diagnostics(
+    diagnostics: BenchmarkDiagnostics,
+    worker_diagnostics: list[BenchmarkWorkerDiagnostics | None],
+    streams_provided: bool,
+    per_thread_iters: int,
+    wall_s: float,
+) -> None:
+    workers = [record for record in worker_diagnostics if record is not None]
+    diagnostics.update(
+        {
+            "timing_method": "multi_stream_wall_clock",
+            "uses_provided_streams": streams_provided,
+            "per_thread_iters": per_thread_iters,
+            "wall_s": wall_s,
+            "workers": workers,
+        }
+    )
+    if not workers:
+        return
+    device_spans_ms = [float(record["device_span_ms"]) for record in workers]
+    diagnostics.update(
+        {
+            "max_device_span_ms": max(device_spans_ms),
+            "min_device_span_ms": min(device_spans_ms),
+        }
+    )
+
+
+def _prepare_wall_clock_streams(
+    streams: list[Any] | None,
+    num_threads: int,
+    device: str,
+) -> list[Any]:
+    stream_list = (
+        streams
+        if streams is not None
+        else [torch.cuda.Stream() for _ in range(num_threads)]
+    )
+    caller_stream = torch.cuda.current_stream(device)
+    for stream in stream_list:
+        stream.wait_stream(caller_stream)
+    return stream_list
+
+
+@torch.inference_mode()
+# pyre-ignore[53]
+def _run_wall_clock_worker_safely(
+    idx: int,
+    f_list: list[Any],
+    args: Any,
+    kwargs: Any,
+    stream_list: list[Any],
+    start_barrier: threading.Barrier,
+    per_thread_iters: int,
+    num_warmups: int,
+    flush_gpu_cache_size_mb: int,
+    device: str,
+    name: str,
+    collect_diagnostics: bool,
+    worker_outputs: list[Any],
+    worker_diagnostics: list[BenchmarkWorkerDiagnostics | None],
+    worker_errors: queue.SimpleQueue[Exception],
+) -> None:
+    try:
+        output, worker_diagnostic = _run_wall_clock_worker(
+            f=f_list[idx],
+            args=args,
+            kwargs=kwargs,
+            stream=stream_list[idx],
+            start_barrier=start_barrier,
+            per_thread_iters=per_thread_iters,
+            num_warmups=num_warmups,
+            flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
+            device=device,
+            name=name,
+            collect_diagnostics=collect_diagnostics,
+        )
+        worker_outputs[idx] = output
+        worker_diagnostics[idx] = worker_diagnostic
+    except Exception as error:
+        worker_errors.put(error)
+        start_barrier.abort()
+
+
+def _execute_wall_clock_workers(
+    f_list: list[Any],
+    args: Any,
+    kwargs: Any,
+    stream_list: list[Any],
+    start_barrier: threading.Barrier,
+    per_thread_iters: int,
+    num_warmups: int,
+    flush_gpu_cache_size_mb: int,
+    device: str,
+    name: str,
+    collect_diagnostics: bool,
+    worker_outputs: list[Any],
+    worker_diagnostics: list[BenchmarkWorkerDiagnostics | None],
+    worker_errors: queue.SimpleQueue[Exception],
+) -> None:
+    worker = partial(
+        _run_wall_clock_worker_safely,
+        f_list=f_list,
+        args=args,
+        kwargs=kwargs,
+        stream_list=stream_list,
+        start_barrier=start_barrier,
+        per_thread_iters=per_thread_iters,
+        num_warmups=num_warmups,
+        flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
+        device=device,
+        name=name,
+        collect_diagnostics=collect_diagnostics,
+        worker_outputs=worker_outputs,
+        worker_diagnostics=worker_diagnostics,
+        worker_errors=worker_errors,
+    )
+    threads = [
+        threading.Thread(target=worker, args=(idx,)) for idx in range(len(f_list))
+    ]
+    for thread in threads:
+        thread.start()
+    try:
+        start_barrier.wait()
+    except threading.BrokenBarrierError:
+        for thread in threads:
+            thread.join()
+        if not worker_errors.empty():
+            raise worker_errors.get()
+        raise
+    for thread in threads:
+        thread.join()
+    if not worker_errors.empty():
+        raise worker_errors.get()
+
+
+def _multi_stream_wall_clock_timing(
+    # pyre-fixme[2]: Parameter must be annotated.
+    f_list: list[Any],
+    # pyre-fixme[2]: Parameter must be annotated.
+    args: Any,
+    # pyre-fixme[2]: Parameter must be annotated.
+    kwargs: Any,
+    num_threads: int,
+    per_thread_iters: int,
+    num_warmups: int,
+    flush_gpu_cache_size_mb: int,
+    device: str,
+    name: str,
+    diagnostics: BenchmarkDiagnostics | None,
+    streams: list[Any] | None,
+) -> tuple[float, Any]:
+    """Wall-clock multi-stream timing with per-stream warmup."""
+    stream_list = _prepare_wall_clock_streams(
+        streams,
+        num_threads,
+        device,
+    )
+    start_time_ns: list[int] = []
+    start_barrier = threading.Barrier(
+        num_threads + 1,
+        action=lambda: start_time_ns.append(time.perf_counter_ns()),
+    )
+    worker_diagnostics: list[BenchmarkWorkerDiagnostics | None] = [
+        None for _ in range(num_threads)
+    ]
+    worker_outputs: list[Any] = [None for _ in range(num_threads)]
+    worker_errors: queue.SimpleQueue[Exception] = queue.SimpleQueue()
+
+    # Prime lazy runtime initialization on a measured stream so affinity-based
+    # runtime pools never observe an extra default-stream key.
+    with torch.inference_mode(), torch.cuda.stream(stream_list[0]):
+        worker_outputs[0] = f_list[0](*args, **kwargs)
+        stream_list[0].synchronize()
+
+    _execute_wall_clock_workers(
+        f_list=f_list,
+        args=args,
+        kwargs=kwargs,
+        stream_list=stream_list,
+        start_barrier=start_barrier,
+        per_thread_iters=per_thread_iters,
+        num_warmups=num_warmups,
+        flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
+        device=device,
+        name=name,
+        collect_diagnostics=diagnostics is not None,
+        worker_outputs=worker_outputs,
+        worker_diagnostics=worker_diagnostics,
+        worker_errors=worker_errors,
+    )
+    torch.cuda.synchronize(device)
+    end_time_ns = time.perf_counter_ns()
+    wall_s = (end_time_ns - start_time_ns[0]) * 1.0e-9
+    if diagnostics is not None:
+        _record_wall_clock_diagnostics(
+            diagnostics,
+            worker_diagnostics,
+            streams is not None,
+            per_thread_iters,
+            wall_s,
+        )
+    return wall_s / (per_thread_iters * num_threads), worker_outputs[0]
+
+
+def _validate_benchmark_inputs(
+    num_threads: int,
+    num_warmups: int,
+    wall_clock_multi_stream_timing: bool,
+    streams: list[Any] | None,
+) -> None:
+    assert num_threads > 0
+    if (
+        wall_clock_multi_stream_timing
+        and (num_threads > 1 or streams is not None)
+        and num_warmups < 1
+    ):
+        raise ValueError("wall-clock multi-stream timing requires num_warmups >= 1")
+    if streams is None:
+        return
+    if len(streams) != num_threads:
+        raise ValueError(f"Expected {num_threads} streams, received {len(streams)}")
+    if not wall_clock_multi_stream_timing:
+        raise ValueError("Provided streams require wall-clock timing")
+
+
+def _warm_up(
+    f: Any,
+    args: Any,
+    kwargs: Any,
+    num_warmups: int,
+) -> Any:
+    output = None
+    for _ in range(num_warmups):
+        output = f(*args, **kwargs)
+    return output
+
+
+def _single_stream_event_timing(
+    f: Any,
+    args: Any,
+    flush_gpu_cache_size_mb: int,
+    iters: int,
+    device: str,
+    name: str,
+    diagnostics: BenchmarkDiagnostics | None,
+) -> tuple[float, Any]:
+    cache = torch.empty(
+        int(flush_gpu_cache_size_mb * 1024 * 1024 // 4),
+        dtype=torch.float,
+        device=device,
+    )
+    start_event = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    end_event = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    torch.cuda.synchronize(device)
+    diagnostic_start_ns = time.perf_counter_ns()
+    output = None
+    for i in range(iters):
+        if flush_gpu_cache_size_mb:
+            cache.zero_()
+        start_event[i].record()
+        with torch.cuda.nvtx.range(f"RunCudaModule_{name}"):
+            output = f(*args)
+        end_event[i].record()
+    torch.cuda.synchronize(device)
+    diagnostic_end_ns = time.perf_counter_ns()
+    times = torch.tensor(
+        [start.elapsed_time(end) for start, end in zip(start_event, end_event)]
+    )
+    elapsed_time = torch.mean(times).item() * 1.0e-3
+    if diagnostics is not None:
+        diagnostics.update(
+            {
+                "timing_method": "single_stream_events",
+                "per_thread_iters": iters,
+                "wall_s": (diagnostic_end_ns - diagnostic_start_ns) * 1.0e-9,
+                "event_mean_ms": elapsed_time * 1.0e3,
+                "device_span_ms": start_event[0].elapsed_time(end_event[-1]),
+            }
+        )
+    return elapsed_time, output
+
+
+def _multi_stream_timing(
+    f: Any,
+    args: Any,
+    kwargs: Any,
+    output: Any,
+    flush_gpu_cache_size_mb: int,
+    iters: int,
+    num_warmups: int,
+    device: str,
+    name: str,
+    num_threads: int,
+    copy_f_for_multi_thread_test: bool,
+    wall_clock_multi_stream_timing: bool,
+    diagnostics: BenchmarkDiagnostics | None,
+    streams: list[Any] | None,
+) -> tuple[float, Any]:
+    if wall_clock_multi_stream_timing and (
+        iters < num_threads or iters % num_threads != 0
+    ):
+        raise ValueError(
+            f"iters ({iters}) must be a positive multiple of "
+            f"num_threads ({num_threads})"
+        )
+    per_thread_iters = iters // num_threads
+    f_list = [f]
+    for _ in range(num_threads - 1):
+        f_list.append(copy.deepcopy(f) if copy_f_for_multi_thread_test else f)
+
+    if wall_clock_multi_stream_timing:
+        elapsed_time, output = _multi_stream_wall_clock_timing(
+            f_list=f_list,
+            args=args,
+            kwargs=kwargs,
+            num_threads=num_threads,
+            per_thread_iters=per_thread_iters,
+            num_warmups=num_warmups,
+            flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
+            device=device,
+            name=name,
+            diagnostics=diagnostics,
+            streams=streams,
+        )
+    else:
+        elapsed_time = _multi_stream_event_amortized_timing(
+            f_list=f_list,
+            args=args,
+            num_threads=num_threads,
+            per_thread_iters=per_thread_iters,
+            iters=iters,
+            flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
+            device=device,
+            name=name,
+        )
+        if diagnostics is not None:
+            diagnostics["timing_method"] = "multi_stream_event_amortized"
+
+    torch.cuda.synchronize(device)
+    if copy_f_for_multi_thread_test:
+        for idx in reversed(range(num_threads - 1)):
+            del f_list[idx + 1]
+    torch.cuda.empty_cache()
+    return elapsed_time, output
+
+
+def _cpu_timing(
+    f: Any,
+    args: Any,
+    kwargs: Any,
+    iters: int,
+    name: str,
+) -> tuple[float, Any]:
+    use_nvtx = torch.cuda.is_available()
+    start_time = time.time()
+    output = None
+    for _ in range(iters):
+        if use_nvtx:
+            with torch.cuda.nvtx.range(f"RunCPUModule_{name}"):
+                output = f(*args, **kwargs)
+        else:
+            output = f(*args, **kwargs)
+    return (time.time() - start_time) / iters, output
+
+
+def benchmark_torch_function(
     # pyre-fixme[2]: Parameter must be annotated.
     f,
     # pyre-fixme[2]: Parameter must be annotated.
@@ -31,105 +528,60 @@ def benchmark_torch_function(  # noqa: C901
     name: str = "",
     num_threads: int = 1,
     copy_f_for_multi_thread_test: bool = False,
+    wall_clock_multi_stream_timing: bool = False,
+    diagnostics: BenchmarkDiagnostics | None = None,
+    streams: list[Any] | None = None,
 ) -> tuple[float, torch.Tensor]:
     logging.debug(f"Start to benchmark {name}...")
     if device != "cpu" and device != "" and device != "cuda":
         torch.cuda.set_device(device)
-    for _ in range(num_warmups):
-        output = f(*args, **kwargs)
+    _validate_benchmark_inputs(
+        num_threads,
+        num_warmups,
+        wall_clock_multi_stream_timing,
+        streams,
+    )
+    is_cuda_benchmark = device != "cpu" and torch.cuda.is_available()
+    is_multi_stream_benchmark = num_threads > 1 or streams is not None
+    uses_wall_clock_multi_stream_timing = (
+        is_cuda_benchmark
+        and is_multi_stream_benchmark
+        and wall_clock_multi_stream_timing
+    )
+    output = (
+        None
+        if uses_wall_clock_multi_stream_timing
+        else _warm_up(f, args, kwargs, num_warmups)
+    )
 
-    assert num_threads > 0
-    if device != "cpu" and torch.cuda.is_available() and (num_threads == 1):
-        cache = torch.empty(
-            int(flush_gpu_cache_size_mb * 1024 * 1024 // 4),
-            dtype=torch.float,
-            device=device,
+    if not is_cuda_benchmark:
+        elapsed_time, output = _cpu_timing(f, args, kwargs, iters, name)
+    elif not is_multi_stream_benchmark:
+        elapsed_time, output = _single_stream_event_timing(
+            f,
+            args,
+            flush_gpu_cache_size_mb,
+            iters,
+            device,
+            name,
+            diagnostics,
         )
-        start_event = [torch.cuda.Event(enable_timing=True) for i in range(iters)]
-        end_event = [torch.cuda.Event(enable_timing=True) for i in range(iters)]
-        torch.cuda.synchronize(device)
-        for i in range(iters):
-            # flush the cache
-            if flush_gpu_cache_size_mb:
-                cache.zero_()
-            start_event[i].record()
-            with torch.cuda.nvtx.range(f"RunCudaModule_{name}"):
-                output = f(*args)
-            end_event[i].record()
-        torch.cuda.synchronize(device)
-        times = torch.tensor(
-            [s.elapsed_time(e) for s, e in zip(start_event, end_event)]
-        )
-        elapsed_time = torch.mean(times).item() * 1.0e-3
-    elif device != "cpu" and torch.cuda.is_available() and (num_threads > 1):
-        cache = torch.empty(
-            int(flush_gpu_cache_size_mb * 1024 * 1024 // 4),
-            dtype=torch.float,
-            device=device,
-        )
-        duration_ms_list: list[float] = []
-
-        f_list = [f]
-        # make deepcopy of f if necessary
-        for _ in range(num_threads - 1):
-            f_list.append(copy.deepcopy(f) if copy_f_for_multi_thread_test else f)
-
-        @torch.inference_mode()
-        # pyre-ignore[53]
-        def forward(idx: int) -> None:
-            stream = torch.cuda.Stream()
-            f_temp = f_list[idx]
-            start_event = [
-                torch.cuda.Event(enable_timing=True)
-                for i in range(iters // num_threads)
-            ]
-            end_event = [
-                torch.cuda.Event(enable_timing=True)
-                for i in range(iters // num_threads)
-            ]
-            torch.cuda.synchronize(device)
-            with torch.cuda.stream(stream):
-                for i in range(iters // num_threads):
-                    # flush the cache
-                    if flush_gpu_cache_size_mb:
-                        cache.zero_()
-                    start_event[i].record()
-                    with torch.cuda.nvtx.range(f"RunCudaModule_{name}"):
-                        _ = f_temp(*args)
-                    end_event[i].record()
-                torch.cuda.synchronize(device)
-                times = torch.tensor(
-                    [s.elapsed_time(e) for s, e in zip(start_event, end_event)]
-                )
-                duration_ms = torch.sum(times).item()
-                duration_ms_list.append(duration_ms)
-
-        threads = [
-            threading.Thread(target=forward, args=(idx,)) for idx in range(num_threads)
-        ]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
-        elapsed_time = sum(duration_ms_list) * 1.0e-3 / num_threads / iters
-
-        torch.cuda.synchronize(device)
-        if copy_f_for_multi_thread_test:
-            # clean the copies of f and clean the HBM cache
-            for idx in reversed(range(num_threads - 1)):
-                del f_list[idx + 1]
-        torch.cuda.empty_cache()
-
     else:
-        use_nvtx = torch.cuda.is_available()
-        start_time = time.time()
-        for _ in range(iters):
-            if use_nvtx:
-                with torch.cuda.nvtx.range(f"RunCPUModule_{name}"):
-                    output = f(*args)
-            else:
-                output = f(*args)
-        elapsed_time = (time.time() - start_time) / iters
+        elapsed_time, output = _multi_stream_timing(
+            f,
+            args,
+            kwargs,
+            output,
+            flush_gpu_cache_size_mb,
+            iters,
+            num_warmups,
+            device,
+            name,
+            num_threads,
+            copy_f_for_multi_thread_test,
+            wall_clock_multi_stream_timing,
+            diagnostics,
+            streams,
+        )
 
-    # pyre-fixme[61]: `output` is undefined, or not always defined.
     return float(elapsed_time), output

--- a/fbgemm_gpu/test/bench_utils_test.py
+++ b/fbgemm_gpu/test/bench_utils_test.py
@@ -1,0 +1,75 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import math
+import unittest
+
+import torch
+from fbgemm_gpu.bench.bench_utils import benchmark_torch_function
+
+
+def _mm(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    return torch.mm(a, b)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class BenchUtilsTest(unittest.TestCase):
+    def _operands(self) -> tuple[torch.Tensor, torch.Tensor]:
+        # Citrine C3: allocate directly on the current accelerator (portable
+        # across cuda/rocm/mtia rather than hardcoding "cuda").
+        dev = torch.accelerator.current_accelerator()
+        a = torch.randn(512, 512, device=dev)
+        b = torch.randn(512, 512, device=dev)
+        return a, b
+
+    def _assert_sane_per_iter(self, elapsed: float) -> None:
+        # Returned value is seconds-per-iteration for both single- and
+        # multi-stream paths (the contract callers rely on for batch/elapsed).
+        self.assertTrue(math.isfinite(elapsed))
+        self.assertGreater(elapsed, 0.0)
+        self.assertLess(elapsed, 1.0)  # a 512x512 mm is well under 1s/iter
+
+    def test_single_thread(self) -> None:
+        a, b = self._operands()
+        elapsed, _ = benchmark_torch_function(
+            _mm, (a, b), iters=20, num_warmups=5, device="cuda", num_threads=1
+        )
+        self._assert_sane_per_iter(elapsed)
+
+    def test_multi_stream_default(self) -> None:
+        # New default: per-stream warmup + wall-clock throughput.
+        a, b = self._operands()
+        elapsed, _ = benchmark_torch_function(
+            _mm, (a, b), iters=40, num_warmups=5, device="cuda", num_threads=2
+        )
+        self._assert_sane_per_iter(elapsed)
+
+    def test_multi_stream_legacy_still_supported(self) -> None:
+        # Legacy event-amortized path preserves the same per-iter contract.
+        a, b = self._operands()
+        elapsed_default, _ = benchmark_torch_function(
+            _mm, (a, b), iters=40, num_warmups=5, device="cuda", num_threads=2
+        )
+        elapsed_legacy, _ = benchmark_torch_function(
+            _mm,
+            (a, b),
+            iters=40,
+            num_warmups=5,
+            device="cuda",
+            num_threads=2,
+            legacy_multi_stream_timing=True,
+        )
+        self._assert_sane_per_iter(elapsed_legacy)
+        # Both measure per-iter time for identical work; they should agree to
+        # within an order of magnitude (sanity that neither path is broken).
+        self.assertLess(elapsed_default / elapsed_legacy, 10.0)
+        self.assertLess(elapsed_legacy / elapsed_default, 10.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/fbgemm_gpu/test/bench_utils_test.py
+++ b/fbgemm_gpu/test/bench_utils_test.py
@@ -1,0 +1,376 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+import torch
+from fbgemm_gpu.bench.bench_utils import benchmark_torch_function, BenchmarkDiagnostics
+
+
+def _mm(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    return torch.mm(a, b)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class BenchUtilsTest(unittest.TestCase):
+    def _operands(self) -> tuple[torch.Tensor, torch.Tensor]:
+        # Citrine C3: allocate directly on device.
+        a = torch.randn(512, 512, device=torch.accelerator.current_accelerator())
+        b = torch.randn(512, 512, device=torch.accelerator.current_accelerator())
+        return a, b
+
+    def _assert_sane_per_iter(self, elapsed: float) -> None:
+        # Returned value is seconds-per-iteration for both single- and
+        # multi-stream paths (the contract callers rely on for batch/elapsed).
+        self.assertTrue(math.isfinite(elapsed))
+        self.assertGreater(elapsed, 0.0)
+        self.assertLess(elapsed, 1.0)  # a 512x512 mm is well under 1s/iter
+
+    def test_single_thread(self) -> None:
+        a, b = self._operands()
+        diagnostics: BenchmarkDiagnostics = {}
+        elapsed, _ = benchmark_torch_function(
+            _mm,
+            (a, b),
+            iters=20,
+            num_warmups=5,
+            device="cuda",
+            num_threads=1,
+            diagnostics=diagnostics,
+        )
+        self._assert_sane_per_iter(elapsed)
+        self.assertEqual("single_stream_events", diagnostics["timing_method"])
+        self.assertGreater(float(diagnostics["device_span_ms"]), 0.0)
+
+    def test_multi_stream_wall_clock(self) -> None:
+        a, b = self._operands()
+        diagnostics: BenchmarkDiagnostics = {}
+        call_count = 0
+        observed_stream_handles: set[int] = set()
+        call_lock = threading.Lock()
+
+        def counted_mm(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            nonlocal call_count
+            with call_lock:
+                call_count += 1
+                observed_stream_handles.add(torch.cuda.current_stream().cuda_stream)
+            return torch.mm(a, b)
+
+        elapsed, _ = benchmark_torch_function(
+            counted_mm,
+            (a, b),
+            iters=40,
+            num_warmups=5,
+            device="cuda",
+            num_threads=2,
+            wall_clock_multi_stream_timing=True,
+            diagnostics=diagnostics,
+        )
+        self._assert_sane_per_iter(elapsed)
+        self.assertEqual("multi_stream_wall_clock", diagnostics["timing_method"])
+        workers = diagnostics["workers"]
+        self.assertEqual(2, len(workers))
+        self.assertGreater(float(diagnostics["max_device_span_ms"]), 0.0)
+        self.assertEqual(51, call_count)
+        self.assertEqual(
+            {int(worker["stream_handle"]) for worker in workers},
+            observed_stream_handles,
+        )
+
+    def test_multi_stream_provided_streams(self) -> None:
+        a, b = self._operands()
+        streams = [torch.cuda.Stream(), torch.cuda.Stream()]
+        expected_handles = {stream.cuda_stream for stream in streams}
+
+        for _ in range(2):
+            diagnostics: BenchmarkDiagnostics = {}
+            elapsed, _ = benchmark_torch_function(
+                _mm,
+                (a, b),
+                iters=40,
+                num_warmups=5,
+                device="cuda",
+                num_threads=2,
+                wall_clock_multi_stream_timing=True,
+                diagnostics=diagnostics,
+                streams=streams,
+            )
+            self._assert_sane_per_iter(elapsed)
+            self.assertTrue(bool(diagnostics["uses_provided_streams"]))
+            workers = diagnostics["workers"]
+            self.assertEqual(
+                expected_handles,
+                {int(worker["stream_handle"]) for worker in workers},
+            )
+
+    def test_single_provided_stream_uses_wall_clock(self) -> None:
+        a, b = self._operands()
+        stream = torch.cuda.Stream()
+        diagnostics: BenchmarkDiagnostics = {}
+        elapsed, _ = benchmark_torch_function(
+            _mm,
+            (a, b),
+            iters=20,
+            num_warmups=5,
+            device="cuda",
+            num_threads=1,
+            wall_clock_multi_stream_timing=True,
+            diagnostics=diagnostics,
+            streams=[stream],
+        )
+        self._assert_sane_per_iter(elapsed)
+        self.assertEqual("multi_stream_wall_clock", diagnostics["timing_method"])
+        workers = diagnostics["workers"]
+        self.assertEqual(1, len(workers))
+        self.assertEqual(stream.cuda_stream, int(workers[0]["stream_handle"]))
+
+    def test_multi_stream_wall_clock_is_opt_in(self) -> None:
+        a, b = self._operands()
+        default_diagnostics: BenchmarkDiagnostics = {}
+        elapsed_default, _ = benchmark_torch_function(
+            _mm,
+            (a, b),
+            iters=40,
+            num_warmups=5,
+            device="cuda",
+            num_threads=2,
+            diagnostics=default_diagnostics,
+        )
+        wall_clock_diagnostics: BenchmarkDiagnostics = {}
+        elapsed_wall_clock, _ = benchmark_torch_function(
+            _mm,
+            (a, b),
+            iters=40,
+            num_warmups=5,
+            device="cuda",
+            num_threads=2,
+            wall_clock_multi_stream_timing=True,
+            diagnostics=wall_clock_diagnostics,
+        )
+        self._assert_sane_per_iter(elapsed_default)
+        self._assert_sane_per_iter(elapsed_wall_clock)
+        self.assertEqual(
+            "multi_stream_event_amortized", default_diagnostics["timing_method"]
+        )
+        self.assertEqual(
+            "multi_stream_wall_clock", wall_clock_diagnostics["timing_method"]
+        )
+
+    def test_default_multi_stream_allows_uneven_iteration_partition(self) -> None:
+        a, b = self._operands()
+        elapsed, _ = benchmark_torch_function(
+            _mm,
+            (a, b),
+            flush_gpu_cache_size_mb=0,
+            iters=5,
+            num_warmups=1,
+            device="cuda",
+            num_threads=2,
+        )
+        self._assert_sane_per_iter(elapsed)
+
+    def test_wall_clock_requires_even_iteration_partition(self) -> None:
+        a, b = self._operands()
+        with self.assertRaisesRegex(ValueError, "positive multiple"):
+            benchmark_torch_function(
+                _mm,
+                (a, b),
+                iters=5,
+                num_warmups=1,
+                device="cuda",
+                num_threads=2,
+                wall_clock_multi_stream_timing=True,
+            )
+
+    def test_wall_clock_requires_stream_warmup(self) -> None:
+        a, b = self._operands()
+        with self.assertRaisesRegex(ValueError, "requires num_warmups >= 1"):
+            benchmark_torch_function(
+                _mm,
+                (a, b),
+                iters=4,
+                num_warmups=0,
+                device="cuda",
+                num_threads=2,
+                wall_clock_multi_stream_timing=True,
+            )
+
+    def test_wall_clock_forwards_keyword_arguments(self) -> None:
+        a, b = self._operands()
+
+        def scaled_mm(
+            a: torch.Tensor,
+            b: torch.Tensor,
+            *,
+            scale: float,
+        ) -> torch.Tensor:
+            return torch.mm(a, b) * scale
+
+        _, output = benchmark_torch_function(
+            scaled_mm,
+            (a, b),
+            kwargs={"scale": 2.0},
+            flush_gpu_cache_size_mb=0,
+            iters=4,
+            num_warmups=1,
+            device="cuda",
+            num_threads=2,
+            wall_clock_multi_stream_timing=True,
+        )
+        self.assertTrue(torch.allclose(torch.mm(a, b) * 2.0, output))
+
+    def test_single_stream_event_timing_preserves_legacy_kwargs_behavior(
+        self,
+    ) -> None:
+        a, b = self._operands()
+
+        def scaled_mm(
+            a: torch.Tensor,
+            b: torch.Tensor,
+            *,
+            scale: float = 1.0,
+        ) -> torch.Tensor:
+            return torch.mm(a, b) * scale
+
+        _, output = benchmark_torch_function(
+            scaled_mm,
+            (a, b),
+            kwargs={"scale": 2.0},
+            flush_gpu_cache_size_mb=0,
+            iters=2,
+            num_warmups=1,
+            device="cuda",
+        )
+        self.assertTrue(torch.allclose(torch.mm(a, b), output))
+
+    def test_multi_stream_event_timing_preserves_legacy_kwargs_behavior(
+        self,
+    ) -> None:
+        a, b = self._operands()
+        observed_scales: list[float] = []
+        call_lock = threading.Lock()
+
+        def scaled_mm(
+            a: torch.Tensor,
+            b: torch.Tensor,
+            *,
+            scale: float = 1.0,
+        ) -> torch.Tensor:
+            with call_lock:
+                observed_scales.append(scale)
+            return torch.mm(a, b) * scale
+
+        benchmark_torch_function(
+            scaled_mm,
+            (a, b),
+            kwargs={"scale": 2.0},
+            flush_gpu_cache_size_mb=0,
+            iters=4,
+            num_warmups=1,
+            device="cuda",
+            num_threads=2,
+        )
+        self.assertCountEqual([2.0, 1.0, 1.0, 1.0, 1.0], observed_scales)
+
+    def test_wall_clock_waits_for_caller_stream(self) -> None:
+        device = torch.accelerator.current_accelerator()
+        # Citrine C3: allocate test inputs directly on device.
+        a = torch.zeros(32, 32, device=device)
+        b = torch.ones(32, 32, device=device)
+        torch.cuda._sleep(100_000_000)
+        a.fill_(2.0)
+
+        _, output = benchmark_torch_function(
+            _mm,
+            (a, b),
+            flush_gpu_cache_size_mb=0,
+            iters=2,
+            num_warmups=1,
+            device="cuda",
+            num_threads=1,
+            wall_clock_multi_stream_timing=True,
+            streams=[torch.cuda.Stream()],
+        )
+        expected = torch.full((32, 32), 64.0, device=device)
+        self.assertTrue(torch.equal(expected, output))
+
+    def test_wall_clock_records_start_before_releasing_workers(self) -> None:
+        a, b = self._operands()
+        timestamp_recorded = threading.Event()
+        work_started_before_timestamp = threading.Event()
+        call_count = 0
+        clock_call_count = 0
+        call_lock = threading.Lock()
+        num_threads = 2
+        num_warmups = 1
+        expected_warmup_calls = 1 + num_threads * num_warmups
+
+        def ordered_mm(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            nonlocal call_count
+            with call_lock:
+                call_count += 1
+                is_measured_call = call_count > expected_warmup_calls
+            if is_measured_call and not timestamp_recorded.is_set():
+                work_started_before_timestamp.set()
+            return torch.mm(a, b)
+
+        def delayed_clock() -> int:
+            nonlocal clock_call_count
+            clock_call_count += 1
+            if clock_call_count == 1:
+                time.sleep(0.05)
+                timestamp_recorded.set()
+                return 1_000_000_000
+            return 2_000_000_000
+
+        with patch(
+            "fbgemm_gpu.bench.bench_utils.time.perf_counter_ns",
+            side_effect=delayed_clock,
+        ):
+            benchmark_torch_function(
+                ordered_mm,
+                (a, b),
+                flush_gpu_cache_size_mb=0,
+                iters=2,
+                num_warmups=num_warmups,
+                device="cuda",
+                num_threads=num_threads,
+                wall_clock_multi_stream_timing=True,
+            )
+        self.assertFalse(work_started_before_timestamp.is_set())
+
+    def test_multi_stream_wall_clock_propagates_worker_error(self) -> None:
+        a, b = self._operands()
+        call_count = 0
+        call_lock = threading.Lock()
+
+        def fail_after_priming(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            nonlocal call_count
+            with call_lock:
+                call_count += 1
+                should_fail = call_count == 2
+            if should_fail:
+                raise RuntimeError("worker failed")
+            return torch.mm(a, b)
+
+        with self.assertRaisesRegex(RuntimeError, "worker failed"):
+            benchmark_torch_function(
+                fail_after_priming,
+                (a, b),
+                iters=4,
+                num_warmups=1,
+                device="cuda",
+                num_threads=2,
+                wall_clock_multi_stream_timing=True,
+            )


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3103

Preserves the existing `benchmark_torch_function` multi-stream default, which estimates throughput from amortized per-call CUDA event durations. Adds `wall_clock_multi_stream_timing=False` as an explicit opt-in. The opt-in creates or accepts the measured stream set, makes those streams wait for work already queued on the caller stream, primes lazy runtime initialization on a measured stream, forwards both positional and keyword arguments, warms every worker stream, flushes caches before the timed interval, records the start timestamp atomically as the worker barrier releases, and measures completed work with one wall-clock interval. Optional diagnostics use explicit typed structures and are limited to the timing method and per-stream device spans. Worker orchestration and error propagation are separated from timing setup; failures abort the barrier and propagate to the caller. Even iteration partitioning is required only for the opt-in wall-clock path, leaving legacy multi-stream behavior unchanged.

Reviewed By: beginner137

Differential Revision: D110656241


