### PR TITLE
Cap TorchInductor compile threads to fix x86 CPU CI OOM (no runner bump)

### DIFF
--- a/.github/workflows/fbgemm_gpu_ci_cpu.yml
+++ b/.github/workflows/fbgemm_gpu_ci_cpu.yml
@@ -203,6 +203,12 @@ jobs:
 
     - name: Test with PyTest
       timeout-minutes: ${{ matrix.host-machine.timeout }}
+      # TorchInductor defaults to one C++ compile worker per vCPU (16 on the x86
+      # linux.4xlarge). The torch.compile TBE tests (backward_adagrad, ...) blow
+      # peak memory past the box's 32GB and OOM-kill the runner. Serialize the
+      # compile workers to bound peak memory (config fix; no runner-size change).
+      env:
+        TORCHINDUCTOR_COMPILE_THREADS: 1
       run: . $PRELUDE; test_all_fbgemm_gpu_modules $BUILD_ENV
 
     - name: Push Wheel to PyPI

--- a/.github/workflows/fbgemm_gpu_release_cpu.yml
+++ b/.github/workflows/fbgemm_gpu_release_cpu.yml
@@ -185,6 +185,12 @@ jobs:
 
     - name: Test with PyTest
       timeout-minutes: ${{ matrix.host-machine.timeout }}
+      # TorchInductor defaults to one C++ compile worker per vCPU (16 on the x86
+      # linux.4xlarge). The torch.compile TBE tests (backward_adagrad, ...) blow
+      # peak memory past the box's 32GB and OOM-kill the runner. Serialize the
+      # compile workers to bound peak memory (config fix; no runner-size change).
+      env:
+        TORCHINDUCTOR_COMPILE_THREADS: 1
       run: . $PRELUDE; test_all_fbgemm_gpu_modules $BUILD_ENV
 
     - name: Push Wheel to PyPI


### PR DESCRIPTION
Summary:
The FBGEMM_GPU-CPU test step OOM-kills on the x86 linux.4xlarge (c5.4xlarge,
16 vCPU / 32GB) for py3.12+ on the torch.compile TBE tests (backward_adagrad,
...), while the arm m7g.4xlarge (16 vCPU / 64GB) passes the identical tests.

Root cause is config, not infra (confirmed with Huy Do / dev-infra, and per
Supadchaya's review note that this shouldn't be a real OOM): TorchInductor
defaults its async C++ compile-worker pool to one worker per vCPU (16 here), so
the compile=True TBE tests spike peak memory past 32GB only on the x86 box. The
64GB arm box absorbs the same spike.

Fix: set TORCHINDUCTOR_COMPILE_THREADS=1 on the 'Test with PyTest' step in both
fbgemm_gpu_ci_cpu.yml and fbgemm_gpu_release_cpu.yml to serialize the compile
workers and bound peak memory. This keeps the existing linux.4xlarge runner (no
CI cost increase) and does not touch the test matrix or coverage. The value can
be tuned up (2-4) if compile time becomes a concern, as long as it stays under
the 32GB threshold. If capping alone proves insufficient, Huy's fallback is
linux.4xlarge.memory (16 vCPU / 128GB, same CPU) rather than a larger box.

Supersedes the runner-size bump approach in D111184249 (rejected by Supadchaya).

Differential Revision: D111831246


