### PR TITLE
group_index_select: capture onesweep sort + data-driven pattern-group report split

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/bench/analysis/aggregate_config_stats.py
+++ b/fbgemm_gpu/fbgemm_gpu/bench/analysis/aggregate_config_stats.py
@@ -148,7 +148,7 @@ def _collect_kernel_stats(
     config_columns: list[str],
     patterns: list[tuple[str, str, str]],
     emit_total: bool = False,
-) -> list[tuple[dict[str, Any], str, str, KernelStats]]:
+) -> list[tuple[dict[str, Any], str, str, str, KernelStats]]:
     """Extract durations and bucket by ``(config_tuple, kernel_name)``.
 
     Returns a flat list of ``(config, kernel_base, kernel_name, stats)``
@@ -166,6 +166,10 @@ def _collect_kernel_stats(
     bucket: dict[tuple, dict[str, list[float]]] = {}
     config_for: dict[tuple, dict[str, Any]] = {}
     all_kernels: set[str] = set()
+    # kernel_name -> the --kernel-pattern group name that matched it. Patterns
+    # are expected mutually disjoint (a kernel matches at most one), so the
+    # first match wins. This makes the category data-driven downstream.
+    kernel_group: dict[str, str] = {}
     entries_per_cfg: Counter[tuple] = Counter()
 
     for entry in config_map:
@@ -189,19 +193,28 @@ def _collect_kernel_stats(
             )
             continue
 
-        for _, pattern, match_mode in patterns:
+        for pname, pattern, match_mode in patterns:
             bucketed = trace.extract_durations(pattern, match_mode=match_mode)
             for kname, durs in bucketed.items():
                 all_kernels.add(kname)
+                kernel_group.setdefault(kname, pname)
                 bucket[cfg_tuple].setdefault(kname, []).extend(durs)
 
-    rows: list[tuple[dict[str, Any], str, str, KernelStats]] = []
+    rows: list[tuple[dict[str, Any], str, str, str, KernelStats]] = []
     for cfg_tuple, cfg_dict in config_for.items():
         kernel_durs = bucket[cfg_tuple]
         for kname in sorted(all_kernels):
             durs = kernel_durs.get(kname, [])
             stats = KernelStats(name=kname, durations_us=list(durs))
-            rows.append((cfg_dict, base_name_of(kname), kname, stats))
+            rows.append(
+                (
+                    cfg_dict,
+                    base_name_of(kname),
+                    kname,
+                    kernel_group.get(kname, ""),
+                    stats,
+                )
+            )
         if emit_total:
             if entries_per_cfg[cfg_tuple] > 1:
                 print(
@@ -223,6 +236,7 @@ def _collect_kernel_stats(
             rows.append(
                 (
                     cfg_dict,
+                    "(total)",
                     "(total)",
                     "(total)",
                     KernelStats(name="(total)", durations_us=totals),

--- a/fbgemm_gpu/fbgemm_gpu/bench/analysis/compute_stats.py
+++ b/fbgemm_gpu/fbgemm_gpu/bench/analysis/compute_stats.py
@@ -122,7 +122,7 @@ def main() -> int:
         return 3
 
     # Union of (config, kernel) keys across commits.
-    all_keys: dict[tuple, tuple[tuple, str, str]] = {}
+    all_keys: dict[tuple, tuple[tuple, str, str, str]] = {}
     for _, _, rows in per_commit_rows:
         for row in rows:
             key = _row_key(row, config_columns)
@@ -131,6 +131,7 @@ def main() -> int:
                     key[0],
                     row["kernel_base"],
                     row["kernel_name"],
+                    row.get("pattern_group", "") or "",
                 )
 
     if not all_keys:
@@ -140,7 +141,7 @@ def main() -> int:
     # Build per-row per-commit stats.
     rows_out: list[dict[str, Any]] = []
     for key in all_keys:
-        cfg_tuple, kernel_base, kernel_name = all_keys[key]
+        cfg_tuple, kernel_base, kernel_name, pattern_group = all_keys[key]
         config_dict = dict(zip(config_columns, cfg_tuple))
         per_commit_entries: list[dict[str, Any]] = []
         for label, _, rows in per_commit_rows:
@@ -179,6 +180,7 @@ def main() -> int:
             "config": config_dict,
             "kernel_base": kernel_base,
             "kernel_name": kernel_name,
+            "pattern_group": pattern_group,
             "per_commit": per_commit_entries,
             "pct_diff": None,
             "welch_t": None,

--- a/fbgemm_gpu/fbgemm_gpu/bench/analysis/types.py
+++ b/fbgemm_gpu/fbgemm_gpu/bench/analysis/types.py
@@ -321,19 +321,22 @@ class KernelStats:
 
 
 def write_config_stats_csv(
-    rows: list[tuple[dict[str, object], str, str, "KernelStats"]],
+    rows: list[tuple[dict[str, object], str, str, str, "KernelStats"]],
     output_path: str,
     config_columns: list[str],
 ) -> None:
     """Write one row per ``(config_tuple, kernel_name)`` to ``output_path``.
 
-    ``rows`` is a list of ``(config_dict, kernel_base, kernel_name, stats)``
-    tuples. Each ``config_dict`` MUST contain every column listed in
+    ``rows`` is a list of ``(config_dict, kernel_base, kernel_name,
+    pattern_group, stats)`` tuples. ``pattern_group`` is the ``--kernel-pattern``
+    group name that matched the kernel (``(total)`` for the rollup row), and
+    lets downstream reporting categorize kernels without op-specific string
+    matching. Each ``config_dict`` MUST contain every column listed in
     ``config_columns`` (missing entries get an empty cell).
 
     Column order is the v1 canonical schema:
         ``config.<col1>, ..., config.<colK>, kernel_base, kernel_name,
-         count, mean_us, stdev_us, median_us, min_us, max_us``
+         pattern_group, count, mean_us, stdev_us, median_us, min_us, max_us``
 
     ``count == 0`` rows are preserved; they are the first-class "kernel
     not dispatched for this config" signal. When ``count == 0``, the stat
@@ -345,6 +348,7 @@ def write_config_stats_csv(
         [
             "kernel_base",
             "kernel_name",
+            "pattern_group",
             "count",
             "mean_us",
             "stdev_us",
@@ -357,13 +361,14 @@ def write_config_stats_csv(
     with open(output_path, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
-        for config_dict, kernel_base, kernel_name, stats in rows:
+        for config_dict, kernel_base, kernel_name, pattern_group, stats in rows:
             out: dict[str, object] = {}
             for col in config_columns:
                 val = config_dict.get(col, "")
                 out[f"config.{col}"] = "" if val is None else val
             out["kernel_base"] = kernel_base
             out["kernel_name"] = kernel_name
+            out["pattern_group"] = pattern_group
             if stats.count == 0:
                 out["count"] = 0
                 out["mean_us"] = ""
@@ -432,6 +437,9 @@ def read_config_stats_csv(
                 "config": config,
                 "kernel_base": raw.get("kernel_base", "") or "",
                 "kernel_name": raw.get("kernel_name", "") or "",
+                # Optional column (added in the v1 pattern_group schema). Older
+                # CSVs without it read as "" and simply carry no category.
+                "pattern_group": raw.get("pattern_group", "") or "",
                 "count": int(raw.get("count", "0") or 0),
             }
             for stat in ("mean_us", "stdev_us", "median_us", "min_us", "max_us"):


### PR DESCRIPTION
Summary:
Improves the group_index_select backward benchmark tooling:

1. Kernel patterns (run_benchmark.sh + run_benchmark_oss.sh): add an explicit
   onesweep pattern so the per-group onesweep radix sort (LARGE per-segment
   counts) is counted, not just the segmented path. Verified mutually disjoint
   on real Kineto traces (segmented_sort vs onesweep never co-occur), so
   aggregate_config_stats does not double-count. Dropped the overlapping
   sort_trampoline pattern. Added a 'huge' synthetic regime (num_rows=524288 >
   400k per segment) so several configs exercise the onesweep path, not just
   the 6 prod shapes.

2. Data-driven kernel categorization: aggregate_config_stats now records the
   matched --kernel-pattern group name per row (new pattern_group CSV column;
   '(total)' for the rollup), compute_stats carries it into
   regression_stats.json, and build_report_html --split-kernel-groups groups
   generically by pattern_group prefix (primary -> Primary, sort_* -> Sort,
   total -> Total) into three separate tables. This removes all op-specific
   (GIS) strings from the generic kernel_grouping.py (category_of +
   _SORT_SUBSTRINGS deleted) -- the benchmark's own --kernel-pattern names are
   now the single source of truth for categories.

3. run_benchmark.sh auto-detects the host AMD arch from rocminfo (gfx942 ->
   mi300, gfx950 -> mi350) instead of hardcoding amd/mi350, which built
   mismatched kernels on a reallocated host and failed every config at runtime
   with hipErrorInvalidDeviceFunction.

These scripts are used to benchmark D111296083.

Reviewed By: henrylhtsang

Differential Revision: D111342461


