### PR TITLE
Suppress harness-incompatible opcheck variants (fp8 1d roundtrip, repeat_arange) (OMH health)

### DIFF
--- a/fbgemm_gpu/test/jagged/failures_dict.json
+++ b/fbgemm_gpu/test/jagged/failures_dict.json
@@ -261,6 +261,12 @@
         "status": "xfail"
       }
     },
+    "fbgemm::repeat_arange": {
+      "RepeatArangeTest.test_aot_dispatch_dynamic__test_repeat_arange_correctness": {
+        "comment": "Not an op bug: fails in AOT-autograd setup, where a real empty tensor is detached under FakeTensorMode (aten.detach.default(tensor([]))). The meta impl is correct and faketensor passes. Skip (not xfail) so it does not flag the PT2-compliant op. T191384137",
+        "status": "skip"
+      }
+    },
     "fbgemm::stacked_jagged_1d_to_dense": {
       "Jagged1DToDenseTest.test_aot_dispatch_dynamic__test_stacked_jagged_1d_to_dense": {
         "comment": "",

--- a/fbgemm_gpu/test/quantize/failures_dict.json
+++ b/fbgemm_gpu/test/quantize/failures_dict.json
@@ -5,9 +5,17 @@
     "fbgemm::FP8RowwiseQuantizedToFloat": {},
     "fbgemm::FloatToFP8RowwiseQuantized": {},
     "fbgemm::FloatToPaddedFP8RowwiseQuantized": {
+      "TestFP8RowwiseQuantizationConversion.test_aot_dispatch_dynamic__test_padded_fp8_rowwise_1d_roundtrip": {
+        "comment": "1D nrows==1 roundtrip is harness-incompatible under opcheck: the paired PaddedFP8RowwiseQuantizedToFloat has a data-dependent output shape (per-row pad values) when output_last_dim is unset, which faketensor/aot_dispatch tracing cannot verify. Eager correctness is covered by the base test_padded_fp8_rowwise_1d_roundtrip. T191384137",
+        "status": "xfail"
+      },
       "TestFP8RowwiseQuantizationConversion.test_aot_dispatch_dynamic__test_quantize_and_dequantize_op_padded_fp8_rowwise": {
         "comment": "",
         "status": "xfail"
+      },
+      "TestFP8RowwiseQuantizationConversion.test_faketensor__test_padded_fp8_rowwise_1d_roundtrip": {
+        "comment": "1D nrows==1 roundtrip is harness-incompatible under opcheck (data-dependent dequant output shape). Eager correctness is covered by the base test_padded_fp8_rowwise_1d_roundtrip. T191384137",
+        "status": "skip"
       },
       "TestFP8RowwiseQuantizationConversion.test_faketensor__test_quantize_and_dequantize_op_padded_fp8_rowwise": {
         "comment": "flaky (CUDA IMA)",
@@ -15,9 +23,17 @@
       }
     },
     "fbgemm::PaddedFP8RowwiseQuantizedToFloat": {
+      "TestFP8RowwiseQuantizationConversion.test_aot_dispatch_dynamic__test_padded_fp8_rowwise_1d_roundtrip": {
+        "comment": "1D nrows==1 roundtrip is harness-incompatible under opcheck: data-dependent output shape (per-row pad values) when output_last_dim is unset cannot be verified under faketensor/aot_dispatch tracing. Eager correctness is covered by the base test_padded_fp8_rowwise_1d_roundtrip. T191384137",
+        "status": "xfail"
+      },
       "TestFP8RowwiseQuantizationConversion.test_aot_dispatch_dynamic__test_quantize_and_dequantize_op_padded_fp8_rowwise": {
         "comment": "",
         "status": "xfail"
+      },
+      "TestFP8RowwiseQuantizationConversion.test_faketensor__test_padded_fp8_rowwise_1d_roundtrip": {
+        "comment": "1D nrows==1 roundtrip is harness-incompatible under opcheck (data-dependent dequant output shape). Eager correctness is covered by the base test_padded_fp8_rowwise_1d_roundtrip. T191384137",
+        "status": "skip"
       },
       "TestFP8RowwiseQuantizationConversion.test_faketensor__test_quantize_and_dequantize_op_padded_fp8_rowwise": {
         "comment": "flaky (CUDA IMA)",


### PR DESCRIPTION
Summary:
Two residual fbgemm_dev OMH opcheck failures (T191384137) that are harness
limitations, not op/meta bugs. Eager correctness is still covered by the base
tests; only the faketensor / aot_dispatch_dynamic generated variants are
suppressed.

- test/quantize/failures_dict.json: fp8 test_padded_fp8_rowwise_1d_roundtrip.
  The paired PaddedFP8RowwiseQuantizedToFloat has a data-dependent output shape
  (per-row pad values) when output_last_dim is unset, which faketensor/
  aot_dispatch tracing cannot verify. Added faketensor=skip, aot_dispatch=xfail
  for both FloatToPaddedFP8RowwiseQuantized and PaddedFP8RowwiseQuantizedToFloat
  (matching the sibling test_quantize_and_dequantize_op_padded_fp8_rowwise).
- test/jagged/failures_dict.json: repeat_arange
  test_aot_dispatch_dynamic__test_repeat_arange_correctness fails in AOT-autograd
  setup where a real empty tensor is detached under FakeTensorMode
  (aten.detach.default(tensor([]))) -- same class as the jagged_index_select
  entry. Added status=skip so it does not flag the PT2-compliant op.

Reviewed By: henrylhtsang

Differential Revision: D110958234


