### PR TITLE
Move x86 CPU test runner to linux.4xlarge.memory to fix py3.12+ OOM

### DIFF
--- a/.github/workflows/fbgemm_gpu_ci_cpu.yml
+++ b/.github/workflows/fbgemm_gpu_ci_cpu.yml
@@ -148,7 +148,7 @@ jobs:
       fail-fast: false
       matrix:
         host-machine: [
-          { arch: x86, instance: "linux.4xlarge", timeout: 20 },
+          { arch: x86, instance: "linux.4xlarge.memory", timeout: 40 },
           { arch: arm, instance: "linux.arm64.m7g.4xlarge", timeout: 30 },
         ]
         build-target: [ "default" ]

--- a/.github/workflows/fbgemm_gpu_release_cpu.yml
+++ b/.github/workflows/fbgemm_gpu_release_cpu.yml
@@ -131,7 +131,7 @@ jobs:
       fail-fast: false
       matrix:
         host-machine: [
-          { arch: x86, instance: "linux.4xlarge", timeout: 20 },
+          { arch: x86, instance: "linux.4xlarge.memory", timeout: 40 },
           { arch: arm, instance: "linux.arm64.m7g.4xlarge", timeout: 30 },
         ]
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]


### PR DESCRIPTION
Summary:
The FBGEMM_GPU-CPU test step OOM-kills on the x86 linux.4xlarge (16 vCPU / 32GB) for py3.12+ on the torch.compile TBE tests (backward_adagrad, ...), while the arm m7g.4xlarge (16 vCPU / 64GB) passes the identical tests. The shortfall is memory, not CPU.

Move the x86 test_and_publish_artifact runner from linux.4xlarge to the memory-optimized linux.4xlarge.memory (16 vCPU / 128GB): same core count, 4x the RAM, so the compile-heavy tests fit without OOM and without paying for extra cores. The x86 test timeout is also raised 20 -> 40 min, since the compile sweep runs longer than the old 20-min cap. The build job stays on linux.4xlarge (it does not OOM); only the test job moves. arm is unchanged (already 64GB). Applied to both fbgemm_gpu_ci_cpu.yml and fbgemm_gpu_release_cpu.yml.

Differential Revision: D111934101


