### PR TITLE
Add grid-stride + ROCm cap to repeat_arange_kernel

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/repeat_arange.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/repeat_arange.cu
@@ -45,21 +45,21 @@ __global__ __launch_bounds__(kMaxThreads) void repeat_arange_kernel(
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         offsets,
     pta::PackedTensorAccessor32<output_t, 1, at::RestrictPtrTraits> output) {
-  // Each block handles one batch item
-  const index_t batch_idx = blockIdx.x;
   const index_t batch_size = lengths.size(0);
 
-  if (batch_idx >= batch_size) {
-    return;
-  }
+  // Grid-stride over batches so a capped grid (used on ROCm to avoid the
+  // 2^32 launch-side limit) still covers every batch item.
+  for (index_t batch_idx = blockIdx.x; batch_idx < batch_size;
+       batch_idx += gridDim.x) {
+    const index_t length = lengths[batch_idx];
+    const index_t offset = offsets[batch_idx];
 
-  const index_t length = lengths[batch_idx];
-  const index_t offset = offsets[batch_idx];
-
-  // Grid-stride loop: each thread processes multiple elements if needed
-  for (index_t local_idx = threadIdx.x; local_idx < length;
-       local_idx += blockDim.x) {
-    output[offset + local_idx] = static_cast<output_t>(local_idx);
+    // Inner grid-stride loop: each thread processes multiple elements if
+    // needed.
+    for (index_t local_idx = threadIdx.x; local_idx < length;
+         local_idx += blockDim.x) {
+      output[offset + local_idx] = static_cast<output_t>(local_idx);
+    }
   }
 }
 
@@ -103,8 +103,15 @@ Tensor repeat_arange_cuda(const Tensor& lengths) {
   // Create output tensor - use same dtype as input for flexibility
   Tensor output = at::empty({output_size}, lengths.options());
 
-  // Launch kernel - one block per batch item
-  const int num_blocks = batch_size;
+  // Launch kernel - one block per batch item.
+  // HIP enforces a hard limit of 2^32 total threads per launch.
+  // repeat_arange_kernel grid-strides over batches, so capping is
+  // correctness-preserving.
+  // See: https://github.com/ROCm/hip/issues/2253
+  const auto num_blocks = utils::cuda::cap_grid_dim_x(
+      static_cast<uint32_t>(batch_size),
+      kMaxThreads,
+      at::cuda::getCurrentCUDAStream());
 
   AT_DISPATCH_INDEX_TYPES(
       lengths.scalar_type(), "repeat_arange_kernel", ([&] {

--- a/fbgemm_gpu/test/jagged/repeat_arange_test.py
+++ b/fbgemm_gpu/test/jagged/repeat_arange_test.py
@@ -18,9 +18,14 @@ from .common import additional_decorators, open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import cpu_and_maybe_gpu, gpu_unavailable, optests
+    from test_utils import cpu_and_maybe_gpu, gpu_memory_lt_gb, gpu_unavailable, optests
 else:
-    from fbgemm_gpu.test.test_utils import cpu_and_maybe_gpu, gpu_unavailable, optests
+    from fbgemm_gpu.test.test_utils import (
+        cpu_and_maybe_gpu,
+        gpu_memory_lt_gb,
+        gpu_unavailable,
+        optests,
+    )
 
 
 def repeat_arange_ref(lengths: torch.Tensor) -> torch.Tensor:
@@ -280,6 +285,44 @@ class RepeatArangeTest(unittest.TestCase):
         # Spot check some values
         for i in [0, 100, 500, 1000, 5000, 9999]:
             self.assertEqual(result[i].item(), i)
+
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(4))
+    def test_repeat_arange_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in `repeat_arange_kernel`
+        and verifies output correctness against the CPU dispatch.
+
+        With kMaxThreads=1024, the launch grid is `batch_size`. Total threads
+        = batch_size * 1024. For batch_size > 2**22, total threads cross the
+        HIP 2**32-per-launch limit and trip
+        KernelLauncher::checkThreadCountNotExceeded on ROCm pre-fix.
+        Post-fix the host caps `num_blocks` to
+        `get_max_thread_blocks(stream)` (~16384) and the kernel grid-strides
+        over batches.
+
+        Uses sparse `lengths` (mostly zero) with sentinel non-zero values at
+        start / middle / end so the kernel actually emits non-trivial output
+        and any "kernel addressed wrong batch" bug surfaces in the output
+        sequence.
+        """
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        # batch_size * 1024 > 2**32 requires batch_size > 2**22.
+        batch_size = (1 << 22) + 1
+        # Sparse non-zero lengths at sentinel positions. Total output = 6.
+        lengths_cpu = torch.zeros(batch_size, dtype=torch.int32)
+        lengths_cpu[0] = 1
+        lengths_cpu[batch_size // 2] = 2
+        lengths_cpu[batch_size - 1] = 3
+
+        # CPU reference oracle.
+        result_cpu = torch.ops.fbgemm.repeat_arange(lengths_cpu)
+
+        # GPU op under test. Pre-fix this trips
+        # KernelLauncher::checkThreadCountNotExceeded on ROCm.
+        result_gpu = torch.ops.fbgemm.repeat_arange(lengths_cpu.to(device))
+
+        torch.testing.assert_close(result_gpu.cpu(), result_cpu)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Diff 2/10 of the Tier-2 ROCm grid-overflow fix stack
(plan: ~/.llms/plans/embedding_inplace_jagged_etc_rocm_grid_overflow_tier2_fix.plan.md).

repeat_arange_kernel runs one block per batch item with no outer grid-stride.
With kMaxThreads=1024, batch_size > 2^22 makes total threads > 2^32 and trips
the HIP runtime's KernelLauncher::checkThreadCountNotExceeded on ROCm.

This diff:
- Wraps the kernel body in for (batch_idx = blockIdx.x; batch_idx < batch_size;
  batch_idx += gridDim.x) (Pattern C). The inner threadIdx.x grid-stride loop
  remains unchanged.
- Adds the standard #ifdef USE_ROCM host-side cap.
- Adds test_repeat_arange_large_grid to repeat_arange_test.py.

Reviewed By: henrylhtsang

Differential Revision: D105202017


