### PR TITLE
Fix `fbgemm::lxu_cache_lookup` schema to declare output alias

### DIFF
--- a/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
@@ -319,6 +319,12 @@ def _benchmark_cpu_fwd_bwd(
     default=False,
     help="Run CPU baseline comparison",
 )
+@click.option(
+    "--deterministic",
+    is_flag=True,
+    default=False,
+    help="Enable torch.use_deterministic_algorithms(True) during benchmarking",
+)
 def device(  # noqa C901
     alpha: float,
     bag_size: int,
@@ -355,6 +361,7 @@ def device(  # noqa C901
     indices_file: str | None,
     offsets_file: str | None,
     compare: bool,
+    deterministic: bool,
 ) -> None:
     assert not ssd or not dense, "--ssd cannot be used together with --dense"
     num_requests = iters if num_requests == -1 else num_requests
@@ -514,6 +521,10 @@ def device(  # noqa C901
         index_dtype=torch.long,
         offset_dtype=torch.long,
     )
+
+    if deterministic:
+        torch.use_deterministic_algorithms(True)
+        logging.info("Deterministic mode enabled")
 
     def _kineto_trace_handler(p: profile, phase: str) -> None:
         p.export_chrome_trace(
@@ -1239,6 +1250,12 @@ def cache(  # noqa C901
     default=False,
     help="Run CPU baseline comparison",
 )
+@click.option(
+    "--deterministic",
+    is_flag=True,
+    default=False,
+    help="Enable torch.use_deterministic_algorithms(True) during benchmarking",
+)
 def device_with_spec(  # noqa C901
     alpha: float,
     bag_size_list: str,
@@ -1262,9 +1279,15 @@ def device_with_spec(  # noqa C901
     export_trace: bool,
     trace_url: str,
     compare: bool,
+    deterministic: bool,
 ) -> None:
     np.random.seed(42)
     torch.manual_seed(42)
+
+    if deterministic:
+        torch.use_deterministic_algorithms(True)
+        logging.info("Deterministic mode enabled")
+
     B = batch_size
     Ds = [int(D) for D in embedding_dim_list.split(",")]
     Es = [int(E) for E in num_embeddings_list.split(",")]

--- a/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
@@ -27,7 +27,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "lfu_cache_populate_byte(Tensor weights, Tensor cache_hash_size_cumsum, int total_cache_hash_size, Tensor cache_index_table_map, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, Tensor linear_cache_indices, Tensor(a!) lxu_cache_state, Tensor(b!) lxu_cache_weights, Tensor(c!) lfu_state, int row_alignment=16) -> ()");
   m.def(
-      "lxu_cache_lookup(Tensor linear_cache_indices, Tensor lxu_cache_state, int invalid_index = -1, bool gather_cache_stats=False, Tensor(a!)? uvm_cache_stats=None, Tensor? num_uniq_cache_indices=None, Tensor(b!)? lxu_cache_locations_output=None) -> Tensor");
+      "lxu_cache_lookup(Tensor linear_cache_indices, Tensor lxu_cache_state, int invalid_index = -1, bool gather_cache_stats=False, Tensor(a!)? uvm_cache_stats=None, Tensor? num_uniq_cache_indices=None, Tensor(b!)? lxu_cache_locations_output=None) -> Tensor(b!)");
   m.def(
       "direct_mapped_lxu_cache_lookup(Tensor linear_cache_indices, Tensor lxu_cache_state, int invalid_index = -1, bool gather_cache_stats=False, Tensor(a!)? uvm_cache_stats=None) -> Tensor");
   m.def(

--- a/fbgemm_gpu/test/tbe/cache/failures_dict_fast.json
+++ b/fbgemm_gpu/test/tbe/cache/failures_dict_fast.json
@@ -124,12 +124,7 @@
     "fbgemm::lru_cache_populate_byte": {},
     "fbgemm::lxu_cache_flush": {},
     "fbgemm::lxu_cache_locking_counter_decrement": {},
-    "fbgemm::lxu_cache_lookup": {
-      "CacheTest.test_schema__test_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::lxu_cache_lookup": {},
     "fbgemm::new_managed_tensor": {},
     "fbgemm::new_unified_tensor": {
       "NBitCacheTest.test_faketensor__test_nbit_cache_miss_counter": {

--- a/fbgemm_gpu/test/tbe/training/failures_dict_fast.json
+++ b/fbgemm_gpu/test/tbe/training/failures_dict_fast.json
@@ -128,56 +128,7 @@
     "fbgemm::lru_cache_populate_byte": {},
     "fbgemm::lxu_cache_flush": {},
     "fbgemm::lxu_cache_locking_counter_decrement": {},
-    "fbgemm::lxu_cache_lookup": {
-      "BackwardAdagradLargeDimTest.test_schema__test_backward_adagrad_large_dims": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_schema__test_backward_adagrad_fp16_pmMEAN": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_schema__test_backward_adagrad_fp16_pmNONE": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_schema__test_backward_adagrad_fp16_pmSUM": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_schema__test_backward_adagrad_fp16_pmSUM_with_max_norm": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_schema__test_backward_adagrad_fp32_pmNONE": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_schema__test_backward_adagrad_fp32_pmSUM": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardSGDTest.test_schema__test_backward_sgd": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardSGDTest.test_schema__test_backward_sgd_really_long_segments": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardSGDTest.test_schema__test_backward_sgd_writeback": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "CacheTest.test_schema__test_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_schema__test_stb_uvm_cache_stats": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::lxu_cache_lookup": {},
     "fbgemm::new_managed_tensor": {},
     "fbgemm::new_unified_tensor": {
       "NBitCacheTest.test_faketensor__test_nbit_cache_miss_counter": {

--- a/fbgemm_gpu/test/tbe/utils/failures_dict_fast.json
+++ b/fbgemm_gpu/test/tbe/utils/failures_dict_fast.json
@@ -124,12 +124,7 @@
     "fbgemm::lru_cache_populate_byte": {},
     "fbgemm::lxu_cache_flush": {},
     "fbgemm::lxu_cache_locking_counter_decrement": {},
-    "fbgemm::lxu_cache_lookup": {
-      "SplitTableBatchedEmbeddingsTest.test_schema__test_stb_uvm_cache_stats": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::lxu_cache_lookup": {},
     "fbgemm::new_managed_tensor": {},
     "fbgemm::new_unified_tensor": {
       "NBitCacheTest.test_faketensor__test_nbit_cache_miss_counter": {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2912

`fbgemm::lxu_cache_lookup` is a write-into-and-return-buffer op: when the optional `lxu_cache_locations_output` buffer is passed, every backend (CPU/CUDA/Meta) returns that exact buffer. The schema declared the arg as a mutable alias `Tensor(b!)? lxu_cache_locations_output` but declared the return as a bare `-> Tensor` with no alias set. PyTorch `SchemaCheckMode` (the `test_schema__` opcheck) then saw the output aliasing input `b` while the schema said it aliased nothing, raising `RuntimeError: Argument lxu_cache_locations_output is not defined to alias output but was aliasing` and failing `test_schema__test_backward_adagrad_fp32_pmMEAN` on `fbgemm::lxu_cache_lookup`.

Since the op genuinely returns the passed-in buffer, this fixes the schema (not the implementation): the return type is now `-> Tensor(b!)`. With the `?`-optional alias, passing None yields a fresh tensor (empty alias set), which is valid. No implementation, Meta/fake, or backend-registration change was needed; they already returned the buffer consistently.

The schema was previously worked around via `xfail` entries in the `generate_opcheck_tests` failures dicts. With the schema fixed those tests pass, which the framework reports as "Unexpected success", so the now-stale `test_schema__` entries for `fbgemm::lxu_cache_lookup` are removed from `test/tbe/training/failures_dict_fast.json`, `test/tbe/cache/failures_dict_fast.json`, and `test/tbe/utils/failures_dict_fast.json`. The top-level `test/failures_dict_fast.json` only has `test_faketensor__` entries for this op (meta impl unchanged) and is left as-is.

Reviewed By: q10

Differential Revision: D111378940


