### PR TITLE
Fix stale group_index_select_dim0 fake/meta kernel (torch.compile)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -1088,8 +1088,12 @@ def group_index_select_dim0_gpu_impl_abstract(
         size = list(input_group[i].size())
         ret.append(input_group[i].new_empty([indices_group[i].size(0)] + size[1:]))
 
-    # divide by 2 since sizeof(int64_t) / sizeof(int32_t) = 2
-    args_tensor_numel = 4 * group_size + 1 + int(math.ceil(group_size / 2))
+    # args_tensor packs, in int64 units (must match the C++ forward layout in
+    # sparse_ops_gpu.cpp, NUM_ARGS = 7): input_ptrs, output_ptrs, indices_ptrs,
+    # sorted_indices_ptrs, reverse_indices_ptrs (5 * group_size) +
+    # warp_offsets_group (group_size + 1) + num_cols_group (int32, packed 2 per
+    # int64 -> ceil(group_size / 2)).
+    args_tensor_numel = 6 * group_size + 1 + int(math.ceil(group_size / 2))
 
     ret.append(
         # sizeof(int64_t) = 8, torch.uint8 = at::kByte
@@ -1098,7 +1102,8 @@ def group_index_select_dim0_gpu_impl_abstract(
         )
     )
 
-    ret.append(torch.zeros(5, dtype=torch.int64, device="cpu"))
+    # Saved args-offsets tensor: NUM_ARGS + 1 int64 entries (NUM_ARGS = 7).
+    ret.append(torch.zeros(8, dtype=torch.int64, device="cpu"))
 
     return ret
 

--- a/fbgemm_gpu/test/sparse/index_select_test.py
+++ b/fbgemm_gpu/test/sparse/index_select_test.py
@@ -299,6 +299,46 @@ class IndexSelectTest(unittest.TestCase):
                 [input0, input1], [indices0, indices1]
             )
 
+    @unittest.skipIf(not gpu_available, "Skip when CUDA is not available")
+    @optests.dontGenerateOpCheckTests(
+        "This test IS the opcheck; the harness variants would double-run it"
+    )
+    def test_group_index_select_dim0_fake_kernel_opcheck(self) -> None:
+        """The fake/meta kernel must report the same output metadata as the real
+        op, otherwise torch.compile sizes the op's buffers wrong and crashes at
+        runtime (assert_size_stride). This directly opchecks the fake kernel
+        against the real forward so an args_tensor layout change in
+        sparse_ops_gpu.cpp can't silently drift from the fake kernel again.
+        """
+        # lint-fixme: TorchDeviceCuda, TorchFunctionCallCudaDevice
+        # CUDA specifically required: GPU-only FBGEMM sparse op.
+        device = torch.device("cuda")
+        # Odd group_size exercises the ceil(group_size / 2) int32 packing.
+        group_size = 9
+        num_input_rows = 16
+        num_cols = 8
+        num_indices = 5
+
+        indices_group = [
+            torch.randint(
+                num_input_rows, (num_indices,), dtype=torch.long, device=device
+            )
+            for _ in range(group_size)
+        ]
+        input_group = [
+            torch.rand((num_input_rows, num_cols), dtype=torch.float, device=device)
+            for _ in range(group_size)
+        ]
+        # group_index_select_dim0_gpu_impl unpacks inputs as
+        # [*indices_group, *input_group].
+        all_indices_input = [*indices_group, *input_group]
+
+        torch.library.opcheck(
+            torch.ops.fbgemm.group_index_select_dim0_gpu_impl.default,
+            (all_indices_input, group_size),
+            test_utils=["test_faketensor"],
+        )
+
     def execute_batch_index_select_dim0(  # noqa: C901
         self,
         num_inputs: int,


### PR DESCRIPTION
Summary:
D96328337 grew the *forward* args_tensor of group_index_select_dim0 in
sparse_ops_gpu.cpp (added sorted_indices_ptrs + reverse_indices_ptrs, bumped
NUM_ARGS 5 -> 7) but never updated the Python fake/meta kernel
group_index_select_dim0_gpu_impl_abstract in sparse_ops.py. Under torch.compile,
Inductor sizes and guards the op's output buffers from the stale fake kernel, so
it pre-allocates args_tensor too small and a runtime guard fires
(assert_size_stride, e.g. expected 480 == 336 for group_size=9, then 8 == 5 on
the offsets tensor). Eager never consults the fake kernel, so this is
compile-only: any torch.compile model using this op crashes non-retryably at
pt2_warmup (hit on mtml_ctr_inline_cvr_mbl_feed_model / interformer).

Update the fake kernel to match the current C++ layout (NUM_ARGS = 7):
- args_tensor_numel = 6 * group_size + 1 + ceil(group_size / 2)
  (5 pointer arrays + warp_offsets_group (group_size + 1) + num_cols int32,
  packed 2 per int64)
- the saved args-offsets tensor is NUM_ARGS + 1 = 8 int64 entries

This went undetected because the generated test_faketensor__test_group_index_select_dim0
opcheck is skip("hangs"). Add a standalone torch.library.opcheck(test_faketensor)
guard plus a torch.compile regression test so an args_tensor layout change can't
silently drift from the fake kernel again.

Reported by Boris Shulman (bshulman). Details:
https://docs.google.com/document/d/1Cs8j5cHXEZPjU7rgBADAYZ4QtBLpWb4hoZ3LU9qYNOk/edit

Reviewed By: henrylhtsang

Differential Revision: D111660348


