### PR TITLE
Fix pyre type-check failures in kmeans/rebatch/ssd (OMH health)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -3450,10 +3450,12 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
 
             # When backend returns whole row, the optimizer will be returned as
             # PMT directly
+            # pyre-ignore[16]
             if sorted_ids[t].size(0) == 0 and self.local_weight_counts[t] > 0:
                 logging.info(
                     f"Before opt PMT loading, resetting id tensor with {self.local_weight_counts[t]}"
                 )
+                # pyre-ignore[16]
                 sorted_ids[t] = torch.zeros(
                     (self.local_weight_counts[t], 1),
                     device=torch.device("cpu"),


### PR DESCRIPTION
Summary:
Fixes three fbgemm_dev OMH '-type-checking' failures (T191384137):

- fb/test/kmeans_ops_test.py (8) and fb/test/rebatch_ops_test.py (1): pyre
  '[56] Invalid decoration' because pyre cannot infer hypothesis strategy types
  on given(...). Added '# pyre-ignore[56]' above each given, matching the
  existing fbgemm pattern (fb/test/int8_ops_test.py).
- fbgemm_gpu/tbe/ssd/training.py: pyre '[16] Undefined attribute' on
  sorted_ids[t] at lines 3453/3457. sorted_ids is Optional and is captured by
  the nested _fetch_offloaded_optimizer_states closure, where pyre cannot carry
  the outer 'if sorted_ids is None' narrowing. Added '# pyre-ignore[16]',
  matching the adjacent kv_zch_params suppressions (lines 3445/3447).

Reviewed By: henrylhtsang

Differential Revision: D111543487


