### PR TITLE
Bump x86 CPU test runner to linux.12xlarge + timeout to 40m (fix py3.12+ OOM) (#5993)

### DIFF
--- a/.github/workflows/fbgemm_gpu_ci_cpu.yml
+++ b/.github/workflows/fbgemm_gpu_ci_cpu.yml
@@ -148,7 +148,11 @@ jobs:
       fail-fast: false
       matrix:
         host-machine: [
-          { arch: x86, instance: "linux.4xlarge", timeout: 20 },
+          # x86 test runner bumped 4xlarge (32GB) -> 12xlarge (96GB): the CPU
+          # gradcheck tests (backward_dense/backward_adagrad/...) OOM on 32GB
+          # for py3.12+. The arm m7g.4xlarge already has 64GB, so it stays.
+          # Timeout also bumped 20 -> 40m: the py3.12+ CPU sweep runs longer.
+          { arch: x86, instance: "linux.12xlarge", timeout: 40 },
           { arch: arm, instance: "linux.arm64.m7g.4xlarge", timeout: 30 },
         ]
         build-target: [ "default" ]

--- a/.github/workflows/fbgemm_gpu_release_cpu.yml
+++ b/.github/workflows/fbgemm_gpu_release_cpu.yml
@@ -131,7 +131,11 @@ jobs:
       fail-fast: false
       matrix:
         host-machine: [
-          { arch: x86, instance: "linux.4xlarge", timeout: 20 },
+          # x86 test runner bumped 4xlarge (32GB) -> 12xlarge (96GB): the CPU
+          # gradcheck tests (backward_dense/backward_adagrad/...) OOM on 32GB
+          # for py3.12+. The arm m7g.4xlarge already has 64GB, so it stays.
+          # Timeout also bumped 20 -> 40m: the py3.12+ CPU sweep runs longer.
+          { arch: x86, instance: "linux.12xlarge", timeout: 40 },
           { arch: arm, instance: "linux.arm64.m7g.4xlarge", timeout: 30 },
         ]
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2904


The v1.8.0 CPU wheels for py3.12/3.13/3.14 failed to publish and the CPU CI (fbgemm_gpu_ci_cpu) was land-blocking: the "Test with PyTest" step OOM-killed or stalled (20-min timeout) on the x86 linux.4xlarge (32GB) runner for newer Python. The CPU torch.autograd.gradcheck() tests (backward_dense_test, backward_adagrad_test, ...) are memory-heavy; py3.10/3.11 fit in 32GB but py3.12+ higher baseline tips over. The arm runner (m7g.4xlarge, 64GB) passes, which confirms the cause is purely memory.

Changes (both CPU workflows, fbgemm_gpu_ci_cpu.yml + fbgemm_gpu_release_cpu.yml):
- Bump the x86 test_and_publish_artifact runner from linux.4xlarge (32GB) to linux.12xlarge (96GB). linux.12xlarge is already used elsewhere in the FBGEMM workflows. arm is unchanged (already 64GB).
- Bump the x86 "Test with PyTest" timeout 20 -> 40 min, since the py3.12+ CPU gradcheck sweep runs longer than the old 20-min cap.
This fixes the whole backward_* CPU test family at once with no test-coverage change.

Differential Revision: D111184249


