### PR TITLE
Un-cascade jagged pt2_compliant_tag tests (OMH health)

### DIFF
--- a/fbgemm_gpu/test/jagged/common.py
+++ b/fbgemm_gpu/test/jagged/common.py
@@ -9,7 +9,6 @@
 # pyre-ignore-all-errors[56]
 
 import itertools
-import unittest
 from collections.abc import Callable
 from typing import Any
 
@@ -43,29 +42,13 @@ settings.load_profile("suppress_differing_executors_check")
 # Please avoid putting tests here, you should put operator-specific
 # skips and failures in deeplearning/fbgemm/fbgemm_gpu/test/failures_dict.json
 #
-# The exception is the auto-generated `test_pt2_compliant_tag_fbgemm_<op>`
-# tests. When an op is tagged `pt2_compliant_tag` but has legitimately-xfail'd
-# opcheck sub-tests (recorded in failures_dict.json), the tag test fails with a
-# cascading "failed some of the generated opcheck tests" assertion even though
-# the underlying gaps are already tracked. These cannot be expressed in
-# failures_dict.json (they are not per-op-per-input entries), so they are
-# skipped here until the underlying opcheck gaps are fixed (T191384137).
-additional_decorators: dict[str, list[Callable[..., Any]]] = {
-    # Cascades from xfail'd ElementwiseBinaryTest.test_aot_dispatch_dynamic /
-    # test_autograd_registration __test_jagged_elementwise_binary entries.
-    "test_pt2_compliant_tag_fbgemm_jagged_dense_elementwise_add": [
-        unittest.skip(
-            "pt2_compliant_tag test cascades from xfail'd jagged_dense_elementwise_add opcheck sub-tests (T191384137)"
-        ),
-    ],
-    # Cascades from xfail'd JaggedToPaddedDenseTest.test_aot_dispatch_dynamic
-    # __test_jagged_to_padded_dense entry.
-    "test_pt2_compliant_tag_fbgemm_jagged_to_padded_dense": [
-        unittest.skip(
-            "pt2_compliant_tag test cascades from xfail'd jagged_to_padded_dense opcheck sub-tests (T191384137)"
-        ),
-    ],
-}
+# The auto-generated `test_pt2_compliant_tag_fbgemm_<op>` tests previously had to
+# be skipped here when an op had `xfail`'d opcheck sub-tests (an `xfail` cascades
+# into the tag test). Those sub-tests for jagged_dense_elementwise_add and
+# jagged_to_padded_dense are now recorded as `skip` (not `xfail`) in
+# failures_dict.json -- `skip` does not cascade -- so no pt2_compliant_tag skips
+# are needed here. See T191384137.
+additional_decorators: dict[str, list[Callable[..., Any]]] = {}
 
 
 def lengths_to_segment_ids(lengths: torch.Tensor) -> torch.Tensor:

--- a/fbgemm_gpu/test/jagged/failures_dict.json
+++ b/fbgemm_gpu/test/jagged/failures_dict.json
@@ -73,12 +73,12 @@
     "fbgemm::jagged_dense_dense_elementwise_add_jagged_output": {},
     "fbgemm::jagged_dense_elementwise_add": {
       "ElementwiseBinaryTest.test_aot_dispatch_dynamic__test_jagged_elementwise_binary": {
-        "comment": "",
-        "status": "xfail"
+        "comment": "Not an op bug. The aot_autograd_check harness fails with 'element 0 of tensors does not require grad and does not have a grad_fn' because jagged_dense_elementwise_add registers autograd via a wrapper (not at the Autograd dispatch key), which the traced aot_dispatch path does not pick up. Eager and real torch.compile autograd are unaffected. Using 'skip' (not 'xfail') so the op's pt2_compliant_tag check stays green. T191384137",
+        "status": "skip"
       },
       "ElementwiseBinaryTest.test_autograd_registration__test_jagged_elementwise_binary": {
-        "comment": "",
-        "status": "xfail"
+        "comment": "Not an op bug. The opcheck autograd_registration check rejects the op's wrapper-based autograd ('does not have an autograd kernel defined at an autograd key'); eager and real autograd work. Using 'skip' (not 'xfail') so the op's pt2_compliant_tag check stays green. T191384137",
+        "status": "skip"
       }
     },
     "fbgemm::jagged_dense_elementwise_add_jagged_output": {},
@@ -113,8 +113,8 @@
     "fbgemm::jagged_softmax": {},
     "fbgemm::jagged_to_padded_dense": {
       "JaggedToPaddedDenseTest.test_aot_dispatch_dynamic__test_jagged_to_padded_dense": {
-        "comment": "",
-        "status": "xfail"
+        "comment": "Not an op bug. Fails in AOT-autograd setup where a real empty tensor is detached under FakeTensorMode (aten.detach.default(tensor([]))) -- the same harness limitation as jagged_index_select. The meta impl is correct and faketensor passes. Using 'skip' (not 'xfail') so the op's pt2_compliant_tag check stays green. T191384137",
+        "status": "skip"
       }
     },
     "fbgemm::jagged_unique_indices": {


### PR DESCRIPTION
Summary:
Re-enables the 96 fbgemm_dev OMH pt2_compliant_tag jagged tests
(test_pt2_compliant_tag_fbgemm_jagged_dense_elementwise_add and
...jagged_to_padded_dense, x48 jagged test classes/configs each), T191384137.

Mechanism: an op tagged PT2_COMPLIANT_TAG gets an auto-generated
test_pt2_compliant_tag_fbgemm_<op> test that *cascades to fail* if the op has any
opcheck sub-test recorded as 'xfail' in failures_dict.json. Status 'skip' does
NOT cascade (this is why dense_to_jagged / jagged_index_select, which use 'skip',
stay green). The two remaining jagged pt2-compliant ops still used 'xfail', so
their tag tests were being blanket-skipped in common.py.

Investigation confirmed all three culprit sub-tests are opcheck-harness
limitations, not op bugs (the ops pass in eager):
- jagged_dense_elementwise_add test_autograd_registration: opcheck rejects the
  op's wrapper-based autograd ('no autograd kernel at an autograd key').
- jagged_dense_elementwise_add test_aot_dispatch_dynamic: aot_autograd_check
  fails 'element 0 of tensors does not require grad' (same wrapper-autograd root).
- jagged_to_padded_dense test_aot_dispatch_dynamic: real empty tensor detached
  under FakeTensorMode (aten.detach.default(tensor([]))) -- identical to the
  already-skipped jagged_index_select case.

Fix: change those 3 entries 'xfail' -> 'skip' (with documenting comments) in
test/jagged/failures_dict.json, and remove the two now-unneeded
test_pt2_compliant_tag skips from test/jagged/common.py (drop the now-unused
unittest import).

Reviewed By: henrylhtsang

Differential Revision: D111153448


