### PR TITLE
Fix HIP grid overflow in jagged_dense_dense_elementwise_jagged_output_kernel

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/common.cuh
+++ b/fbgemm_gpu/src/jagged_tensor_ops/common.cuh
@@ -766,6 +766,64 @@ inline bool jagged_dense_dense_elementwise_jagged_output_matches_opt(
   return matches;
 }
 
+#ifdef USE_ROCM
+// HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
+// which silently wraps; see https://github.com/ROCm/hip/issues/2253). Cap
+// blocks.x unconditionally on ROCm; the launched
+// jagged_dense_dense_elementwise_jagged_output_kernel_ grid-strides over
+// `offset` at line 327 of common.cuh
+// (`for (offset = offset_begin; offset < nnz; offset += offset_stride)`),
+// so capping is correctness-preserving.
+#define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)                              \
+  {                                                                         \
+    dim3 threads, blocks;                                                   \
+    StackArray<int64_t> jagged_dims_tensor;                                 \
+    std::tie(threads, blocks, jagged_dims_tensor) =                         \
+        check_shape_and_partition_(x_values, x_offsets, y);                 \
+    blocks.x = div_round_up(x_values.size(0), threads.y);                   \
+    blocks.x = utils::cuda::cap_grid_dim_x(                                 \
+        static_cast<uint32_t>(blocks.x),                                    \
+        static_cast<int64_t>(threads.x) * static_cast<int64_t>(threads.y) * \
+            static_cast<int64_t>(threads.z),                                \
+        at::cuda::getCurrentCUDAStream());                                  \
+    std::vector<Tensor> x_offsets_contig;                                   \
+    x_offsets_contig.resize(num_jagged_dim);                                \
+    StackArray<index_t*> x_offset_ptrs;                                     \
+    x_offset_ptrs.ndim = num_jagged_dim;                                    \
+    StackArray<int64_t> x_offset_sizes;                                     \
+    x_offset_sizes.ndim = num_jagged_dim;                                   \
+    for (int d = 0; d < num_jagged_dim; ++d) {                              \
+      x_offsets_contig[d] = x_offsets[d].contiguous();                      \
+      x_offset_ptrs.vals[d] =                                               \
+          x_offsets_contig[d].template data_ptr<index_t>();                 \
+      x_offset_sizes.vals[d] = x_offsets[d].numel();                        \
+    }                                                                       \
+    const auto ff =                                                         \
+        ([f] __device__(                                                    \
+             scalar_t x, scalar_t y, scalar_t /*unused*/) -> scalar_t {     \
+          return f(x, y);                                                   \
+        });                                                                 \
+                                                                            \
+    FBGEMM_LAUNCH_KERNEL(                                                   \
+        (jagged_dense_dense_elementwise_jagged_output_kernel_<              \
+            NUM_JAGGED_DIM,                                                 \
+            index_t,                                                        \
+            scalar_t,                                                       \
+            decltype(ff)>),                                                 \
+        blocks,                                                             \
+        threads,                                                            \
+        0,                                                                  \
+        at::cuda::getCurrentCUDAStream(),                                   \
+        PTA_B(x_values, scalar_t, 2, 32),                                   \
+        x_offset_ptrs,                                                      \
+        x_offset_sizes,                                                     \
+        PTA_B(y_reshaped, scalar_t, 3, 32),                                 \
+        PTA_B(y_reshaped, scalar_t, 3, 32),                                 \
+        PTA_B(output_values, scalar_t, 2, 32),                              \
+        jagged_dims_tensor,                                                 \
+        ff);                                                                \
+  }
+#else
 #define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)                          \
   {                                                                     \
     dim3 threads, blocks;                                               \
@@ -810,6 +868,7 @@ inline bool jagged_dense_dense_elementwise_jagged_output_matches_opt(
         jagged_dims_tensor,                                             \
         ff);                                                            \
   }
+#endif
 
 ///@addtogroup jagged-tensor-ops-cuda
 template <typename scalar_t, typename F>

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_elementwise_mul_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_elementwise_mul_backward.cu
@@ -90,6 +90,18 @@ void jagged_jagged_elementwise_dense_output_(
   std::tie(threads, blocks, jagged_dims_tensor) =
       check_shape_and_partition_(x_values, x_offsets, output);
 
+  // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
+  // which silently wraps). jagged_jagged_elementwise_dense_output_kernel_
+  // grid-strides over the outer dim
+  // (`outer_stride = gridDim.x * blockDim.y`), so capping is
+  // correctness-preserving.
+  // See: https://github.com/ROCm/hip/issues/2253
+  blocks.x = utils::cuda::cap_grid_dim_x(
+      static_cast<uint32_t>(blocks.x),
+      static_cast<int64_t>(threads.x) * static_cast<int64_t>(threads.y) *
+          static_cast<int64_t>(threads.z),
+      at::cuda::getCurrentCUDAStream());
+
   // Canonicalize output to 3D, collapsing jagged dimensions.
   Tensor output_reshaped = output.view({output.size(0), -1, output.size(-1)});
 

--- a/fbgemm_gpu/test/jagged/dense_dense_elementwise_add_test.py
+++ b/fbgemm_gpu/test/jagged/dense_dense_elementwise_add_test.py
@@ -25,10 +25,17 @@ from .common import (
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import cpu_and_maybe_gpu, gpu_unavailable, gradcheck, optests
+    from test_utils import (
+        cpu_and_maybe_gpu,
+        gpu_memory_lt_gb,
+        gpu_unavailable,
+        gradcheck,
+        optests,
+    )
 else:
     from fbgemm_gpu.test.test_utils import (
         cpu_and_maybe_gpu,
+        gpu_memory_lt_gb,
         gpu_unavailable,
         gradcheck,
         optests,
@@ -275,6 +282,102 @@ class DenseDenseElementwiseAddTest(unittest.TestCase):
         output = to_padded_dense(output, output_offsets, max_lengths)
 
         assert output.size() == output_ref.size()
+
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(40))
+    def test_jagged_dense_dense_elementwise_add_jagged_output_large_grid(
+        self,
+    ) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in
+        jagged_dense_dense_elementwise_jagged_output_kernel_ (the
+        common.cuh `_opt_` codepath, kernel template at common.cuh:738)
+        and verifies output correctness via a downsampled CPU oracle.
+
+        Same block/grid arithmetic as the mul_backward kernel: block <= 1024;
+        grid.x = div_round_up(outer * jagged_folded, 32); saturation at
+        outer * jagged_folded >= 2**27. With D=8 we keep
+        x_values.numel() < 2**31 (the kernel's int32_t accessor limit).
+
+        Verification strategy (downsampled-oracle):
+        1. Full-scale forward to verify launch survival at the cap-trip
+           scale. Uses zeros so output is zeros; shape and zero-fill are
+           asserted.
+        2. Small-scale invocation vs CPU dispatch with sentinel non-zero
+           values to validate kernel correctness end-to-end.
+        """
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+
+        # ---- Step 1: full-scale launch survival (cap-trip detection). ----
+        B = 1
+        max_L = (1 << 27) + 1
+        # D=8 keeps numel < 2**31 for int32_t accessor compatibility.
+        D = 8
+        nnz = max_L
+        x_values_large = torch.zeros((nnz, D), dtype=torch.float32, device=device)
+        x_offsets_large = [torch.tensor([0, nnz], dtype=torch.int64, device=device)]
+        y0_large = torch.zeros((B, max_L, D), dtype=torch.float32, device=device)
+        y1_large = torch.zeros((B, max_L, D), dtype=torch.float32, device=device)
+
+        output_large = (
+            torch.ops.fbgemm.jagged_dense_dense_elementwise_add_jagged_output(
+                x_values_large, x_offsets_large, y0_large, y1_large
+            )
+        )
+        # output[0] is the output jagged values.
+        self.assertEqual(output_large[0].shape, (nnz, D))
+        self.assertTrue(torch.all(output_large[0] == 0).item())
+        del x_values_large, x_offsets_large, y0_large, y1_large, output_large
+        torch.cuda.empty_cache()
+
+        # ---- Step 2: downsampled CPU-oracle correctness check. ----
+        # Same kernel code path, smaller scale. Distinct non-zero values so
+        # any "kernel addressed wrong row" bug surfaces in the output sum.
+        small_B = 2
+        small_max_L = 4
+        small_D = 3
+        small_lengths = torch.tensor([1, 3], dtype=torch.int64)
+        small_x_offsets_cpu = [torch.zeros(small_B + 1, dtype=torch.int64)]
+        small_x_offsets_cpu[0][1:] = torch.cumsum(small_lengths, dim=0)
+        small_nnz = int(small_x_offsets_cpu[0][-1].item())
+        small_x_values_cpu = torch.arange(
+            small_nnz * small_D, dtype=torch.float32
+        ).reshape(small_nnz, small_D)
+        small_y0_cpu = (
+            torch.arange(small_B * small_max_L * small_D, dtype=torch.float32).reshape(
+                small_B, small_max_L, small_D
+            )
+            * 0.1
+        )
+        small_y1_cpu = (
+            torch.arange(small_B * small_max_L * small_D, dtype=torch.float32).reshape(
+                small_B, small_max_L, small_D
+            )
+            * 0.01
+        )
+
+        # CPU reference oracle.
+        small_output_cpu = (
+            torch.ops.fbgemm.jagged_dense_dense_elementwise_add_jagged_output(
+                small_x_values_cpu,
+                small_x_offsets_cpu,
+                small_y0_cpu,
+                small_y1_cpu,
+            )
+        )
+
+        # GPU op under test.
+        small_x_offsets_gpu = [t.to(device) for t in small_x_offsets_cpu]
+        small_output_gpu = (
+            torch.ops.fbgemm.jagged_dense_dense_elementwise_add_jagged_output(
+                small_x_values_cpu.to(device),
+                small_x_offsets_gpu,
+                small_y0_cpu.to(device),
+                small_y1_cpu.to(device),
+            )
+        )
+
+        torch.testing.assert_close(small_output_gpu[0].cpu(), small_output_cpu[0])
 
 
 if __name__ == "__main__":

--- a/fbgemm_gpu/test/jagged/elementwise_binary_test.py
+++ b/fbgemm_gpu/test/jagged/elementwise_binary_test.py
@@ -25,10 +25,17 @@ from .common import (
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import cpu_and_maybe_gpu, gpu_unavailable, gradcheck, optests
+    from test_utils import (
+        cpu_and_maybe_gpu,
+        gpu_memory_lt_gb,
+        gpu_unavailable,
+        gradcheck,
+        optests,
+    )
 else:
     from fbgemm_gpu.test.test_utils import (
         cpu_and_maybe_gpu,
+        gpu_memory_lt_gb,
         gpu_unavailable,
         gradcheck,
         optests,
@@ -270,6 +277,129 @@ class ElementwiseBinaryTest(unittest.TestCase):
             raise AssertionError(f"Unknown operation {operation}")
 
         assert output.size() == output_ref.size()
+
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(32))
+    def test_jagged_dense_elementwise_mul_backward_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in
+        jagged_jagged_elementwise_dense_output_kernel_ (the backward of
+        fbgemm.jagged_dense_elementwise_mul) and verifies output
+        correctness via a downsampled CPU oracle.
+
+        block = up to 1024 (dim3(threads_x<=32, threads_y=32) from
+            check_shape_and_partition_ at common.cuh:187)
+        grid.x = div_round_up(outer * jagged_folded, 32)
+        Total threads ~= outer * jagged_folded * 32.
+        For pre-fix to trip and post-fix to pass:
+            pre-fix:  outer * jagged_folded > 2**27 ⇒ trips.
+            post-fix: 16384 * 32 * 32 = 2**24 < 2**32 (always passes).
+
+        Verification strategy (downsampled-oracle):
+        1. Full-scale forward + backward to verify the backward kernel
+           launches successfully under the cap. Uses zero values so per-
+           element work is zero; backward grad shape is asserted.
+        2. Small-scale forward + backward vs CPU dispatch to validate
+           kernel correctness end-to-end.
+        """
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+
+        # ---- Step 1: full-scale forward + backward launch survival. ----
+        B = 1
+        max_L = (1 << 27) + 1
+        # D=8 keeps x_values.numel() = max_L*D < 2**31 (the kernel's
+        # int32_t accessor limit) while still leaving outer*jagged_folded
+        # = max_L > 2**27, which trips the cap pre-fix.
+        D = 8
+        nnz = max_L  # one segment of length max_L
+        x_values_large = torch.zeros(
+            (nnz, D), dtype=torch.float32, device=device, requires_grad=True
+        )
+        x_offsets_large = [torch.tensor([0, nnz], dtype=torch.int64, device=device)]
+        y_large = torch.zeros(
+            (B, max_L, D),
+            dtype=torch.float32,
+            device=device,
+            requires_grad=True,
+        )
+
+        output_large = torch.ops.fbgemm.jagged_dense_elementwise_mul(
+            x_values_large, x_offsets_large, y_large
+        )
+        # output is a tuple (output_jagged_values, output_offsets). Use the
+        # jagged values for backward.
+        if isinstance(output_large, (tuple, list)):
+            loss_large = output_large[0].sum()
+        else:
+            loss_large = output_large.sum()
+        # Pre-fix this trips KernelLauncher::checkThreadCountNotExceeded on
+        # ROCm.
+        loss_large.backward()
+        # pyre-ignore[16]
+        self.assertEqual(x_values_large.grad.shape, x_values_large.shape)
+        # pyre-ignore[16]
+        self.assertEqual(y_large.grad.shape, y_large.shape)
+        del x_values_large, x_offsets_large, y_large, output_large, loss_large
+        torch.cuda.empty_cache()
+
+        # ---- Step 2: downsampled CPU-oracle correctness check. ----
+        # Same kernel code path, smaller scale to keep the CPU oracle cheap.
+        # Distinct non-zero values so any "kernel addressed wrong row" bug
+        # surfaces in both the forward output and the backward grads.
+        small_B = 2
+        small_max_L = 4
+        small_D = 3
+        # Sparse jagged: segment 0 has 1 row, segment 1 has 3 rows.
+        small_lengths = torch.tensor([1, 3], dtype=torch.int64)
+        small_offsets_cpu = [torch.zeros(small_B + 1, dtype=torch.int64)]
+        small_offsets_cpu[0][1:] = torch.cumsum(small_lengths, dim=0)
+        small_nnz = int(small_offsets_cpu[0][-1].item())
+        x_values_init = torch.arange(small_nnz * small_D, dtype=torch.float32).reshape(
+            small_nnz, small_D
+        )
+        y_init = (
+            torch.arange(small_B * small_max_L * small_D, dtype=torch.float32).reshape(
+                small_B, small_max_L, small_D
+            )
+            * 0.1
+        )
+
+        # CPU forward + backward.
+        x_values_cpu = x_values_init.detach().clone().requires_grad_(True)
+        y_cpu = y_init.detach().clone().requires_grad_(True)
+        output_cpu = torch.ops.fbgemm.jagged_dense_elementwise_mul(
+            x_values_cpu, small_offsets_cpu, y_cpu
+        )
+        if isinstance(output_cpu, (tuple, list)):
+            loss_cpu = output_cpu[0].sum()
+        else:
+            loss_cpu = output_cpu.sum()
+        loss_cpu.backward()
+
+        # GPU forward + backward.
+        x_values_gpu = x_values_init.detach().clone().to(device).requires_grad_(True)
+        y_gpu = y_init.detach().clone().to(device).requires_grad_(True)
+        small_offsets_gpu = [t.to(device) for t in small_offsets_cpu]
+        output_gpu = torch.ops.fbgemm.jagged_dense_elementwise_mul(
+            x_values_gpu, small_offsets_gpu, y_gpu
+        )
+        if isinstance(output_gpu, (tuple, list)):
+            loss_gpu = output_gpu[0].sum()
+        else:
+            loss_gpu = output_gpu.sum()
+        loss_gpu.backward()
+
+        # Forward jagged values must match.
+        if isinstance(output_cpu, (tuple, list)) and isinstance(
+            output_gpu, (tuple, list)
+        ):
+            torch.testing.assert_close(output_gpu[0].cpu(), output_cpu[0])
+        else:
+            torch.testing.assert_close(output_gpu.cpu(), output_cpu)
+        # pyre-ignore[16]
+        torch.testing.assert_close(x_values_gpu.grad.cpu(), x_values_cpu.grad)
+        # pyre-ignore[16]
+        torch.testing.assert_close(y_gpu.grad.cpu(), y_cpu.grad)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA, which
silently wraps; see https://github.com/ROCm/hip/issues/2253).
The `INVOKE_KERNEL_WITH_DIM` macro in `common.cuh` (line 713, used by
`jagged_dense_elementwise_jagged_output_opt_` at line 760) launches
`jagged_dense_dense_elementwise_jagged_output_kernel_` with grid
`blocks` from `check_shape_and_partition_` then overwritten as
`blocks.x = div_round_up(x_values.size(0), threads.y)` with block size
up to 1024 (threads.y = 32). Total launch threads ~=
`x_values.size(0) * 32`; saturation at `x_values.size(0) >= 2^27` trips
`KernelLauncher::checkThreadCountNotExceeded` on ROCm.

The kernel grid-strides over `offset` at line 327 of common.cuh
(`for (offset = offset_begin; offset < nnz; offset += offset_stride)`),
so capping the host-side `blocks.x` unconditionally on ROCm is
correctness-preserving. Per the audit plan, the cap is applied inside the
`INVOKE_KERNEL_WITH_DIM` macro using two macro variants
(`#ifdef USE_ROCM` / `#else`) rather than refactoring
`check_shape_and_partition_`, to keep the diff scoped to one file. Same
`#ifdef USE_ROCM` cap pattern as parent fixes D104903707 / D104937969 in
`sparse_ops/`.

Note: this fix covers the `_opt_` codepath in common.cuh. The optimized
`_opt_search_kernel_` and `_opt_gather_kernel_` paths are out of scope
(Tier-2 / already capped); the non-`_opt_` macros in
`dense_to_jagged_forward.cu` and
`jagged_dense_dense_elementwise_add_jagged_output_forward.cu` define
their own local macros and are not affected by this change.

Audit: /home/bensonma415/.llms/plans/jagged_and_more_rocm_grid_overflow_audit.plan.md

Differential Revision: D105098561


