### PR TITLE
Add --deterministic flag to TBE benchmark

### DIFF
--- a/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
@@ -319,6 +319,12 @@ def _benchmark_cpu_fwd_bwd(
     default=False,
     help="Run CPU baseline comparison",
 )
+@click.option(
+    "--deterministic",
+    is_flag=True,
+    default=False,
+    help="Enable torch.use_deterministic_algorithms(True) during benchmarking",
+)
 def device(  # noqa C901
     alpha: float,
     bag_size: int,
@@ -355,6 +361,7 @@ def device(  # noqa C901
     indices_file: str | None,
     offsets_file: str | None,
     compare: bool,
+    deterministic: bool,
 ) -> None:
     assert not ssd or not dense, "--ssd cannot be used together with --dense"
     num_requests = iters if num_requests == -1 else num_requests
@@ -514,6 +521,10 @@ def device(  # noqa C901
         index_dtype=torch.long,
         offset_dtype=torch.long,
     )
+
+    if deterministic:
+        torch.use_deterministic_algorithms(True)
+        logging.info("Deterministic mode enabled")
 
     def _kineto_trace_handler(p: profile, phase: str) -> None:
         p.export_chrome_trace(
@@ -1239,6 +1250,12 @@ def cache(  # noqa C901
     default=False,
     help="Run CPU baseline comparison",
 )
+@click.option(
+    "--deterministic",
+    is_flag=True,
+    default=False,
+    help="Enable torch.use_deterministic_algorithms(True) during benchmarking",
+)
 def device_with_spec(  # noqa C901
     alpha: float,
     bag_size_list: str,
@@ -1262,9 +1279,15 @@ def device_with_spec(  # noqa C901
     export_trace: bool,
     trace_url: str,
     compare: bool,
+    deterministic: bool,
 ) -> None:
     np.random.seed(42)
     torch.manual_seed(42)
+
+    if deterministic:
+        torch.use_deterministic_algorithms(True)
+        logging.info("Deterministic mode enabled")
+
     B = batch_size
     Ds = [int(D) for D in embedding_dim_list.split(",")]
     Es = [int(E) for E in num_embeddings_list.split(",")]


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2909

Add `--deterministic` flag to the TBE benchmark `device` and `device-with-spec` commands. When passed, the benchmark calls `torch.use_deterministic_algorithms(True)` before running forward and backward passes, which forces the backward CTA kernel to use `max_segment_length_per_cta = INT_MAX` (single CTA per segment, eliminating non-deterministic inter-CTA atomic accumulation).

This enables benchmarking the performance cost of determinism by comparing runs with and without the flag.

**Benchmark Python changes:**
- `split_table_batched_embeddings_benchmark.py`: Add `--deterministic` click option to both `device` and `device-with-spec` commands

**Benchmark script changes:**
- `run_tbe_benchmark.sh`: Add `--deterministic` flag parsing and pass-through to the benchmark binary
- `run_tbe_benchmark_sweep.sh`: Add `--deterministic` to help text (flag passes through via `extra_args`)
- `run_tbe_bench_list.sh`: Add `--deterministic` flag parsing and propagate via `EXTRA_BENCH_OPTS` through `_export_opts`

Differential Revision: D111364519


