### PR TITLE
Add grid-stride + ROCm cap to get_source_mask_kernel

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/get_source_mask.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/get_source_mask.cu
@@ -38,22 +38,21 @@ __global__ __launch_bounds__(kMaxThreads) void get_source_mask_kernel(
     const index_t* __restrict__ offsets,
     bool* __restrict__ output,
     const index_t batch_size) {
-  // Each block handles one batch item
-  const index_t batch_idx = blockIdx.x;
+  // Grid-stride over batches so a capped grid (used on ROCm to avoid the
+  // 2^32 launch-side limit) still covers every batch item.
+  for (index_t batch_idx = blockIdx.x; batch_idx < batch_size;
+       batch_idx += gridDim.x) {
+    const index_t ns = num_sources[batch_idx];
+    const index_t nt = num_targets[batch_idx];
+    const index_t total = ns + nt;
+    const index_t offset = offsets[batch_idx];
 
-  if (batch_idx >= batch_size) {
-    return;
-  }
-
-  const index_t ns = num_sources[batch_idx];
-  const index_t nt = num_targets[batch_idx];
-  const index_t total = ns + nt;
-  const index_t offset = offsets[batch_idx];
-
-  // Grid-stride loop: each thread processes multiple elements if needed
-  for (index_t local_idx = threadIdx.x; local_idx < total;
-       local_idx += blockDim.x) {
-    output[offset + local_idx] = (local_idx < ns);
+    // Inner grid-stride loop: each thread processes multiple elements if
+    // needed.
+    for (index_t local_idx = threadIdx.x; local_idx < total;
+         local_idx += blockDim.x) {
+      output[offset + local_idx] = (local_idx < ns);
+    }
   }
 }
 
@@ -81,8 +80,15 @@ Tensor get_source_mask_cuda(
     return output;
   }
 
-  // Launch kernel - one block per batch item
-  const int num_blocks = batch_size;
+  // Launch kernel - one block per batch item.
+  // HIP enforces a hard limit of 2^32 total threads per launch.
+  // get_source_mask_kernel grid-strides over batches, so capping is
+  // correctness-preserving.
+  // See: https://github.com/ROCm/hip/issues/2253
+  const auto num_blocks = utils::cuda::cap_grid_dim_x(
+      static_cast<uint32_t>(batch_size),
+      kMaxThreads,
+      at::cuda::getCurrentCUDAStream());
 
   AT_DISPATCH_INDEX_TYPES(
       num_sources.scalar_type(), "get_source_mask_kernel", ([&] {

--- a/fbgemm_gpu/test/jagged/get_source_mask_test.py
+++ b/fbgemm_gpu/test/jagged/get_source_mask_test.py
@@ -19,9 +19,9 @@ from .common import additional_decorators, open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_unavailable, optests
+    from test_utils import gpu_memory_lt_gb, gpu_unavailable, optests
 else:
-    from fbgemm_gpu.test.test_utils import gpu_unavailable, optests
+    from fbgemm_gpu.test.test_utils import gpu_memory_lt_gb, gpu_unavailable, optests
 
 
 def get_source_mask_reference(
@@ -325,6 +325,55 @@ class GetSourceMaskTest(unittest.TestCase):
 
         jit_result = scripted_wrapper(num_sources, num_targets)
         self.assertTrue(torch.equal(jit_result, expected))
+
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(4))
+    def test_get_source_mask_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in `get_source_mask_kernel`
+        and verifies output correctness against the CPU dispatch.
+
+        With kMaxThreads=1024, the launch grid is `batch_size`. Total threads
+        = batch_size * 1024. For batch_size > 2**22, total threads cross the
+        HIP 2**32-per-launch limit and trip
+        KernelLauncher::checkThreadCountNotExceeded on ROCm pre-fix.
+        Post-fix the host caps `num_blocks` to
+        `get_max_thread_blocks(stream)` (~16384) and the kernel grid-strides
+        over batches.
+
+        Uses sparse num_sources/num_targets (mostly zero) with sentinel
+        non-zero values at start / middle / end so the kernel emits a
+        non-trivial output and any "kernel addressed wrong batch" bug
+        surfaces in the True/False boundary positions.
+        """
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        # batch_size * 1024 > 2**32 requires batch_size > 2**22.
+        batch_size = (1 << 22) + 1
+        # Sparse non-zero counts at sentinel positions.
+        num_sources_cpu = torch.zeros(batch_size, dtype=torch.int32)
+        num_targets_cpu = torch.zeros(batch_size, dtype=torch.int32)
+        num_sources_cpu[0] = 1
+        num_targets_cpu[0] = 1
+        num_sources_cpu[batch_size // 2] = 2
+        num_targets_cpu[batch_size // 2] = 1
+        num_sources_cpu[batch_size - 1] = 3
+        num_targets_cpu[batch_size - 1] = 2
+        output_size = int((num_sources_cpu + num_targets_cpu).sum().item())
+
+        # CPU reference oracle.
+        result_cpu = torch.ops.fbgemm.get_source_mask(
+            num_sources_cpu, num_targets_cpu, output_size
+        )
+
+        # GPU op under test. Pre-fix this trips
+        # KernelLauncher::checkThreadCountNotExceeded on ROCm.
+        result_gpu = torch.ops.fbgemm.get_source_mask(
+            num_sources_cpu.to(device),
+            num_targets_cpu.to(device),
+            output_size,
+        )
+
+        torch.testing.assert_close(result_gpu.cpu(), result_cpu)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Diff 3/10 of the Tier-2 ROCm grid-overflow fix stack
(plan: ~/.llms/plans/embedding_inplace_jagged_etc_rocm_grid_overflow_tier2_fix.plan.md).

Same shape as Diff 2 (repeat_arange). get_source_mask_kernel runs one block
per batch item with no outer grid-stride. Saturates at batch_size > 2^22 on
ROCm (kMaxThreads=1024).

This diff:
- Wraps the kernel body in for (batch_idx = blockIdx.x; batch_idx < batch_size;
  batch_idx += gridDim.x) (Pattern C). Inner threadIdx.x grid-stride loop
  unchanged.
- Adds the standard #ifdef USE_ROCM host-side cap.
- Adds test_get_source_mask_large_grid to get_source_mask_test.py.

Reviewed By: henrylhtsang

Differential Revision: D105202464


