### PR TITLE
Stabilize flaky fused_nbit faketensor opcheck (OMH health)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -3450,10 +3450,12 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
 
             # When backend returns whole row, the optimizer will be returned as
             # PMT directly
+            # pyre-ignore[16]
             if sorted_ids[t].size(0) == 0 and self.local_weight_counts[t] > 0:
                 logging.info(
                     f"Before opt PMT loading, resetting id tensor with {self.local_weight_counts[t]}"
                 )
+                # pyre-ignore[16]
                 sorted_ids[t] = torch.zeros(
                     (self.local_weight_counts[t], 1),
                     device=torch.device("cpu"),

--- a/fbgemm_gpu/test/quantize/failures_dict_fast.json
+++ b/fbgemm_gpu/test/quantize/failures_dict_fast.json
@@ -68,8 +68,8 @@
     "fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloat": {},
     "fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf": {
       "TestFusedNBitRowwiseQuantizationConversion.test_faketensor__test_quantize_and_dequantize_op": {
-        "comment": "",
-        "status": "xfail"
+        "comment": "Flaky under opcheck by sampled output dtype: the FloatOrHalf meta raises 'Unsupported output dtype' for some dtypes but passes for others, so 'xfail' oscillates between XPASS (Unexpected success) and fail. Eager is correct. Skip (not xfail) for a stable signal. T191384137",
+        "status": "skip"
       },
       "TestFusedNBitRowwiseQuantizationConversion.test_faketensor__test_quantize_and_dequantize_op_cpu_and_cuda": {
         "comment": "",


### PR DESCRIPTION
Summary:
Fixes the fbgemm_dev OMH failure for
test/quantize:fused_nbit_rowwise - test_faketensor__test_quantize_and_dequantize_op
(T191384137), which oscillated between 'Unexpected success' (XPASS) and a hard
failure.

Root cause: the faketensor opcheck of fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf
is flaky by the hypothesis-sampled output dtype -- the FloatOrHalf meta raises
'RuntimeError: Unsupported output dtype' for some sampled dtypes but passes for
others. Under 'xfail' it therefore XPASSes on all-passing samples and fails on
others. Eager execution is correct.

Changed that entry from 'xfail' to 'skip' in
test/quantize/failures_dict_fast.json for a stable signal (does not run, so it
neither fails nor XPASSes), matching the file's existing skip pattern for
harness-flaky faketensor variants.

Reviewed By: henrylhtsang

Differential Revision: D111543486


