### PR TITLE
Reduce Hypothesis test log verbosity to failing cases only (verbose -> normal) (#5997)

### DIFF
--- a/fbgemm_gpu/test/jagged/1d_to_dense_test.py
+++ b/fbgemm_gpu/test/jagged/1d_to_dense_test.py
@@ -38,7 +38,7 @@ else:
 @optests.generate_opcheck_tests(additional_decorators=additional_decorators)
 class Jagged1DToDenseTest(unittest.TestCase):
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=20,
         deadline=None,
     )
@@ -136,7 +136,7 @@ class Jagged1DToDenseTest(unittest.TestCase):
     @optests.dontGenerateOpCheckTests("tests that call torch.compile are slow")
     @unittest.skipIf(*symint_vector_unsupported())
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=20,
         deadline=None,
     )
@@ -196,7 +196,7 @@ class Jagged1DToDenseTest(unittest.TestCase):
 
     @unittest.skipIf(*gpu_unavailable)
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=20,
         deadline=None,
     )

--- a/fbgemm_gpu/test/jagged/2d_to_dense_test.py
+++ b/fbgemm_gpu/test/jagged/2d_to_dense_test.py
@@ -28,7 +28,7 @@ else:
 @optests.generate_opcheck_tests(additional_decorators=additional_decorators)
 class Jagged2DToDenseTest(unittest.TestCase):
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=20,
         deadline=None,
     )
@@ -135,7 +135,7 @@ class Jagged2DToDenseTest(unittest.TestCase):
 
     @optests.dontGenerateOpCheckTests("tests that call torch.compile are slow")
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=20,
         deadline=None,
     )
@@ -191,7 +191,7 @@ class Jagged2DToDenseTest(unittest.TestCase):
 
     @unittest.skipIf(*gpu_unavailable)
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=20,
         deadline=None,
     )

--- a/fbgemm_gpu/test/jagged/batched_dense_vec_jagged_2d_mul_test.py
+++ b/fbgemm_gpu/test/jagged/batched_dense_vec_jagged_2d_mul_test.py
@@ -39,7 +39,7 @@ else:
 @optests.generate_opcheck_tests(additional_decorators=additional_decorators)
 class BatchedDenseVecJagged2DMulTest(unittest.TestCase):
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=20,
         deadline=None,
     )
@@ -116,7 +116,7 @@ class BatchedDenseVecJagged2DMulTest(unittest.TestCase):
         )
 
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=20,
         deadline=None,
     )
@@ -176,7 +176,7 @@ class BatchedDenseVecJagged2DMulTest(unittest.TestCase):
 
     @optests.dontGenerateOpCheckTests("tests that call torch.compile are slow")
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=20,
         deadline=None,
     )

--- a/fbgemm_gpu/test/jagged/dense_bmm_test.py
+++ b/fbgemm_gpu/test/jagged/dense_bmm_test.py
@@ -34,7 +34,7 @@ class DenseBmmTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float]),
         device=cpu_and_maybe_gpu(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_jagged_jagged_bmm(
         self,
         B: int,
@@ -108,7 +108,7 @@ class DenseBmmTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float]),
         device=cpu_and_maybe_gpu(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=2, deadline=None)
     def test_jagged_dense_bmm(
         self,
         B: int,
@@ -168,7 +168,7 @@ class DenseBmmTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float]),
         device=st.just(torch.device("cpu")),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_jagged_dense_bmm_dynamic_shape(
         self,
         B: int,

--- a/fbgemm_gpu/test/jagged/dense_dense_elementwise_add_test.py
+++ b/fbgemm_gpu/test/jagged/dense_dense_elementwise_add_test.py
@@ -121,7 +121,7 @@ class DenseDenseElementwiseAddTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float, torch.half, torch.bfloat16]),
         device=cpu_and_maybe_gpu(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_jagged_dense_dense_elementwise_add_jagged_output(
         self,
         num_jagged_dim: int,
@@ -142,7 +142,7 @@ class DenseDenseElementwiseAddTest(unittest.TestCase):
         dtype=st.just(torch.half),
         device=cpu_and_maybe_gpu(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=4, deadline=None)
     def test_jagged_dense_dense_elementwise_add_jagged_output_opt(
         self,
         num_jagged_dim: int,
@@ -162,7 +162,7 @@ class DenseDenseElementwiseAddTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float, torch.half, torch.bfloat16]),
         device_type=st.just("meta"),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_jagged_dense_dense_elementwise_add_jagged_output_meta_backend(
         self,
         num_jagged_dim: int,
@@ -224,7 +224,7 @@ class DenseDenseElementwiseAddTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float, torch.half, torch.bfloat16]),
         device_type=st.just("cpu"),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_jagged_dense_dense_elementwise_add_jagged_output_dynamic_shape(
         self,
         num_jagged_dim: int,

--- a/fbgemm_gpu/test/jagged/dense_to_jagged_test.py
+++ b/fbgemm_gpu/test/jagged/dense_to_jagged_test.py
@@ -88,7 +88,7 @@ class DenseToJaggedTest(unittest.TestCase):
         device=cpu_and_maybe_gpu(),
         precompute_total_L=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_dense_to_jagged(
         self,
         num_jagged_dim: int,
@@ -116,7 +116,7 @@ class DenseToJaggedTest(unittest.TestCase):
         device=cpu_and_maybe_gpu(),
         precompute_total_L=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_dense_to_jagged_opt(
         self,
         num_jagged_dim: int,
@@ -146,7 +146,7 @@ class DenseToJaggedTest(unittest.TestCase):
         device=cpu_and_maybe_gpu(),
         precompute_total_L=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=1, deadline=None)
     def test_dense_to_jagged_opt_large_batch(
         self,
         num_jagged_dim: int,
@@ -279,7 +279,7 @@ class DenseToJaggedTest(unittest.TestCase):
         device=st.sampled_from([torch.device("meta")]),
         precompute_total_L=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_dense_to_jagged_meta_backend(
         self,
         num_jagged_dim: int,
@@ -329,7 +329,7 @@ class DenseToJaggedTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float, torch.half, torch.bfloat16]),
         device=cpu_and_maybe_gpu(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_dense_to_jagged_dynamic_shape(
         self,
         num_jagged_dim: int,

--- a/fbgemm_gpu/test/jagged/elementwise_binary_test.py
+++ b/fbgemm_gpu/test/jagged/elementwise_binary_test.py
@@ -140,7 +140,7 @@ class ElementwiseBinaryTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float, torch.half, torch.bfloat16]),
         device=cpu_and_maybe_gpu(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_jagged_elementwise_binary(
         self,
         num_jagged_dim: int,
@@ -168,7 +168,7 @@ class ElementwiseBinaryTest(unittest.TestCase):
         dtype=st.just(torch.half),
         device=cpu_and_maybe_gpu(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=4, deadline=None)
     def test_jagged_elementwise_binary_opt(
         self,
         num_jagged_dim: int,
@@ -196,7 +196,7 @@ class ElementwiseBinaryTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float, torch.half, torch.bfloat16]),
         device=cpu_and_maybe_gpu(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_jagged_elementwise_binary_dynamic_shape(
         self,
         num_jagged_dim: int,

--- a/fbgemm_gpu/test/jagged/expand_into_jagged_permute_test.py
+++ b/fbgemm_gpu/test/jagged/expand_into_jagged_permute_test.py
@@ -61,7 +61,7 @@ class ExpandIntoJaggedPermuteTest(unittest.TestCase):
         T=st.integers(min_value=10, max_value=20),
         W=st.integers(min_value=8, max_value=64),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=10, deadline=None)
     def test_expand_into_jagged_permute(
         self,
         T: int,

--- a/fbgemm_gpu/test/jagged/get_source_mask_test.py
+++ b/fbgemm_gpu/test/jagged/get_source_mask_test.py
@@ -46,7 +46,7 @@ class GetSourceMaskTest(unittest.TestCase):
         max_targets=st.integers(min_value=1, max_value=20),
         dtype=st.sampled_from([torch.int32, torch.int64]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_get_source_mask_basic(
         self,
         batch_size: int,
@@ -135,7 +135,7 @@ class GetSourceMaskTest(unittest.TestCase):
     @given(
         batch_size=st.integers(min_value=10, max_value=1000),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=5, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=5, deadline=None)
     def test_get_source_mask_large_batch(self, batch_size: int) -> None:
         device = torch.accelerator.current_accelerator()
 

--- a/fbgemm_gpu/test/jagged/jagged_index_select_2d_test.py
+++ b/fbgemm_gpu/test/jagged/jagged_index_select_2d_test.py
@@ -66,7 +66,7 @@ class JaggedIndexSelect2DTest(unittest.TestCase):
         check_non_contiguous=st.booleans(),
         known_shape=st.booleans(),
     )
-    @settings(max_examples=20, deadline=None, verbosity=Verbosity.verbose)
+    @settings(max_examples=20, deadline=None, verbosity=Verbosity.normal)
     def test_jagged_index_select_2d(
         self,
         max_seq_length: int,

--- a/fbgemm_gpu/test/jagged/jagged_to_padded_dense_test.py
+++ b/fbgemm_gpu/test/jagged/jagged_to_padded_dense_test.py
@@ -40,7 +40,7 @@ class JaggedToPaddedDenseTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float, torch.half, torch.bfloat16]),
         device_type=cpu_and_maybe_gpu(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_jagged_to_padded_dense(
         self,
         num_jagged_dim: int,
@@ -165,7 +165,7 @@ class JaggedToPaddedDenseTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float, torch.half, torch.bfloat16]),
         device_type=st.just("meta"),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_jagged_to_padded_dense_meta_backend(
         self,
         num_jagged_dim: int,

--- a/fbgemm_gpu/test/jagged/misc_ops_test.py
+++ b/fbgemm_gpu/test/jagged/misc_ops_test.py
@@ -188,7 +188,7 @@ class JaggedTensorOpsTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float]),
         device_type=cpu_and_maybe_gpu(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_jagged_softmax(
         self,
         B: int,

--- a/fbgemm_gpu/test/jagged/repeat_arange_test.py
+++ b/fbgemm_gpu/test/jagged/repeat_arange_test.py
@@ -54,7 +54,7 @@ class RepeatArangeTest(unittest.TestCase):
         dtype=st.sampled_from([torch.int32, torch.int64]),
         device=cpu_and_maybe_gpu(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_repeat_arange_correctness(
         self,
         batch_size: int,
@@ -110,7 +110,7 @@ class RepeatArangeTest(unittest.TestCase):
         dtype=st.sampled_from([torch.int32, torch.int64]),
         device=cpu_and_maybe_gpu(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=10, deadline=None)
     def test_repeat_arange_single_length(
         self,
         batch_size: int,
@@ -157,7 +157,7 @@ class RepeatArangeTest(unittest.TestCase):
         max_length=st.integers(1, 100),
         dtype=st.sampled_from([torch.int32, torch.int64]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=10, deadline=None)
     def test_repeat_arange_large_batch(
         self,
         batch_size: int,
@@ -185,7 +185,7 @@ class RepeatArangeTest(unittest.TestCase):
         dtype=st.sampled_from([torch.int32, torch.int64]),
         device=st.sampled_from([torch.device("meta")]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_repeat_arange_meta_backend(
         self,
         batch_size: int,
@@ -218,7 +218,7 @@ class RepeatArangeTest(unittest.TestCase):
         dtype=st.sampled_from([torch.int32, torch.int64]),
         device=cpu_and_maybe_gpu(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=10, deadline=None)
     def test_repeat_arange_dynamic_shape(
         self,
         batch_size: int,

--- a/fbgemm_gpu/test/jagged/slice_test.py
+++ b/fbgemm_gpu/test/jagged/slice_test.py
@@ -33,7 +33,7 @@ class JaggedSliceTest(unittest.TestCase):
         slice_length=st.integers(0, 64),
         dtype=st.sampled_from([torch.float]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_jagged_slice(
         self,
         B: int,

--- a/fbgemm_gpu/test/jagged/unique_indices_test.py
+++ b/fbgemm_gpu/test/jagged/unique_indices_test.py
@@ -100,7 +100,7 @@ class UniqueIndicesTest(unittest.TestCase):
         max_length=st.integers(min_value=5, max_value=10),
         dtype=st.sampled_from([torch.int32, torch.int64]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=10, deadline=None)
     def test_jagged_unique_indices(
         self,
         B: int,  # Batch size
@@ -206,7 +206,7 @@ class UniqueIndicesTest(unittest.TestCase):
         max_length=st.integers(min_value=5, max_value=10),
         dtype=st.sampled_from([torch.int32, torch.int64]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=10, deadline=None)
     def test_jagged_unique_indices_multi_keys(
         self,
         B: int,  # Batch size
@@ -280,7 +280,7 @@ class UniqueIndicesTest(unittest.TestCase):
         F=st.integers(min_value=50, max_value=100),
         dtype=st.sampled_from([torch.int32, torch.int64]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=2, deadline=None)
     def test_jagged_unique_indices_empty(
         self,
         B: int,  # Batch size
@@ -709,7 +709,7 @@ class UniqueIndicesTest(unittest.TestCase):
         weight_dtype=st.sampled_from([torch.float32, torch.float16]),
         use_cpu=st.booleans() if not gpu_unavailable[0] else st.just(True),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_jagged_acc_weights_and_counts_1d(
         self,
         num_elements: int,
@@ -759,7 +759,7 @@ class UniqueIndicesTest(unittest.TestCase):
     @given(
         use_cpu=st.booleans() if not gpu_unavailable[0] else st.just(True),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=2, deadline=None)
     def test_jagged_acc_weights_and_counts_edge_cases(self, use_cpu: bool) -> None:
         """Test edge cases for both 1D and 2D accumulation kernels.
 
@@ -786,7 +786,7 @@ class UniqueIndicesTest(unittest.TestCase):
         torch.testing.assert_close(result, expected)
 
     @given(use_cpu=st.booleans() if not gpu_unavailable[0] else st.just(True))
-    @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=2, deadline=None)
     def test_jagged_acc_weights_and_counts_different_sizes(self, use_cpu: bool) -> None:
         """Test that the kernel works correctly with different dataset sizes.
 

--- a/fbgemm_gpu/test/layout_transform_ops_test.py
+++ b/fbgemm_gpu/test/layout_transform_ops_test.py
@@ -39,7 +39,7 @@ class LayoutTransformOpsTest(unittest.TestCase):
         D=st.integers(min_value=2, max_value=20),
         W=st.integers(min_value=1, max_value=20),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_recat_embedding_grad_output(self, B: int, T: int, D: int, W: int) -> None:
         num_features_per_rank = np.random.randint(low=1, high=20, size=(W,)).tolist()
         grad_output = torch.randn(B, sum(num_features_per_rank), D).float().cuda()
@@ -65,7 +65,7 @@ class LayoutTransformOpsTest(unittest.TestCase):
         W=st.integers(min_value=1, max_value=20),
         cuda=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_recat_embedding_grad_output_mixed_D(
         self, B: int, W: int, cuda: bool
     ) -> None:
@@ -107,7 +107,7 @@ class LayoutTransformOpsTest(unittest.TestCase):
         B=st.integers(min_value=1, max_value=20),
         W=st.integers(min_value=1, max_value=20),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_recat_embedding_grad_output_mixed_D_batch(self, B: int, W: int) -> None:
         num_features_per_rank = np.random.randint(low=1, high=20, size=(W,)).tolist()
         global_T = sum(num_features_per_rank)

--- a/fbgemm_gpu/test/merge_pooled_embeddings_test.py
+++ b/fbgemm_gpu/test/merge_pooled_embeddings_test.py
@@ -69,7 +69,7 @@ class MergePooledEmbeddingsTest(unittest.TestCase):
         source_from_same_device=st.booleans(),
     )
     # Can instantiate 8 contexts which takes a long time.
-    @settings(verbosity=Verbosity.verbose, max_examples=40, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=40, deadline=None)
     def test_merge(
         self,
         num_ads: int,
@@ -133,7 +133,7 @@ class MergePooledEmbeddingsTest(unittest.TestCase):
         use_pitched=st.booleans(),
     )
     # Can instantiate 8 contexts which takes a long time.
-    @settings(verbosity=Verbosity.verbose, max_examples=40, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=40, deadline=None)
     def test_all_to_one_device(
         self,
         num_inputs: int,
@@ -181,7 +181,7 @@ class MergePooledEmbeddingsTest(unittest.TestCase):
         target_deivce=st.integers(min_value=0, max_value=torch.cuda.device_count() - 1),
     )
     # Can instantiate 8 contexts which takes a long time.
-    @settings(verbosity=Verbosity.verbose, max_examples=40, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=40, deadline=None)
     def test_merge_pooled_embeddings_gpu_to_cuda_without_index(
         self,
         # pyre-fixme[2]: Parameter must be annotated.
@@ -234,7 +234,7 @@ class MergePooledEmbeddingsTest(unittest.TestCase):
         r=st.randoms(use_true_random=False),
     )
     # Can instantiate 8 contexts which takes a long time.
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=10, deadline=None)
     def test_sum_reduce_to_one(
         self,
         # pyre-fixme[2]: Parameter must be annotated.

--- a/fbgemm_gpu/test/quantize/fp8_rowwise_test.py
+++ b/fbgemm_gpu/test/quantize/fp8_rowwise_test.py
@@ -62,7 +62,7 @@ class TestFP8RowwiseQuantizationConversion(unittest.TestCase):
         ),
         test_compile=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=max_examples, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=max_examples, deadline=None)
     def test_quantize_and_dequantize_op_fp8_rowwise(
         self,
         batched: bool,
@@ -154,7 +154,7 @@ class TestFP8RowwiseQuantizationConversion(unittest.TestCase):
             ],
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=max_examples, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=max_examples, deadline=None)
     def test_quantize_and_dequantize_op_padded_fp8_rowwise(
         self,
         m: int,

--- a/fbgemm_gpu/test/quantize/mx4_test.py
+++ b/fbgemm_gpu/test/quantize/mx4_test.py
@@ -153,7 +153,7 @@ class TestMXQuantizationConversion(unittest.TestCase):
         power=st.integers(min_value=5, max_value=8),
         sizes=st.integers(min_value=4, max_value=12),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_mx4(self, power: int, sizes: int) -> None:
         group_size = 2**power
         device = torch.device("cuda")
@@ -250,7 +250,7 @@ class TestMXQuantizationConversion(unittest.TestCase):
         mx4_format=st.sampled_from([(2, 1), (3, 0)]),
         device=st.sampled_from(["cpu", "cuda"]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_mx4_cases(
         self,
         shape: list[int],
@@ -293,7 +293,7 @@ class TestMXQuantizationConversion(unittest.TestCase):
         output_dtype=st.sampled_from([None, SparseType.FP32, SparseType.BF16]),
         use_triton=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=10, deadline=None)
     def test_mx4_to_float_correctness(
         self, output_dtype: SparseType | None, use_triton: bool
     ) -> None:
@@ -384,7 +384,7 @@ class TestMXQuantizationConversion(unittest.TestCase):
         mx4_format=st.sampled_from([(2, 1)]),
         device=st.sampled_from(["cuda"]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=2, deadline=None)
     def test_mx4_large_cases(
         self,
         shape: list[int],

--- a/fbgemm_gpu/test/sparse/block_bucketize_2d_weights_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_2d_weights_test.py
@@ -59,7 +59,7 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
         sequence=st.booleans(),
         weights_dim=st.sampled_from([2, 3, 4]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_2d_weights(
         self,
         index_type: type[torch.dtype],
@@ -177,7 +177,7 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
         bucketize_pos=st.booleans(),
         sequence=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_2d_weights_vs_original(
         self,
         index_type: type[torch.dtype],
@@ -332,7 +332,7 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
         bucketize_pos=st.booleans(),
         weights_dtype=st.sampled_from([torch.float, torch.double]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_2d_weights_pooled_vs_sequence(
         self,
         index_type: type[torch.dtype],
@@ -480,7 +480,7 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
         sequence=st.booleans(),
         keep_orig_idx=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_2d_weights_keep_orig_idx(
         self,
         index_type: type[torch.dtype],
@@ -590,7 +590,7 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
         bucketize_pos=st.booleans(),
         sequence=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_2d_weights_keep_orig_idx_per_feature(
         self,
         index_type: type[torch.dtype],
@@ -695,7 +695,7 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
         bucketize_pos=st.booleans(),
         sequence=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_2d_weights_total_num_blocks(
         self,
         index_type: type[torch.dtype],
@@ -796,7 +796,7 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
         bucketize_pos=st.booleans(),
         sequence=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_2d_weights_block_bucketize_pos(
         self,
         index_type: type[torch.dtype],
@@ -905,7 +905,7 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
         bucketize_pos=st.booleans(),
         sequence=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_2d_weights_with_variable_batch_sizes(
         self,
         index_type: type[torch.dtype],

--- a/fbgemm_gpu/test/sparse/block_bucketize_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_test.py
@@ -84,7 +84,7 @@ class BlockBucketizeTest(unittest.TestCase):
         sequence=st.booleans(),
         bucketize_pos=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_long_indices(
         self,
         long_indices: bool,
@@ -282,7 +282,7 @@ class BlockBucketizeTest(unittest.TestCase):
         sequence=st.booleans(),
         bucketize_pos=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_keep_orig_idx_per_feature(
         self,
         long_indices: bool,
@@ -477,7 +477,7 @@ class BlockBucketizeTest(unittest.TestCase):
         keep_orig_idx=st.booleans(),
         sequence=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_total_num_blocks_uneven_raw_ids(
         self,
         long_indices: bool,
@@ -612,7 +612,7 @@ class BlockBucketizeTest(unittest.TestCase):
         keep_orig_idx=st.booleans(),
         sequence=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_total_num_blocks_uneven(
         self,
         long_indices: bool,
@@ -735,7 +735,7 @@ class BlockBucketizeTest(unittest.TestCase):
         keep_orig_idx=st.booleans(),
         sequence=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_total_num_blocks(
         self,
         long_indices: bool,
@@ -846,7 +846,7 @@ class BlockBucketizeTest(unittest.TestCase):
         keep_orig_idx=st.booleans(),
         sequence=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_total_num_blocks_raw_ids(
         self,
         long_indices: bool,
@@ -956,7 +956,7 @@ class BlockBucketizeTest(unittest.TestCase):
         bucketize_pos=st.booleans(),
         sequence=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features(
         self,
         index_type: type[torch.dtype],
@@ -1120,7 +1120,7 @@ class BlockBucketizeTest(unittest.TestCase):
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_inference(
         self,
         index_type: type[torch.dtype],
@@ -1201,7 +1201,7 @@ class BlockBucketizeTest(unittest.TestCase):
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_populate_bucketized_permute(
         self,
         index_type: type[torch.dtype],
@@ -1388,7 +1388,7 @@ class BlockBucketizeTest(unittest.TestCase):
         my_size=st.integers(min_value=1, max_value=16),
         num_sequences=st.integers(min_value=1, max_value=32),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_populate_bucketized_permute_long_sequences(
         self,
         index_type: torch.dtype,
@@ -1411,7 +1411,7 @@ class BlockBucketizeTest(unittest.TestCase):
         index_type=st.sampled_from([torch.int, torch.long]),
         num_sequences=st.integers(min_value=1, max_value=16),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_populate_bucketized_permute_my_size_boundary(
         self,
         index_type: torch.dtype,
@@ -1434,7 +1434,7 @@ class BlockBucketizeTest(unittest.TestCase):
         my_size=st.integers(min_value=33, max_value=64),
         num_sequences=st.integers(min_value=1, max_value=16),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_populate_bucketized_permute_fallback_kernel(
         self,
         index_type: torch.dtype,
@@ -1457,7 +1457,7 @@ class BlockBucketizeTest(unittest.TestCase):
         index_type=st.sampled_from([torch.int, torch.long]),
         my_size=st.integers(min_value=1, max_value=32),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_populate_bucketized_permute_many_sequences(
         self,
         index_type: torch.dtype,
@@ -1478,7 +1478,7 @@ class BlockBucketizeTest(unittest.TestCase):
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_populate_bucketized_permute_warp_parallel_vs_original(
         self,
         index_type: torch.dtype,
@@ -1589,7 +1589,7 @@ class BlockBucketizeTest(unittest.TestCase):
         bucketize_pos=st.booleans(),
         sequence=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_with_variable_batch_sizes(
         self,
         index_type: torch.dtype | None,
@@ -1681,7 +1681,7 @@ class BlockBucketizeTest(unittest.TestCase):
         bucketize_pos=st.booleans(),
         sequence=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_with_block_bucketize_pos(
         self,
         index_type: torch.dtype | None,
@@ -1850,7 +1850,7 @@ class BlockBucketizeTest(unittest.TestCase):
         sequence=st.booleans(),
         my_size=st.sampled_from([3, 194, 256, 1024]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=32, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=32, deadline=None)
     def test_block_bucketize_sparse_features_large(
         self,
         index_type: type[torch.dtype],
@@ -1956,7 +1956,7 @@ class BlockBucketizeTest(unittest.TestCase):
         bucketize_pos=st.booleans(),
         sequence=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_float64_weights(
         self,
         index_type: type[torch.dtype],

--- a/fbgemm_gpu/test/sparse/cumsum_test.py
+++ b/fbgemm_gpu/test/sparse/cumsum_test.py
@@ -42,7 +42,7 @@ class CumSumTest(unittest.TestCase):
         ),
         device=cpu_and_maybe_gpu(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_cumsum(
         self,
         n: int,
@@ -108,7 +108,7 @@ class CumSumTest(unittest.TestCase):
         ),
         device=cpu_and_maybe_gpu(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_asynchronous_complete_cumsum_2d(
         self,
         n: int,
@@ -148,7 +148,7 @@ class CumSumTest(unittest.TestCase):
         device=cpu_and_maybe_gpu(),
     )
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=50,
         deadline=None,
     )

--- a/fbgemm_gpu/test/sparse/histogram_binning_calibration_test.py
+++ b/fbgemm_gpu/test/sparse/histogram_binning_calibration_test.py
@@ -28,7 +28,7 @@ else:
 
 class HistogramBinningCalibrationTest(unittest.TestCase):
     @given(data_type=st.sampled_from([torch.bfloat16, torch.half, torch.float32]))
-    @settings(verbosity=Verbosity.verbose, deadline=None)
+    @settings(verbosity=Verbosity.normal, deadline=None)
     def test_histogram_binning_calibration(self, data_type: torch.dtype) -> None:
         num_bins = 5000
 
@@ -114,7 +114,7 @@ class HistogramBinningCalibrationTest(unittest.TestCase):
         segment_value_type=st.sampled_from([torch.int, torch.long]),
         segment_length_type=st.sampled_from([torch.int, torch.long]),
     )
-    @settings(verbosity=Verbosity.verbose, deadline=None)
+    @settings(verbosity=Verbosity.normal, deadline=None)
     def test_histogram_binning_calibration_by_feature(
         self,
         data_type: torch.dtype,
@@ -219,7 +219,7 @@ class HistogramBinningCalibrationTest(unittest.TestCase):
         segment_value_type=st.sampled_from([torch.int, torch.long]),
         segment_length_type=st.sampled_from([torch.int, torch.long]),
     )
-    @settings(verbosity=Verbosity.verbose, deadline=None)
+    @settings(verbosity=Verbosity.normal, deadline=None)
     def test_generic_histogram_binning_calibration_by_feature(
         self,
         data_type: torch.dtype,
@@ -326,7 +326,7 @@ class HistogramBinningCalibrationTest(unittest.TestCase):
     @given(
         data_type=st.sampled_from([torch.bfloat16, torch.half, torch.float32]),
     )
-    @settings(verbosity=Verbosity.verbose, deadline=None)
+    @settings(verbosity=Verbosity.normal, deadline=None)
     @optests.dontGenerateOpCheckTests(
         "GPU-only CPU/GPU parity test; op covered by test_generic_histogram_binning_calibration_by_feature (T191384137)"
     )

--- a/fbgemm_gpu/test/sparse/index_select_test.py
+++ b/fbgemm_gpu/test/sparse/index_select_test.py
@@ -132,7 +132,7 @@ class IndexSelectTest(unittest.TestCase):
         check_non_contiguous=st.booleans(),
     )
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=20,
         deadline=None,
     )
@@ -544,7 +544,7 @@ class IndexSelectTest(unittest.TestCase):
         ),
     )
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=20,
         deadline=None,
     )
@@ -616,7 +616,7 @@ class IndexSelectTest(unittest.TestCase):
         max_rl=st.sampled_from([32, 64, 128, 256, 512]),
     )
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=20,
         deadline=None,
     )

--- a/fbgemm_gpu/test/sparse/misc_ops_test.py
+++ b/fbgemm_gpu/test/sparse/misc_ops_test.py
@@ -38,7 +38,7 @@ class MiscOpsTest(unittest.TestCase):
         permute_size=st.integers(min_value=0, max_value=1000),
         long_index=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_invert_permute(
         self,
         permute_size: int,
@@ -64,7 +64,7 @@ class MiscOpsTest(unittest.TestCase):
         N=st.integers(min_value=1, max_value=20),
         offsets_type=st.sampled_from([torch.int32, torch.int64]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_offsets_range(
         self,
         N: int,
@@ -94,7 +94,7 @@ class MiscOpsTest(unittest.TestCase):
         has_weight=st.booleans(),
         bucketize_pos=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=2, deadline=None)
     def test_bucketize_sparse_features(
         self,
         index_type: type[torch.dtype],
@@ -260,7 +260,7 @@ class MiscOpsTest(unittest.TestCase):
         n=st.just(5),
         use_cpu=st.booleans() if gpu_available else st.just(True),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_permute102_baddbmm_permute102(
         self,
         batch_size: int,

--- a/fbgemm_gpu/test/sparse/permute_embeddings_test.py
+++ b/fbgemm_gpu/test/sparse/permute_embeddings_test.py
@@ -98,7 +98,7 @@ class PermuteEmbeddingsTest(unittest.TestCase):
         # routing it through the Callable-typed param so pyre accepts the op.
         permute_fn=st.just(torch.ops.fbgemm.permute_2D_sparse_data),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=10, deadline=None)
     def test_permute_embeddings_2d(
         self,
         B: int,
@@ -119,7 +119,7 @@ class PermuteEmbeddingsTest(unittest.TestCase):
         # routing it through the Callable-typed param so pyre accepts the op.
         permute_fn=st.just(torch.ops.fbgemm.permute_sequence_embeddings),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=10, deadline=None)
     def test_permute_embeddings_seq(
         self,
         B: int,
@@ -133,7 +133,7 @@ class PermuteEmbeddingsTest(unittest.TestCase):
     @given(
         weights_dtype=st.sampled_from([torch.float, torch.double, torch.half]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=10, deadline=None)
     def test_permute_2D_sparse_data_weights_dtype(
         self, weights_dtype: torch.dtype
     ) -> None:

--- a/fbgemm_gpu/test/sparse/permute_indices_test.py
+++ b/fbgemm_gpu/test/sparse/permute_indices_test.py
@@ -54,7 +54,7 @@ class PermuteIndicesTest(unittest.TestCase):
         is_1D=st.booleans(),
         W=st.integers(min_value=4, max_value=8),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_permute_indices(
         self,
         B: int,
@@ -180,7 +180,7 @@ class PermuteIndicesTest(unittest.TestCase):
         L=st.integers(min_value=2, max_value=20),
         long_index=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     @unittest.skipIf(*gpu_unavailable)
     @optests.dontGenerateOpCheckTests(
         "GPU-only test; opcheck variants only skip on CPU samples and add no op coverage (T191384137)"
@@ -294,7 +294,7 @@ class PermuteIndicesTest(unittest.TestCase):
         long_index=st.booleans(),
         has_weight=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=10, deadline=None)
     def test_permute_indices_with_repeats(
         self, B: int, T: int, L: int, long_index: bool, has_weight: bool
     ) -> None:
@@ -366,7 +366,7 @@ class PermuteIndicesTest(unittest.TestCase):
         index_dtype=st.sampled_from([torch.int32, torch.int64, torch.float32]),
         has_weight=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=100, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=100, deadline=None)
     @unittest.skipIf(*gpu_unavailable)
     @optests.dontGenerateOpCheckTests(
         "GPU-only test; opcheck variants only skip on CPU samples and add no op coverage (T191384137)"
@@ -518,7 +518,7 @@ class PermuteIndicesTest(unittest.TestCase):
         index_dtype=st.sampled_from([torch.int32, torch.int64, torch.float32]),
         weights_columns=st.sampled_from([2, 3, 4, 7, 8]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=50, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=50, deadline=None)
     @unittest.skipIf(*gpu_unavailable)
     @optests.dontGenerateOpCheckTests(
         "GPU-only test; opcheck variants only skip on CPU samples and add no op coverage (T191384137)"
@@ -660,7 +660,7 @@ class PermuteIndicesTest(unittest.TestCase):
         long_index=st.booleans(),
         has_weight=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=10, deadline=None)
     @unittest.skipIf(*gpu_unavailable)
     @optests.dontGenerateOpCheckTests(
         "GPU-only test; opcheck variants only skip on CPU samples and add no op coverage (T191384137)"
@@ -739,7 +739,7 @@ class PermuteIndicesTest(unittest.TestCase):
         index_dtype=st.sampled_from([torch.int32, torch.int64, torch.float32]),
         has_weight=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=10, deadline=None)
     @unittest.skipIf(*gpu_unavailable)
     @optests.dontGenerateOpCheckTests(
         "GPU-only test; opcheck variants only skip on CPU samples and add no op coverage (T191384137)"
@@ -1055,7 +1055,7 @@ class PermuteIndicesTest(unittest.TestCase):
         long_index=st.booleans(),
         has_weight=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_permute_indices_with_preallocated_output(
         self,
         B: int,
@@ -1210,7 +1210,7 @@ class PermuteIndicesTest(unittest.TestCase):
         L=st.integers(min_value=2, max_value=20),
         long_index=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_permute_indices_backward(
         self,
         B: int,

--- a/fbgemm_gpu/test/sparse/reorder_batched_test.py
+++ b/fbgemm_gpu/test/sparse/reorder_batched_test.py
@@ -43,7 +43,7 @@ class ReorderBatchedTest(unittest.TestCase):
         Dtype=st.sampled_from([torch.int32, torch.float, torch.int64]),
         broadcast_lengths=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     @optests.dontGenerateOpCheckTests(
         "GPU-only test; opcheck variants only skip on CPU samples; op covered by *_cpu twin (T191384137)"
     )
@@ -98,7 +98,7 @@ class ReorderBatchedTest(unittest.TestCase):
         Dtype=st.sampled_from([torch.int32, torch.float, torch.int64]),
         broadcast_lengths=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=40, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=40, deadline=None)
     def test_reorder_batched_ad_lengths_cpu(
         self,
         B: int,
@@ -144,7 +144,7 @@ class ReorderBatchedTest(unittest.TestCase):
         Itype=st.sampled_from([torch.int32, torch.int64]),
         broadcast_indices=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     @optests.dontGenerateOpCheckTests(
         "GPU-only test; opcheck variants only skip on CPU samples; op covered by *_cpu twin (T191384137)"
     )
@@ -239,7 +239,7 @@ class ReorderBatchedTest(unittest.TestCase):
         broadcast_indices=st.booleans(),
         max_batch_size=st.integers(min_value=-2, max_value=5),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=20, deadline=None)
     def test_cat_reorder_batched_ad_indices_cpu(
         self,
         B: int,
@@ -356,7 +356,7 @@ class ReorderBatchedTest(unittest.TestCase):
         Itype=st.sampled_from([torch.int32, torch.int64]),
         broadcast_indices=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=40, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=40, deadline=None)
     def test_reorder_batched_ad_indices_cpu(
         self,
         B: int,
@@ -434,7 +434,7 @@ class ReorderBatchedTest(unittest.TestCase):
         L=st.integers(min_value=2, max_value=20),
         index_dtype=st.sampled_from([torch.int32, torch.int64]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=40, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=40, deadline=None)
     def test_reorder_batched_sequence_embeddings_cpu(
         self,
         B: int,
@@ -523,7 +523,7 @@ class ReorderBatchedTest(unittest.TestCase):
             [torch.float32, torch.uint8, torch.bfloat16, torch.float16]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=40, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=40, deadline=None)
     @optests.dontGenerateOpCheckTests(
         "GPU-only test; opcheck variants only skip on CPU samples; op covered by *_cpu twin (T191384137)"
     )

--- a/fbgemm_gpu/test/tbe/cache/cache_common.py
+++ b/fbgemm_gpu/test/tbe/cache/cache_common.py
@@ -48,7 +48,7 @@ else:
     )
 
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 
 class TestingStatsReporter(TBEStatsReporter):

--- a/fbgemm_gpu/test/tbe/cache/copy_test.py
+++ b/fbgemm_gpu/test/tbe/cache/copy_test.py
@@ -42,7 +42,7 @@ class CopyTest(unittest.TestCase):
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     # pyre-fixme[2]: Parameter must be annotated.
     def test_uvm_to_cpu(self, sizes: list[int], uvm_op) -> None:
         if uvm_op is torch.ops.fbgemm.new_unified_tensor:
@@ -83,7 +83,7 @@ class CopyTest(unittest.TestCase):
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     # pyre-fixme[2]: Parameter must be annotated.
     def test_uvm_to_device(self, sizes: list[int], uvm_op) -> None:
         if uvm_op is torch.ops.fbgemm.new_unified_tensor:
@@ -125,7 +125,7 @@ class CopyTest(unittest.TestCase):
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     # pyre-fixme[2]: Parameter must be annotated.
     def test_uvm_to_cpu_clone(self, sizes: list[int], uvm_op) -> None:
         if uvm_op is torch.ops.fbgemm.new_unified_tensor:

--- a/fbgemm_gpu/test/tbe/cache/host_mapped_test.py
+++ b/fbgemm_gpu/test/tbe/cache/host_mapped_test.py
@@ -83,7 +83,7 @@ class HostMappedUvmOpsTest(unittest.TestCase):
     @given(
         sizes=st.lists(st.integers(min_value=1, max_value=8), min_size=1, max_size=3),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_uvm_to_cpu_host_mapped(self, sizes: list[int]) -> None:
         uvm_t = _make_host_mapped(sizes)
         self.assertTrue(torch.ops.fbgemm.is_uvm_tensor(uvm_t))
@@ -113,7 +113,7 @@ class HostMappedUvmOpsTest(unittest.TestCase):
     @given(
         sizes=st.lists(st.integers(min_value=1, max_value=8), min_size=1, max_size=3),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_uvm_to_cpu_unified_host_mapped(self, sizes: list[int]) -> None:
         uvm_t = _make_unified_host_mapped(sizes)
         self.assertTrue(torch.ops.fbgemm.is_uvm_tensor(uvm_t))

--- a/fbgemm_gpu/test/tbe/cache/linearize_cache_indices_test.py
+++ b/fbgemm_gpu/test/tbe/cache/linearize_cache_indices_test.py
@@ -24,7 +24,7 @@ else:
     from fbgemm_gpu.test.test_utils import gpu_unavailable, optests
 
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 
 @optests.generate_opcheck_tests(fast=True)

--- a/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
+++ b/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
@@ -25,7 +25,7 @@ from torch import Tensor
 from ..common import MAX_EXAMPLES  # noqa E402
 from .cache_common import generate_cache_tbes, gpu_unavailable, optests
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 
 @optests.generate_opcheck_tests(fast=True)
@@ -247,7 +247,7 @@ class LXUCacheTest(unittest.TestCase):
         log_E=st.integers(min_value=3, max_value=5),
         L=st.integers(min_value=0, max_value=20),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_unique_lxu_cache_lookup(
         self,
         T: int,

--- a/fbgemm_gpu/test/tbe/cache/uvm_test.py
+++ b/fbgemm_gpu/test/tbe/cache/uvm_test.py
@@ -50,7 +50,7 @@ class UvmTest(unittest.TestCase):
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     # pyre-fixme[2]: Parameter must be annotated.
     def test_is_uvm_tensor(self, sizes: list[int], uvm_op) -> None:
         if uvm_op is torch.ops.fbgemm.new_unified_tensor:
@@ -83,7 +83,7 @@ class UvmTest(unittest.TestCase):
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     # pyre-fixme[2]: Parameter must be annotated.
     def test_cudaMemAdvise(self, sizes: list[int], uvm_op) -> None:
         if uvm_op is torch.ops.fbgemm.new_unified_tensor:
@@ -115,7 +115,7 @@ class UvmTest(unittest.TestCase):
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     # pyre-fixme[2]: Parameter must be annotated.
     def test_cudaMemPrefetchAsync(self, sizes: list[int], uvm_op) -> None:
         if uvm_op is torch.ops.fbgemm.new_unified_tensor:
@@ -148,7 +148,7 @@ class UvmTest(unittest.TestCase):
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     # pyre-fixme[2]: Parameter must be annotated.
     def test_uvm_slice(self, sizes: list[int], uvm_op) -> None:
         if uvm_op is torch.ops.fbgemm.new_unified_tensor:
@@ -188,7 +188,7 @@ class UvmTest(unittest.TestCase):
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     # pyre-fixme[2]: Parameter must be annotated.
     def test_uvm_memadviceDontFork(self, sizes: list[int], uvm_op) -> None:
         if uvm_op is torch.ops.fbgemm.new_unified_tensor:
@@ -214,7 +214,7 @@ class UvmTest(unittest.TestCase):
             st.integers(min_value=1, max_value=(512)), min_size=1, max_size=3
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_new_managed_tensor_meta(self, sizes: list[int]) -> None:
         cpu_tensor = torch.empty(sizes).to("meta")
         cpu_tensor_meta = torch.ops.fbgemm.new_managed_tensor(cpu_tensor, sizes)

--- a/fbgemm_gpu/test/tbe/common.py
+++ b/fbgemm_gpu/test/tbe/common.py
@@ -72,7 +72,7 @@ MAX_EXAMPLES_LONG_RUNNING = 15
 
 FORWARD_MAX_THREADS = 512
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 
 def gen_mixed_B_batch_sizes(

--- a/fbgemm_gpu/test/tbe/dram_kv/dram_kv_test.py
+++ b/fbgemm_gpu/test/tbe/dram_kv/dram_kv_test.py
@@ -37,7 +37,7 @@ default_st: dict[str, Any] = {
 }
 
 default_settings: dict[str, Any] = {
-    "verbosity": Verbosity.verbose,
+    "verbosity": Verbosity.normal,
     "max_examples": MAX_EXAMPLES,
     "deadline": None,
 }

--- a/fbgemm_gpu/test/tbe/inference/inference_converter_test.py
+++ b/fbgemm_gpu/test/tbe/inference/inference_converter_test.py
@@ -152,7 +152,7 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
         use_cpu=st.booleans() if gpu_available else st.just(True),
         pruning_ratio=st.sampled_from([None, 0.0]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_quantize_workflow(
         self,
         T: int,
@@ -255,7 +255,7 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_l2_norm_pruning_workflow(
         self,
         use_cpu: bool,
@@ -338,7 +338,7 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
         use_cpu=st.booleans() if gpu_available else st.just(True),
         use_array_for_index_remapping=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_pruning_workflow_large_scale(
         self,
         T: int,

--- a/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
@@ -41,7 +41,7 @@ else:
     from fbgemm_gpu.test.test_utils import gpu_unavailable, optests
 
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 
 additional_decorators: dict[str, list[Callable[..., Any]]] = {

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_autovec_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_autovec_test.py
@@ -24,7 +24,7 @@ from hypothesis import given, settings, Verbosity
 from ..common import MAX_EXAMPLES, TEST_WITH_ROCM
 from .common import get_nbit_weights_ty, NBitFowardTestCommon
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 
 class NBitFowardAutovecTest(NBitFowardTestCommon):

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -52,7 +52,7 @@ else:
     from fbgemm_gpu.test.test_utils import gpu_unavailable, optests, TEST_WITH_ROCM
 
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 
 # Cases for ``test_nbit_forward_nan_zero_fill``. Each tuple is

--- a/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
@@ -38,7 +38,7 @@ else:
     from fbgemm_gpu.test.test_utils import gpu_unavailable, optests, TEST_WITH_ROCM
 
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 # pyre-ignore
 additional_decorators: dict[str, list[Callable[..., Any]]] = {

--- a/fbgemm_gpu/test/tbe/ssd/kv_backend_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/kv_backend_test.py
@@ -47,7 +47,7 @@ default_st: dict[str, Any] = {
 }
 
 default_settings: dict[str, Any] = {
-    "verbosity": Verbosity.verbose,
+    "verbosity": Verbosity.normal,
     "max_examples": MAX_EXAMPLES,
     "deadline": None,
 }

--- a/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
@@ -31,7 +31,7 @@ if not open_source:
 MAX_EXAMPLES = 20
 MAX_D = 256
 default_settings: dict[str, Any] = {
-    "verbosity": Verbosity.verbose,
+    "verbosity": Verbosity.normal,
     "max_examples": MAX_EXAMPLES,
     "deadline": None,
 }

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
@@ -96,7 +96,7 @@ class SSDIntNBitTableBatchedEmbeddingsTest(unittest.TestCase):
         ),
         mixed_weights_ty=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_nbit_ssd_forward(
         self,
         T: int,
@@ -250,7 +250,7 @@ class SSDIntNBitTableBatchedEmbeddingsTest(unittest.TestCase):
         L=st.integers(min_value=0, max_value=20),
         weighted=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_nbit_ssd_cache(
         self, T: int, D: int, B: int, log_E: int, L: int, weighted: bool
     ) -> None:

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
@@ -68,7 +68,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
         weights_precision=st.sampled_from([SparseType.FP32, SparseType.FP16]),
         indice_int64_t=st.sampled_from([True, False]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_ssd(self, indice_int64_t: bool, weights_precision: SparseType) -> None:
         import tempfile
 
@@ -114,7 +114,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
         **default_strategies,
         backend_type=st.sampled_from([BackendType.SSD, BackendType.DRAM]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_ssd_forward(
         self,
         T: int,
@@ -454,7 +454,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
 
     @given(**default_strategies)
     @settings(
-        verbosity=Verbosity.verbose, max_examples=MAX_PIPELINE_EXAMPLES, deadline=None
+        verbosity=Verbosity.normal, max_examples=MAX_PIPELINE_EXAMPLES, deadline=None
     )
     def test_ssd_cache_implicit_prefetch(self, **kwargs: Any):
         """
@@ -475,7 +475,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
 
     @given(**default_strategies)
     @settings(
-        verbosity=Verbosity.verbose, max_examples=MAX_PIPELINE_EXAMPLES, deadline=None
+        verbosity=Verbosity.normal, max_examples=MAX_PIPELINE_EXAMPLES, deadline=None
     )
     def test_ssd_cache_explicit_prefetch(self, **kwargs: Any):
         """
@@ -506,7 +506,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
 
     @given(use_prefetch_stream=st.booleans(), **default_strategies)
     @settings(
-        verbosity=Verbosity.verbose, max_examples=MAX_PIPELINE_EXAMPLES, deadline=None
+        verbosity=Verbosity.normal, max_examples=MAX_PIPELINE_EXAMPLES, deadline=None
     )
     def test_ssd_cache_pipeline_before_fwd(self, **kwargs: Any):
         """
@@ -536,7 +536,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
 
     @given(use_prefetch_stream=st.booleans(), **default_strategies)
     @settings(
-        verbosity=Verbosity.verbose, max_examples=MAX_PIPELINE_EXAMPLES, deadline=None
+        verbosity=Verbosity.normal, max_examples=MAX_PIPELINE_EXAMPLES, deadline=None
     )
     def test_ssd_cache_pipeline_between_fwd_bwd(self, **kwargs: Any):
         """
@@ -571,7 +571,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
         num_buckets=st.integers(min_value=10, max_value=15),
         backend_type=st.sampled_from([BackendType.SSD, BackendType.DRAM]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_kv_db_forward(
         self,
         T: int,
@@ -659,7 +659,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
         backend_type=st.sampled_from([BackendType.SSD, BackendType.DRAM]),
         enable_optimizer_offloading=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_apply_kv_state_dict(
         self,
         T: int,
@@ -930,7 +930,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
         **default_strategies,
     )
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=MAX_PIPELINE_EXAMPLES,
         deadline=None,
     )
@@ -973,7 +973,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
         **default_strategies,
     )
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=MAX_PIPELINE_EXAMPLES,
         deadline=None,
     )
@@ -1017,7 +1017,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
         enable_optimizer_offloading=st.booleans(),
         prefetch_pipeline=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_direct_write_embedding(
         self,
         T: int,
@@ -1327,7 +1327,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
         enable_optimizer_offloading=st.just(True),
         prefetch_pipeline=st.just(True),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_direct_write_with_async_backend_fetch_synchronization(
         self,
         T: int,
@@ -1566,7 +1566,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
         enable_optimizer_offloading=st.just(True),
         prefetch_pipeline=st.just(True),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_direct_write_clears_location_update_queue(
         self,
         T: int,
@@ -1818,7 +1818,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
     @given(
         weights_precision=st.sampled_from([SparseType.FP32, SparseType.FP16]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=4, deadline=None)
     def test_auto_size_block_cache(
         self,
         weights_precision: SparseType,
@@ -1893,7 +1893,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
     @given(
         ssd_rocksdb_shards=st.sampled_from([1, 4, 8]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=3, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=3, deadline=None)
     def test_rocksdb_tuning_thread_pool_scaling(
         self,
         ssd_rocksdb_shards: int,
@@ -2043,7 +2043,7 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
         use_prefetch_stream=st.booleans(),
     )
     @settings(
-        verbosity=Verbosity.verbose,
+        verbosity=Verbosity.normal,
         max_examples=2,
         deadline=None,
     )

--- a/fbgemm_gpu/test/tbe/ssd/ssd_tbe_training_adam_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_tbe_training_adam_test.py
@@ -43,7 +43,7 @@ class SSDSplitTBEAdamTest(SSDSplitTableBatchedEmbeddingsTestCommon):
         **default_st,
         backend_type=st.sampled_from([BackendType.SSD, BackendType.DRAM]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_ssd_backward_adam(
         self,
         T: int,
@@ -203,7 +203,7 @@ class SSDSplitTBEAdamTest(SSDSplitTableBatchedEmbeddingsTestCommon):
         bulk_init_chunk_size=st.sampled_from([0, 204800]),
         lazy_bulk_init_enabled=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_ssd_emb_state_dict_adam(
         self,
         T: int,
@@ -355,7 +355,7 @@ class SSDSplitTBEAdamTest(SSDSplitTableBatchedEmbeddingsTestCommon):
         enable_optimizer_offloading=st.booleans(),
         backend_type=st.sampled_from([BackendType.SSD, BackendType.DRAM]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_kv_emb_state_dict_adam(
         self,
         T: int,
@@ -556,7 +556,7 @@ class SSDSplitTBEAdamTest(SSDSplitTableBatchedEmbeddingsTestCommon):
         enable_optimizer_offloading=st.just(True),
         backend_type=st.sampled_from([BackendType.DRAM]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_kv_emb_state_dict_adam_whole_row(
         self,
         T: int,

--- a/fbgemm_gpu/test/tbe/ssd/ssd_tbe_training_partial_rowwise_adam_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_tbe_training_partial_rowwise_adam_test.py
@@ -44,7 +44,7 @@ class SSDSplitTBEPartialRowwiseAdamTest(SSDSplitTableBatchedEmbeddingsTestCommon
         **default_st,
         backend_type=st.sampled_from([BackendType.SSD, BackendType.DRAM]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_ssd_backward_partial_rowwise_adam(
         self,
         T: int,
@@ -205,7 +205,7 @@ class SSDSplitTBEPartialRowwiseAdamTest(SSDSplitTableBatchedEmbeddingsTestCommon
         bulk_init_chunk_size=st.sampled_from([0, 204800]),
         lazy_bulk_init_enabled=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_ssd_emb_state_dict_partial_rowwise_adam(
         self,
         T: int,
@@ -370,7 +370,7 @@ class SSDSplitTBEPartialRowwiseAdamTest(SSDSplitTableBatchedEmbeddingsTestCommon
         enable_optimizer_offloading=st.booleans(),
         backend_type=st.just(BackendType.DRAM),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_kv_emb_state_dict_partial_rowwise_adam(
         self,
         T: int,
@@ -572,7 +572,7 @@ class SSDSplitTBEPartialRowwiseAdamTest(SSDSplitTableBatchedEmbeddingsTestCommon
         enable_optimizer_offloading=st.just(True),
         backend_type=st.sampled_from([BackendType.DRAM]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_kv_emb_state_dict_partial_rowwise_adam_whole_row(
         self,
         T: int,
@@ -819,7 +819,7 @@ class SSDSplitTBEPartialRowwiseAdamTest(SSDSplitTableBatchedEmbeddingsTestCommon
             table_offset += VIRTUAL_TABLE_ROWS
 
     @given(**default_st)
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_ssd_fetch_from_l1_sp_w_row_ids_partial_rowwise_adam(
         self,
         T: int,

--- a/fbgemm_gpu/test/tbe/ssd/ssd_tbe_training_rowwise_adagrad_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_tbe_training_rowwise_adagrad_test.py
@@ -36,7 +36,7 @@ class SSDSplitTBERowwiseAdagradTest(SSDSplitTableBatchedEmbeddingsTestCommon):
         **default_strategies,
         backend_type=st.sampled_from([BackendType.SSD, BackendType.DRAM]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_ssd_backward_adagrad(
         self,
         T: int,
@@ -174,7 +174,7 @@ class SSDSplitTBERowwiseAdagradTest(SSDSplitTableBatchedEmbeddingsTestCommon):
         bulk_init_chunk_size=st.sampled_from([0, 204800]),
         lazy_bulk_init_enabled=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_ssd_emb_state_dict_adagrad(
         self, bulk_init_chunk_size: int, lazy_bulk_init_enabled: bool
     ) -> None:
@@ -297,7 +297,7 @@ class SSDSplitTBERowwiseAdagradTest(SSDSplitTableBatchedEmbeddingsTestCommon):
         enable_optimizer_offloading=st.booleans(),
         backend_type=st.sampled_from([BackendType.SSD, BackendType.DRAM]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_kv_emb_state_dict_adagrad(
         self,
         T: int,
@@ -512,7 +512,7 @@ class SSDSplitTBERowwiseAdagradTest(SSDSplitTableBatchedEmbeddingsTestCommon):
         num_buckets=st.integers(min_value=10, max_value=15),
         enable_optimizer_offloading=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_kv_opt_state_w_offloading_adagrad(
         self,
         T: int,
@@ -740,7 +740,7 @@ class SSDSplitTBERowwiseAdagradTest(SSDSplitTableBatchedEmbeddingsTestCommon):
         **default_strategies,
         num_buckets=st.integers(min_value=10, max_value=15),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_kv_state_dict_w_backend_return_whole_row(
         self,
         T: int,
@@ -1001,7 +1001,7 @@ class SSDSplitTBERowwiseAdagradTest(SSDSplitTableBatchedEmbeddingsTestCommon):
             )
 
     @given(**default_strategies)
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_ssd_fetch_from_l1_sp_w_row_ids_weight(
         self,
         T: int,
@@ -1166,7 +1166,7 @@ class SSDSplitTBERowwiseAdagradTest(SSDSplitTableBatchedEmbeddingsTestCommon):
             )
 
     @given(**default_strategies)
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_ssd_fetch_from_l1_sp_w_row_ids_opt_only(
         self,
         T: int,

--- a/fbgemm_gpu/test/tbe/ssd/ssd_utils_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_utils_test.py
@@ -100,7 +100,7 @@ class SSDUtilsTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float, torch.half]),
         use_pipeline=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_masked_index_put(
         self,
         num_indices: int,
@@ -135,7 +135,7 @@ class SSDUtilsTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float, torch.half]),
         use_pipeline=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_masked_index_select(
         self,
         num_indices: int,
@@ -180,7 +180,7 @@ class SSDUtilsTest(unittest.TestCase):
         iters=st.integers(min_value=1, max_value=5),
         total_to_uniq_ratio=st.integers(min_value=1, max_value=5),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_scratch_pad_indices_queue(
         self,
         hash_size: int,
@@ -333,7 +333,7 @@ class SSDUtilsTest(unittest.TestCase):
         num_indices=st.integers(min_value=1, max_value=128),
         num_tensors=st.integers(min_value=1, max_value=2),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    @settings(verbosity=Verbosity.normal, max_examples=MAX_EXAMPLES, deadline=None)
     def test_compact_indices(self, num_indices: int, num_tensors: int) -> None:
         """
         Test correctness of `torch.ops.fbgemm.compact_indices`

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
@@ -68,7 +68,7 @@ else:
         use_cpu_strategy,
     )
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 common_strategy: dict[str, Any] = {
     "T": st.integers(min_value=1, max_value=5),

--- a/fbgemm_gpu/test/tbe/training/backward_dense_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_dense_test.py
@@ -46,7 +46,7 @@ else:
     )
 
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 
 @optests.generate_opcheck_tests(fast=True, additional_decorators=additional_decorators)

--- a/fbgemm_gpu/test/tbe/training/backward_determinism_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_determinism_test.py
@@ -56,7 +56,7 @@ else:
     )
 
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 
 @optests.generate_opcheck_tests(fast=True, additional_decorators=additional_decorators)

--- a/fbgemm_gpu/test/tbe/training/backward_none_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_none_test.py
@@ -59,7 +59,7 @@ else:
         running_on_github,
         TEST_WITH_ROCM,
     )
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 # pyre-ignore
 additional_decorators.update(

--- a/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
@@ -76,7 +76,7 @@ else:
     )
 
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 
 @optests.generate_opcheck_tests(fast=True, additional_decorators=additional_decorators)

--- a/fbgemm_gpu/test/tbe/training/backward_sgd_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_sgd_test.py
@@ -63,7 +63,7 @@ else:
         use_cpu_strategy,
     )
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 
 @optests.generate_opcheck_tests(fast=True, additional_decorators=additional_decorators)

--- a/fbgemm_gpu/test/tbe/training/forward_backward_int32_overflow_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_backward_int32_overflow_test.py
@@ -28,7 +28,7 @@ common_st = {
 }
 
 common_settings = {
-    "verbosity": Verbosity.verbose,
+    "verbosity": Verbosity.normal,
     "max_examples": 4,
     "deadline": None,
 }

--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -68,7 +68,7 @@ else:
         TEST_WITH_ROCM,
     )
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 fp8_dtype: torch.dtype = (
     torch.float8_e4m3fnuz if torch.version.hip is not None else torch.float8_e4m3fn

--- a/fbgemm_gpu/test/tbe/utils/split_embeddings_test.py
+++ b/fbgemm_gpu/test/tbe/utils/split_embeddings_test.py
@@ -48,7 +48,7 @@ else:
     from fbgemm_gpu.test.test_utils import gpu_unavailable, optests, use_cpu_strategy
 
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 
 additional_decorators: dict[str, list[Callable[..., Any]]] = {}

--- a/fbgemm_gpu/test/tbe/utils/split_embeddings_utils_test.py
+++ b/fbgemm_gpu/test/tbe/utils/split_embeddings_utils_test.py
@@ -39,7 +39,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training_common import (
     generate_vbe_metadata,
 )
 
-VERBOSITY: Verbosity = Verbosity.verbose
+VERBOSITY: Verbosity = Verbosity.normal
 
 
 def gen_inputs(


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2907

The Hypothesis property tests across fbgemm_gpu set settings(verbosity=Verbosity.verbose), which prints a "Trying example: ..." block for EVERY generated example. On the property-heavy TBE tests this floods CI logs (a single fbgemm_gpu_ci_cpu run was ~99k lines) and buries the real failure under thousands of per-example lines.

What controls the per-example output: the "verbosity" field on each test's settings(...) decorator (sourced from a shared VERBOSITY constant in files such as test/tbe/common.py). Hypothesis Verbosity levels:
  - Verbosity.verbose - prints each example as it is tried (the flood).
  - Verbosity.normal (Hypothesis default) - prints nothing per-example on success and, on FAILURE, reports only the minimal falsifying example.

This diff switches Verbosity.verbose -> Verbosity.normal across the test tree (189 occurrences over 59 files, plus the shared VERBOSITY constants that a further 77 settings reference). Result: CI logs show output only for failing cases; passing runs stay quiet. Verbosity is a reporting-only setting - it does not change input generation, execution, or coverage.

Reviewed By: q10

Differential Revision: D111350239
