### PR TITLE
Fix int32 truncation in tbe_input_combine offset accumulation

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -383,7 +383,7 @@ def tbe_input_combine_abstract(
             need_weight = True
     total_offsets = torch.library.get_ctx().new_dynamic_size()
     combined_indices = indices_list[0].new_empty([total_indices], dtype=torch.int)
-    combined_offsets = offsets_list[0].new_empty([total_offsets], dtype=torch.int)
+    combined_offsets = offsets_list[0].new_empty([total_offsets], dtype=torch.long)
     if need_weight:
         combined_weights = per_sample_weights[0].new_empty(
             [total_indices], dtype=torch.float

--- a/fbgemm_gpu/src/input_combine_ops/input_combine_cpu.cpp
+++ b/fbgemm_gpu/src/input_combine_ops/input_combine_cpu.cpp
@@ -202,6 +202,22 @@ Tensor _cat_per_sample_weights_list(
   return combined_weights;
 }
 
+// Allocates the int64 combined_offsets buffer shared by the tbe_input_combine
+// family. Centralizing this keeps the output dtype (int64) consistent across
+// variants; previously each caller built at::empty with its own options, so the
+// int32->int64 overflow fix had to be applied to every copy.
+static Tensor _allocate_combined_offsets(
+    int64_t total_offsets,
+    const Tensor& device_ref,
+    bool pin_memory) {
+  return at::empty(
+      {total_offsets},
+      at::TensorOptions()
+          .dtype(c10::kLong)
+          .device(device_ref.device())
+          .pinned_memory(pin_memory));
+}
+
 std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_cpu(
     const std::vector<Tensor>& indices_list,
     const std::vector<Tensor>& offsets_list,
@@ -276,15 +292,11 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_cpu(
       to_trim_padding,
       indices_terminating_idx);
 
-  auto combined_offsets = at::empty(
-      {total_offsets},
-      at::TensorOptions()
-          .dtype(c10::kInt)
-          .device(offsets_list[0].device())
-          .pinned_memory(pin_memory));
+  auto combined_offsets =
+      _allocate_combined_offsets(total_offsets, offsets_list[0], pin_memory);
 
-  auto combined_offsets_data_ptr = combined_offsets.mutable_data_ptr<int32_t>();
-  int32_t offset = 0;
+  auto combined_offsets_data_ptr = combined_offsets.mutable_data_ptr<int64_t>();
+  int64_t offset = 0;
   size_t offsets_acc_idx = 0;
   combined_offsets_data_ptr[offsets_acc_idx++] = 0;
 
@@ -299,13 +311,13 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_cpu(
                j < size;
                j++) {
             combined_offsets_data_ptr[offsets_acc_idx++] =
-                offset + static_cast<int32_t>(offsets_data_ptr[j]);
+                offset + offsets_data_ptr[j];
           }
 
           if (to_trim_padding) {
-            offset += static_cast<int32_t>(offsets_list[i][-1].item().toInt());
+            offset += offsets_list[i][-1].item().toLong();
           } else {
-            offset += static_cast<int32_t>(indices_list[i].numel());
+            offset += indices_list[i].numel();
           }
           combined_offsets_data_ptr[offsets_acc_idx++] = offset;
         });
@@ -470,15 +482,11 @@ std::tuple<Tensor, Tensor, Tensor> padding_fused_tbe_input_combine_cpu(
   auto combined_indices =
       _cat_int_tensors(indices_list, total_indices, pin_memory);
 
-  auto combined_offsets = at::empty(
-      {total_offsets},
-      at::TensorOptions()
-          .dtype(c10::kInt)
-          .device(offsets_list[0].device())
-          .pinned_memory(pin_memory));
+  auto combined_offsets =
+      _allocate_combined_offsets(total_offsets, offsets_list[0], pin_memory);
 
-  auto combined_offsets_data_ptr = combined_offsets.mutable_data_ptr<int32_t>();
-  int32_t offset = 0;
+  auto combined_offsets_data_ptr = combined_offsets.mutable_data_ptr<int64_t>();
+  int64_t offset = 0;
   size_t offsets_acc_idx = 0;
   combined_offsets_data_ptr[offsets_acc_idx++] = 0;
 
@@ -489,11 +497,19 @@ std::tuple<Tensor, Tensor, Tensor> padding_fused_tbe_input_combine_cpu(
           auto* offsets_data_ptr = offsets_list[i].const_data_ptr<index_t>();
           int64_t offsets_size =
               offsets_list[i].numel() - (include_last_offsets_acc[i] ? 1 : 0);
+          TORCH_CHECK(
+              offsets_size >= 1 && offsets_size <= batch_size + 1,
+              "padding_fused_tbe_input_combine expects each table's effective "
+              "offsets count to be in [1, batch_size + 1], but got ",
+              offsets_size,
+              " (batch_size = ",
+              batch_size,
+              ")");
           for (const auto j : c10::irange(1, offsets_size)) {
             combined_offsets_data_ptr[offsets_acc_idx++] =
-                offset + static_cast<int32_t>(offsets_data_ptr[j]);
+                offset + offsets_data_ptr[j];
           }
-          offset += static_cast<int32_t>(indices_list[i].numel());
+          offset += indices_list[i].numel();
           for (int64_t j = offsets_size; j <= batch_size; j++) {
             combined_offsets_data_ptr[offsets_acc_idx++] = offset;
           }

--- a/fbgemm_gpu/test/combine/common.py
+++ b/fbgemm_gpu/test/combine/common.py
@@ -54,12 +54,12 @@ class TBEInputPrepareReference(torch.nn.Module):
         torch.cat(indices_list, out=combined_indices)
         offsets_starts = torch.zeros(
             [len(offsets_list) + 1],
-            dtype=offsets_list[0].dtype,
+            dtype=torch.int64,
             device=offsets_list[0].device,
         )
         offsets_accs = torch.zeros(
             [len(offsets_list) + 1],
-            dtype=offsets_list[0].dtype,
+            dtype=torch.int64,
             device=offsets_list[0].device,
         )
 
@@ -78,7 +78,7 @@ class TBEInputPrepareReference(torch.nn.Module):
         )
         combined_offsets = torch.zeros(
             combined_offsets_size,
-            dtype=torch.int32,
+            dtype=torch.int64,
             device=offsets_list[0].device,
         )
         if batch_size is None:
@@ -120,5 +120,5 @@ class TBEInputPrepareReference(torch.nn.Module):
                     )
                     # fmt: on
 
-        # indices and offsets are required to be int32 for TBE
+        # indices are int32 and combined_offsets are int64 for TBE
         return combined_indices, combined_offsets, per_sample_weights

--- a/fbgemm_gpu/test/combine/input_combine_test.py
+++ b/fbgemm_gpu/test/combine/input_combine_test.py
@@ -113,7 +113,7 @@ class InputCombineTest(unittest.TestCase):
         for i, j in zip(outputs, ref_outputs):
             torch.testing.assert_close(i, j)
         self.assertTrue(outputs[0].dtype == torch.int32)
-        self.assertTrue(outputs[1].dtype == torch.int32)
+        self.assertTrue(outputs[1].dtype == torch.int64)
 
         outputs = torch.ops.fbgemm.tbe_input_combine(
             indices_list,
@@ -124,10 +124,9 @@ class InputCombineTest(unittest.TestCase):
         ref_outputs = ref_mod(indices_list, offsets_list, empty_per_sample_weights)
         for i, j in zip(outputs[:-1], ref_outputs[:-1]):
             torch.testing.assert_close(i, j)
-            self.assertTrue(j.dtype == torch.int32)
 
         self.assertTrue(outputs[0].dtype == torch.int32)
-        self.assertTrue(outputs[1].dtype == torch.int32)
+        self.assertTrue(outputs[1].dtype == torch.int64)
         self.assertTrue(outputs[-1].size(0) == 0)
 
     def _run_test_with_prepadded_indices_weights(self) -> None:
@@ -155,7 +154,7 @@ class InputCombineTest(unittest.TestCase):
             torch.tensor(
                 [1, 2, 3, 1, 2, 3, 4, 123, 123, 123, 456, 456, 456], dtype=torch.int32
             ),
-            torch.tensor([0, 2, 3, 4, 7], dtype=torch.int32),
+            torch.tensor([0, 2, 3, 4, 7], dtype=torch.int64),
             torch.tensor(
                 [1.0, 2.0, 1.0, 1.0, 2.0, 1.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
             ),
@@ -163,7 +162,7 @@ class InputCombineTest(unittest.TestCase):
         for i, j in zip(outputs, expected_outputs):
             torch.testing.assert_close(i, j)
         self.assertTrue(outputs[0].dtype == torch.int32)
-        self.assertTrue(outputs[1].dtype == torch.int32)
+        self.assertTrue(outputs[1].dtype == torch.int64)
 
         outputs = torch.ops.fbgemm.tbe_input_combine(
             indices_list,
@@ -175,13 +174,13 @@ class InputCombineTest(unittest.TestCase):
             torch.tensor(
                 [1, 2, 3, 1, 2, 3, 4, 123, 123, 123, 456, 456, 456], dtype=torch.int32
             ),
-            torch.tensor([0, 2, 3, 4, 7], dtype=torch.int32),
+            torch.tensor([0, 2, 3, 4, 7], dtype=torch.int64),
             torch.empty(0),
         ]
         for i, j in zip(outputs, expected_outputs):
             torch.testing.assert_close(i, j)
         self.assertTrue(outputs[0].dtype == torch.int32)
-        self.assertTrue(outputs[1].dtype == torch.int32)
+        self.assertTrue(outputs[1].dtype == torch.int64)
         self.assertTrue(outputs[2].size(0) == 0)
 
     def _run_test_with_prepadded_indices_weights_without_last_offsets(self) -> None:
@@ -210,7 +209,7 @@ class InputCombineTest(unittest.TestCase):
         for i, j in zip(outputs, ref_outputs):
             torch.testing.assert_close(i, j)
         self.assertTrue(outputs[0].dtype == torch.int32)
-        self.assertTrue(outputs[1].dtype == torch.int32)
+        self.assertTrue(outputs[1].dtype == torch.int64)
 
         outputs = torch.ops.fbgemm.tbe_input_combine(
             indices_list,
@@ -222,7 +221,7 @@ class InputCombineTest(unittest.TestCase):
         for i, j in zip(outputs[:-1], ref_outputs[:-1]):
             torch.testing.assert_close(i, j)
         self.assertTrue(outputs[0].dtype == torch.int32)
-        self.assertTrue(outputs[1].dtype == torch.int32)
+        self.assertTrue(outputs[1].dtype == torch.int64)
         self.assertTrue(outputs[2].size(0) == 0)
 
     # pyre-fixme[2]: Parameter must be annotated.
@@ -249,7 +248,7 @@ class InputCombineTest(unittest.TestCase):
         for i, j in zip(outputs, ref_outputs):
             torch.testing.assert_close(i, j)
         self.assertTrue(outputs[0].dtype == torch.int32)
-        self.assertTrue(outputs[1].dtype == torch.int32)
+        self.assertTrue(outputs[1].dtype == torch.int64)
 
         outputs = torch.ops.fbgemm.padding_fused_tbe_input_combine(
             indices_list,
@@ -263,10 +262,9 @@ class InputCombineTest(unittest.TestCase):
         )
         for i, j in zip(outputs[:-1], ref_outputs[:-1]):
             torch.testing.assert_close(i, j)
-            self.assertTrue(j.dtype == torch.int32)
 
         self.assertTrue(outputs[0].dtype == torch.int32)
-        self.assertTrue(outputs[1].dtype == torch.int32)
+        self.assertTrue(outputs[1].dtype == torch.int64)
         self.assertTrue(outputs[-1].size(0) == 0)
 
     # pyre-fixme[3]: Return type must be annotated.
@@ -322,7 +320,7 @@ class InputCombineTest(unittest.TestCase):
         self.assertTrue(ref_outputs[2].allclose(outputs[2]))
 
         ref_lengths = self._offsets_to_lengths(ref_outputs[1], ref_outputs[0], True)
-        self.assertTrue(ref_lengths.allclose(outputs[1]))
+        self.assertTrue(ref_lengths.to(outputs[1].dtype).allclose(outputs[1]))
 
     # pyre-fixme[2]: Parameter must be annotated.
     def _run_padding_fused_test_with_length(self, dtypes, batch_size) -> None:
@@ -357,7 +355,7 @@ class InputCombineTest(unittest.TestCase):
         self.assertTrue(ref_outputs[2].allclose(outputs[2]))
 
         ref_lengths = self._offsets_to_lengths(ref_outputs[1], ref_outputs[0], True)
-        self.assertTrue(ref_lengths.allclose(outputs[1]))
+        self.assertTrue(ref_lengths.to(outputs[1].dtype).allclose(outputs[1]))
 
     def test_input_combine_int64(self) -> None:
         self._run_test((torch.int64, torch.int64))
@@ -367,6 +365,62 @@ class InputCombineTest(unittest.TestCase):
 
     def test_input_combined_mix(self) -> None:
         self._run_test((torch.int64, torch.int32))
+
+    def _run_large_offsets_test(self, batch_size: int | None = None) -> None:
+        # Regression test for int32 truncation of combined offsets. A synthetic
+        # int64 offset value beyond INT32_MAX exercises the int64 *storage* /
+        # passthrough path (offset + offsets_data_ptr[j]); the int64
+        # *accumulation* variable (offset += numel) is only reachable with
+        # >2^31 real indices elements (~8 GB), which is impractical to
+        # materialize here. Uses non-trim mode (include_last_offsets=False) so
+        # raw offset values pass through without the offsets[-1] <= numel check.
+        big = 2_500_000_000  # > INT32_MAX (2_147_483_647)
+        indices_list = [
+            torch.tensor([1, 2, 3], dtype=torch.int32),
+            torch.tensor([1, 2, 3, 4], dtype=torch.int32),
+        ]
+        offsets_list = [
+            torch.tensor([0, 2], dtype=torch.int64),
+            torch.tensor([0, big], dtype=torch.int64),
+        ]
+        empty_per_sample_weights = [
+            torch.tensor([], dtype=torch.float),
+            torch.tensor([], dtype=torch.float),
+        ]
+        include_last_offsets = [False, False]
+
+        if batch_size is None:
+            outputs = torch.ops.fbgemm.tbe_input_combine(
+                indices_list,
+                offsets_list,
+                empty_per_sample_weights,
+                torch.BoolTensor(include_last_offsets),
+            )
+        else:
+            outputs = torch.ops.fbgemm.padding_fused_tbe_input_combine(
+                indices_list,
+                offsets_list,
+                empty_per_sample_weights,
+                torch.BoolTensor(include_last_offsets),
+                batch_size,
+            )
+        ref_mod = TBEInputPrepareReference(include_last_offsets)
+        ref_outputs = ref_mod(
+            indices_list, offsets_list, empty_per_sample_weights, batch_size
+        )
+
+        self.assertTrue(outputs[1].dtype == torch.int64)
+        # No truncation: the large shifted offset (big + 3) is preserved exactly.
+        self.assertEqual(outputs[1].tolist(), [0, 2, 3, big + 3, 7])
+        for i, j in zip(outputs[:-1], ref_outputs[:-1]):
+            torch.testing.assert_close(i, j)
+        self.assertTrue(outputs[-1].size(0) == 0)
+
+    def test_tbe_input_combine_large_offsets(self) -> None:
+        self._run_large_offsets_test()
+
+    def test_padding_fused_tbe_input_combine_large_offsets(self) -> None:
+        self._run_large_offsets_test(batch_size=2)
 
     def test_tbe_input_combine_cpu_with_padded_indices(self) -> None:
         self._run_test_with_prepadded_indices_weights()


### PR DESCRIPTION
## Summary

`tbe_input_combine` and `padding_fused_tbe_input_combine` accumulated `combined_offsets` in `int32`, which overflows once total indices across tables exceed `INT32_MAX` (~2.1B). This promotes the offset accumulator and output buffer to `int64`.

## Changes

- **Core fix** (`input_combine_cpu.cpp`): `combined_offsets` buffer, the running `offset` accumulator, and per-table offset reads are now `int64`. The `to_trim_padding` last-offset read uses `.toLong()` (was `.toInt()`, which truncated *before* the widening cast).
- **Meta sync** (`sparse_ops.py`): `tbe_input_combine_abstract` now declares `combined_offsets` as `int64` to match the kernel — otherwise `torch.compile` / `opcheck` hit a dtype-guard mismatch. (`padding_fused_tbe_input_combine` has no abstract and is not `PT2_COMPLIANT_TAG`, so it is unaffected.)
- **Reference oracle** (`common.py`): `offsets_starts` / `offsets_accs` forced to `int64` so the test oracle does not itself overflow int32 at the scale this fix targets.
- **Guard**: `padding_fused_tbe_input_combine` now `TORCH_CHECK`s each table's effective offsets count is in `[1, batch_size + 1]`, preventing a heap out-of-bounds write on malformed offsets (pre-existing, surfaced here).
- **Cleanup**: extracted a shared `_allocate_combined_offsets` helper; removed a now-vestigial `static_cast<int64_t>`.
- **Tests**: large-offset regression coverage for both ops (an int64 offset value beyond `INT32_MAX` is preserved verbatim), via a shared `_run_large_offsets_test` helper.

## Notes

- The `*_with_length` variants intentionally still return `int32` — they concatenate per-batch lengths (no accumulation), so there is no overflow path.
- CI is the primary validation (the extension is not built in the local environment where this was authored).