### PR TITLE
group_index_select backward correctness fixes (ROCm)

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_group_index.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_group_index.cu
@@ -317,12 +317,17 @@ __launch_bounds__(kMaxThreads) void group_index_select_or_add_2d_kernel(
       // Compile time conditional
       if constexpr (USE_INDEX_SELECT) {
         if constexpr (USE_CACHE) {
-          if (cached_idx != idx) {
+          // Force re-read when col_tile changes (output pointer shifted)
+          const bool col_tile_changed =
+              (last_member_output_tile != nullptr &&
+               output != last_member_output_tile);
+          if (cached_idx != idx || col_tile_changed) {
             storage = LDG(&input[static_cast<int64_t>(idx) * num_cols + i]);
             cached_idx = idx;
           }
 
           output[row * num_cols + i] = storage;
+          last_member_output_tile = output;
         } else {
           output[row * num_cols + i] =
               LDG(&input[static_cast<int64_t>(idx) * num_cols + i]);
@@ -332,14 +337,18 @@ __launch_bounds__(kMaxThreads) void group_index_select_or_add_2d_kernel(
           const bool member_changed =
               (last_member_id_for_accum != -1 &&
                member_id != last_member_id_for_accum);
-          // Probably might be merged into following if-else cascade
-          if (member_changed) {
+          // Detect col_tile boundary: output pointer changes within the
+          // same member
+          const bool col_tile_changed =
+              (!member_changed && last_member_output_tile != nullptr &&
+               output != last_member_output_tile);
+          if (member_changed || col_tile_changed) {
             flush_cache_accumulator(
                 last_member_output_tile, last_member_num_cols);
           }
 
           const bool is_first_warp =
-              member_changed || (warp_id == start_warp_id);
+              member_changed || col_tile_changed || (warp_id == start_warp_id);
           const bool is_last_warp = (warp_id + warp_stride >= warp_end);
           if (is_first_warp) {
             storage = input[row * num_cols + i];

--- a/fbgemm_gpu/test/sparse/index_select_test.py
+++ b/fbgemm_gpu/test/sparse/index_select_test.py
@@ -260,6 +260,72 @@ class IndexSelectTest(unittest.TestCase):
         )
 
     @unittest.skipIf(not gpu_available, "Skip when CUDA is not available")
+    @unittest.skipIf(
+        not getattr(torch.version, "hip", None),
+        "ROCm-only: tests contiguous warp cache flush",
+    )
+    @optests.dontGenerateOpCheckTests(
+        "GPU-only correctness regression test; the faketensor variant only "
+        "exercises the (pre-existing, separately tracked) stale fake kernel "
+        "and adds no op coverage"
+    )
+    def test_group_index_select_backward_col_tile_boundary(self) -> None:
+        """Regression test for col_tile boundary cache accumulator flush bug.
+
+        When USE_CONTIGUOUS_WARPS and USE_CACHE are both true (ROCm backward),
+        the cache accumulator must be flushed when a warp crosses a col_tile
+        boundary.  Without the fix, columns [0:32] of grad_input lose a
+        contribution and columns [32:64] gain a spurious one.
+
+        Trigger conditions:
+          - num_cols > 32 (multiple col_tiles)
+          - total_num_warps > warps_per_launch (chunk_size >= 2)
+          - duplicate index at col_tile boundary (cached_idx == idx)
+        """
+        # lint-fixme: TorchDeviceCuda, TorchFunctionCallCudaDevice
+        # CUDA specifically required: testing GPU-only FBGEMM sparse op
+        device = torch.device("cuda")
+        dtype = torch.float
+
+        # 64 cols → 2 col_tiles (warps_per_row = 2).
+        # 100003 indices (prime) → total_num_warps = 200006, which exceeds
+        # warps_per_launch on all current AMD GPUs, so chunk_size >= 2.
+        # Being prime ensures the col_tile boundary never aligns with chunk
+        # boundaries for any chunk_size.
+        num_cols = 64
+        num_embedding_rows = 10
+        num_indices = 100003
+
+        # All indices point to the same row so the cache always hits across
+        # the col_tile boundary.
+        indices = torch.zeros(num_indices, device=device, dtype=torch.long)
+
+        input_tensor = torch.randn(
+            num_embedding_rows, num_cols, device=device, dtype=dtype
+        )
+        input_tensor.requires_grad = True
+
+        input_ref = input_tensor.detach().clone()
+        input_ref.requires_grad = True
+
+        # Forward
+        output = torch.ops.fbgemm.group_index_select_dim0([input_tensor], [indices])
+        output_ref = [torch.index_select(input_ref, 0, indices)]
+
+        # Backward with ones — expected gradient per column = num_indices.
+        grad = torch.ones(num_indices, num_cols, device=device, dtype=dtype)
+        output_ref[0].backward(grad)
+        output[0].backward(grad)
+
+        torch.testing.assert_close(
+            input_tensor.grad,
+            input_ref.grad,
+            atol=0.5,
+            rtol=0,
+            msg="grad_input mismatch — col_tile boundary cache flush bug?",
+        )
+
+    @unittest.skipIf(not gpu_available, "Skip when CUDA is not available")
     @optests.dontGenerateOpCheckTests(
         "GPU-only test; opcheck variants only skip on CPU samples and add no op coverage (T191384137)"
     )


### PR DESCRIPTION
Summary:
Folds two follow-up correctness/test fixes for the group_index_select
backward optimizations (D96328337) into a single diff:

- Cache accumulator col_tile boundary fix (was D102425657): flush the
  warp-level cache accumulator when a warp crosses a col_tile boundary in
  the USE_CONTIGUOUS_WARPS + USE_CACHE path. Without this, columns [0:32]
  of grad_input lose a contribution and [32:64] gain a spurious one. Adds
  a ROCm regression test
  (test_group_index_select_backward_col_tile_boundary).

- AMD opcheck skip (was D102847266): skip
  test_pt2_compliant_tag_fbgemm_group_index_select_dim0 on ROCm, since the
  required faketensor sub-test is already skipped (hangs), which otherwise
  makes the pt2_compliant_tag aggregation report a failure.

The fp32 pre-sort gate previously folded here is dropped: trunk already
avoids the fp32 pre-sort regression via a dtype-dependent lower threshold
(kSortIndicesLowerThresholdFullPrec), which supersedes the blanket
is_low_precision gate.

Differential Revision: D107772512


