### PR TITLE
Add grid-stride + ROCm cap to jagged_dense_dense_elementwise_jagged_output_opt_search_kernel_ (#6006)

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/common.cuh
+++ b/fbgemm_gpu/src/jagged_tensor_ops/common.cuh
@@ -468,30 +468,34 @@ __global__ void jagged_dense_dense_elementwise_jagged_output_opt_search_kernel_(
     offsets_sh[i] = offsets[i];
   }
   __syncthreads();
-  auto row = threadIdx.x + blockIdx.x * blockDim.x;
-  if (row >= nnz)
-    return;
-  int first = -1;
-  int count = B - 1;
-  first = 1;
-  while (count > 0) {
-    int idx = first;
-    int step = count / 2;
-    idx += step;
-    if (offsets_sh[idx] <= row) {
-      first = ++idx;
-      count -= step + 1;
-    } else {
-      count = step;
+  // Grid-stride over rows so a capped grid (used on ROCm to avoid the 2^32
+  // launch-side limit) still covers every row. The pre-loop shared-memory
+  // load above is performed once per block; the data remains valid across
+  // all grid-stride iterations.
+  const auto row_init = threadIdx.x + blockIdx.x * blockDim.x;
+  const auto row_stride = gridDim.x * blockDim.x;
+  for (auto row = row_init; row < nnz; row += row_stride) {
+    int first = 1;
+    int count = B - 1;
+    while (count > 0) {
+      int idx = first;
+      int step = count / 2;
+      idx += step;
+      if (offsets_sh[idx] <= row) {
+        first = ++idx;
+        count -= step + 1;
+      } else {
+        count = step;
+      }
     }
-  }
-  --first;
+    --first;
 
-  int dense_row = first;
-  int offset = offsets_sh[dense_row];
-  int dense_col = row - offset;
-  rows[row] = dense_row;
-  cols[row] = dense_col;
+    int dense_row = first;
+    int offset = offsets_sh[dense_row];
+    int dense_col = row - offset;
+    rows[row] = dense_row;
+    cols[row] = dense_col;
+  }
 }
 
 struct VecType128 {
@@ -953,10 +957,16 @@ void jagged_dense_elementwise_jagged_output_opt_(
           }
 
           dim3 threads_bs = dim3(1024, 1, 1);
+          // HIP enforces a hard limit of 2^32 total threads per launch.
+          // The opt_search_kernel grid-strides over rows, so capping is
+          // correctness-preserving.
+          // See: https://github.com/ROCm/hip/issues/2253
+          const auto blocks_bs_x = utils::cuda::cap_grid_dim_x_from_workload(
+              nnz, threads_bs.x, at::cuda::getCurrentCUDAStream());
           FBGEMM_LAUNCH_KERNEL(
               (jagged_dense_dense_elementwise_jagged_output_opt_search_kernel_<
                   index_t>),
-              dim3(div_round_up(nnz, threads_bs.x), 1, 1),
+              dim3(blocks_bs_x, 1, 1),
               threads_bs,
               dynamic_smem_size,
               at::cuda::getCurrentCUDAStream(),

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_dense_elementwise_add_jagged_output_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_dense_elementwise_add_jagged_output_forward.cu
@@ -133,7 +133,13 @@ void jagged_dense_dense_elementwise_jagged_output_opt_(
           }
 
           const auto threads_bs = dim3(1024, 1, 1);
-          const auto blocks_bs = dim3(div_round_up(nnz, threads_bs.x), 1, 1);
+          // HIP enforces a hard limit of 2^32 total threads per launch.
+          // The opt_search_kernel grid-strides over rows, so capping is
+          // correctness-preserving.
+          // See: https://github.com/ROCm/hip/issues/2253
+          const auto blocks_bs_x = utils::cuda::cap_grid_dim_x_from_workload(
+              nnz, threads_bs.x, at::cuda::getCurrentCUDAStream());
+          const auto blocks_bs = dim3(blocks_bs_x, 1, 1);
           FBGEMM_LAUNCH_KERNEL(
               (jagged_dense_dense_elementwise_jagged_output_opt_search_kernel_<
                   index_t>),

--- a/fbgemm_gpu/test/jagged/dense_dense_elementwise_add_test.py
+++ b/fbgemm_gpu/test/jagged/dense_dense_elementwise_add_test.py
@@ -379,6 +379,97 @@ class DenseDenseElementwiseAddTest(unittest.TestCase):
 
         torch.testing.assert_close(small_output_gpu[0].cpu(), small_output_cpu[0])
 
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(40))
+    def test_jagged_dense_dense_elementwise_add_jagged_output_opt_search_large_grid(
+        self,
+    ) -> None:
+        """
+        Retro: regression test for the HIP grid-overflow bug in
+        ``jagged_dense_dense_elementwise_jagged_output_opt_search_kernel_``
+        (D105203391 / Subplan D Diff #25), which lacked its own test
+        method when landed.
+
+        The opt-search path is taken by
+        ``jagged_dense_dense_elementwise_add_jagged_output`` when
+        ``D = Half`` and ``B == 1``. With kMaxThreads=1024, the
+        binary-search kernel launches with grid_x = ceil(nnz / 1024).
+        For nnz > 2**22 the launch exceeds 2^32 threads pre-fix; the
+        production fix caps grid_x to ``get_max_thread_blocks(stream)``
+        and the kernel grid-strides over rows.
+
+        Verification strategy:
+        1. Full-scale launch survival to verify the cap-trip path.
+        2. Small-scale CPU-oracle correctness to verify kernel logic
+           through the opt-search dispatch.
+        """
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+
+        # ---- Step 1: full-scale launch survival. ----
+        B = 1  # opt-search path requires B == 1.
+        max_L = (1 << 22) + 1  # nnz > 2**22 trips the cap pre-fix.
+        D_half = 16  # half-dtype required; numel < 2**31 satisfied.
+        nnz = max_L
+        x_values_large = torch.zeros((nnz, D_half), dtype=torch.float16, device=device)
+        x_offsets_large = [torch.tensor([0, nnz], dtype=torch.int64, device=device)]
+        y0_large = torch.zeros((B, max_L, D_half), dtype=torch.float16, device=device)
+        y1_large = torch.zeros((B, max_L, D_half), dtype=torch.float16, device=device)
+
+        output_large = (
+            torch.ops.fbgemm.jagged_dense_dense_elementwise_add_jagged_output(
+                x_values_large, x_offsets_large, y0_large, y1_large
+            )
+        )
+        self.assertEqual(output_large[0].shape, (nnz, D_half))
+        del x_values_large, x_offsets_large, y0_large, y1_large, output_large
+        torch.cuda.empty_cache()
+
+        # ---- Step 2: small-scale CPU-oracle correctness. ----
+        small_B = 1
+        small_max_L = 4
+        small_D = 8
+        small_lengths = torch.tensor([3], dtype=torch.int64)
+        small_x_offsets_cpu = [torch.zeros(small_B + 1, dtype=torch.int64)]
+        small_x_offsets_cpu[0][1:] = torch.cumsum(small_lengths, dim=0)
+        small_nnz = int(small_x_offsets_cpu[0][-1].item())
+        small_x_values_cpu = (
+            torch.arange(small_nnz * small_D, dtype=torch.float16).reshape(
+                small_nnz, small_D
+            )
+            * 0.1
+        )
+        small_y0_cpu = (
+            torch.arange(small_B * small_max_L * small_D, dtype=torch.float16).reshape(
+                small_B, small_max_L, small_D
+            )
+            * 0.01
+        )
+        small_y1_cpu = (
+            torch.arange(small_B * small_max_L * small_D, dtype=torch.float16).reshape(
+                small_B, small_max_L, small_D
+            )
+            * 0.001
+        )
+
+        small_output_cpu = (
+            torch.ops.fbgemm.jagged_dense_dense_elementwise_add_jagged_output(
+                small_x_values_cpu,
+                small_x_offsets_cpu,
+                small_y0_cpu,
+                small_y1_cpu,
+            )
+        )
+        small_x_offsets_gpu = [t.to(device) for t in small_x_offsets_cpu]
+        small_output_gpu = (
+            torch.ops.fbgemm.jagged_dense_dense_elementwise_add_jagged_output(
+                small_x_values_cpu.to(device),
+                small_x_offsets_gpu,
+                small_y0_cpu.to(device),
+                small_y1_cpu.to(device),
+            )
+        )
+        torch.testing.assert_close(small_output_gpu[0].cpu(), small_output_cpu[0])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2916


Diff 5/10 of the Tier-2 ROCm grid-overflow fix stack.

The opt_search codepath of the jagged-dense-dense elementwise add kernel
template (defined in common.cuh:401, instantiated in
jagged_dense_dense_elementwise_add_jagged_output_forward.cu:137 and
common.cuh:900) bails out with if (row >= nnz) return; and lacks a
grid-stride loop. Saturates at nnz >= 2^32.

This diff:
- Wraps the kernel body in an explicit grid-stride for-loop over rows
  (Pattern A). The pre-loop shared-memory load is performed once per
  block; data remains valid across grid-stride iterations.
- Adds the standard #ifdef USE_ROCM host-side cap to blocks.x at both
  launch sites.

Reviewed By: henrylhtsang

Differential Revision: D105203391


