### PR TITLE
Add grid-stride + ROCm cap to embedding_inplace_update kernels and pruned_array_lookup_from_row_idx_kernel

### DIFF
--- a/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update.cu
+++ b/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update.cu
@@ -6,11 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <algorithm>
+#include <limits>
+
 #include <c10/cuda/CUDAGuard.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include "fbgemm_gpu/embedding_inplace_update.h"
 #include "fbgemm_gpu/utils/cuda_prelude.cuh"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 #include "fbgemm_gpu/utils/kernel_launcher.cuh"
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
 #include "fbgemm_gpu/utils/tensor_utils.h"
@@ -44,15 +48,8 @@ inline __device__ void embedding_inplace_update_kernel_impl(
     pta::PackedTensorAccessor64<uint8_t, 2, at::RestrictPtrTraits>
         lxu_cache_weights,
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        lxu_cache_locations) {
-  // each row is updated by one warp of threads
-  // blockIdx.x: block idx, threadIdx.x: thread idx in the warp,
-  // threadIdx.y: warp idx in the block.
-  // blockDim.x = warpSize, blockDim.y = warpsPerBlock.
-  const int64_t i = blockIdx.x * blockDim.y + threadIdx.y;
-  if (i >= update_row_idx.size(0)) {
-    return;
-  }
+        lxu_cache_locations,
+    const int64_t i) {
   const int32_t table_idx = update_table_idx[i];
   const auto row_idx = update_row_idx[i];
 
@@ -131,31 +128,31 @@ __launch_bounds__(kMaxThreads) __global__
             lxu_cache_weights,
         const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
             lxu_cache_locations) {
-  // each row is updated by one warp of threads
-  // blockIdx.x: block idx, threadIdx.x: thread idx in the warp,
-  // threadIdx.y: warp idx in the block.
-  // blockDim.x = warpSize, blockDim.y = warpsPerBlock.
-  const int64_t i = blockIdx.x * blockDim.y + threadIdx.y;
-  if (i >= update_row_idx.size(0)) {
-    return;
+  // each row is updated by one warp of threads.
+  // Grid-stride over rows so a capped grid (used on ROCm to avoid the 2^32
+  // launch-side limit) still covers every row.
+  const int64_t N = update_row_idx.size(0);
+  for (int64_t i = blockIdx.x * blockDim.y + threadIdx.y; i < N;
+       i += gridDim.x * blockDim.y) {
+    const int32_t table_idx = update_table_idx[i];
+    const auto placement =
+        static_cast<PlacementType>(weights_placements[table_idx]);
+    embedding_inplace_update_kernel_impl(
+        dev_weights,
+        uvm_weights,
+        placement,
+        weights_offsets,
+        weights_tys,
+        D_offsets,
+        update_weights,
+        update_table_idx,
+        update_row_idx,
+        update_offsets,
+        row_alignment,
+        lxu_cache_weights,
+        lxu_cache_locations,
+        i);
   }
-  const int32_t table_idx = update_table_idx[i];
-  const auto placement =
-      static_cast<PlacementType>(weights_placements[table_idx]);
-  embedding_inplace_update_kernel_impl(
-      dev_weights,
-      uvm_weights,
-      placement,
-      weights_offsets,
-      weights_tys,
-      D_offsets,
-      update_weights,
-      update_table_idx,
-      update_row_idx,
-      update_offsets,
-      row_alignment,
-      lxu_cache_weights,
-      lxu_cache_locations);
 }
 
 template <typename index_t>
@@ -185,20 +182,26 @@ __launch_bounds__(kMaxThreads) __global__
             lxu_cache_weights,
         const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
             lxu_cache_locations) {
-  embedding_inplace_update_kernel_impl(
-      dev_weights,
-      uvm_weights,
-      weights_placement,
-      weights_offsets,
-      weights_tys,
-      D_offsets,
-      update_weights,
-      update_table_idx,
-      update_row_idx,
-      update_offsets,
-      row_alignment,
-      lxu_cache_weights,
-      lxu_cache_locations);
+  // Grid-stride over rows; see kernel_1 for details.
+  const int64_t N = update_row_idx.size(0);
+  for (int64_t i = blockIdx.x * blockDim.y + threadIdx.y; i < N;
+       i += gridDim.x * blockDim.y) {
+    embedding_inplace_update_kernel_impl(
+        dev_weights,
+        uvm_weights,
+        weights_placement,
+        weights_offsets,
+        weights_tys,
+        D_offsets,
+        update_weights,
+        update_table_idx,
+        update_row_idx,
+        update_offsets,
+        row_alignment,
+        lxu_cache_weights,
+        lxu_cache_locations,
+        i);
+  }
 }
 
 void embedding_inplace_update_cuda(
@@ -247,9 +250,25 @@ void embedding_inplace_update_cuda(
 
   AT_DISPATCH_INDEX_TYPES(
       update_row_idx.scalar_type(), "embedding_inplace_update_kernel_1", [&] {
+        // HIP enforces a hard limit of 2^32 total threads per launch.
+        // See: https://github.com/ROCm/hip/issues/2253
+        // Compute the uncapped block count in 64-bit and clamp to uint32_t
+        // max before handing it to cap_grid_dim_x. A bare
+        // static_cast<uint32_t> would truncate for N >= ~2^32 * warpsPerBlock
+        // and could wrap to 0, which would make the cap's overflow check
+        // (blocks * threads) pass and silently launch no work. Clamping keeps
+        // the value above the cap threshold so the ROCm cap engages; the
+        // grid-stride loop then still covers all N rows.
+        const int64_t blocks_uncapped = nbit::div_round_up(N, warpsPerBlock);
+        const auto blocks = utils::cuda::cap_grid_dim_x(
+            static_cast<uint32_t>(std::min<int64_t>(
+                blocks_uncapped,
+                static_cast<int64_t>(std::numeric_limits<uint32_t>::max()))),
+            kMaxThreads,
+            at::cuda::getCurrentCUDAStream());
         FBGEMM_LAUNCH_KERNEL(
             (embedding_inplace_update_kernel_1<index_t>),
-            nbit::div_round_up(N, warpsPerBlock), // number of blocks needed
+            blocks, // number of blocks needed
             dim3(kWarpSize, warpsPerBlock), // shape of each block
             0,
             at::cuda::getCurrentCUDAStream(),
@@ -315,9 +334,21 @@ void embedding_inplace_update_single_placement_cuda(
 
   AT_DISPATCH_INDEX_TYPES(
       update_row_idx.scalar_type(), "embedding_inplace_update_kernel_2", [&] {
+        // HIP enforces a hard limit of 2^32 total threads per launch.
+        // See: https://github.com/ROCm/hip/issues/2253
+        // See embedding_inplace_update_kernel_1 above: clamp the uncapped
+        // block count in 64-bit so a huge N cannot truncate/wrap the
+        // uint32_t and defeat the ROCm overflow cap.
+        const int64_t blocks_uncapped = nbit::div_round_up(N, warpsPerBlock);
+        const auto blocks = utils::cuda::cap_grid_dim_x(
+            static_cast<uint32_t>(std::min<int64_t>(
+                blocks_uncapped,
+                static_cast<int64_t>(std::numeric_limits<uint32_t>::max()))),
+            kMaxThreads,
+            at::cuda::getCurrentCUDAStream());
         FBGEMM_LAUNCH_KERNEL(
             (embedding_inplace_update_kernel_2<index_t>),
-            nbit::div_round_up(N, warpsPerBlock), // number of blocks needed
+            blocks, // number of blocks needed
             dim3(kWarpSize, warpsPerBlock), // shape of each block
             0,
             at::cuda::getCurrentCUDAStream(),
@@ -351,25 +382,30 @@ __launch_bounds__(kMaxThreads) void pruned_array_lookup_from_row_idx_kernel(
         index_remappings_offsets,
     pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         dense_indices) {
-  const int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
-  if (idx >= update_row_indices.size(0)) {
-    return;
-  }
-  const auto row_idx = update_row_indices[idx];
-  if (idx >= update_table_indices.size(0)) {
-    return;
-  }
-  const int table_idx = update_table_indices[idx];
+  const int64_t total = update_row_indices.size(0);
+  const int64_t update_table_size = update_table_indices.size(0);
+  // Grid-stride over rows so a capped grid (used on ROCm to avoid the 2^32
+  // launch-side limit) still covers every row.
+  for (int64_t idx =
+           static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       idx < total;
+       idx += static_cast<int64_t>(gridDim.x) * blockDim.x) {
+    if (idx >= update_table_size) {
+      continue;
+    }
+    const auto row_idx = update_row_indices[idx];
+    const int table_idx = update_table_indices[idx];
 
-  const auto index_remappings_start = index_remappings_offsets[table_idx];
-  const auto index_remappings_end = index_remappings_offsets[table_idx + 1];
-  const auto capacity = index_remappings_end - index_remappings_start;
+    const auto index_remappings_start = index_remappings_offsets[table_idx];
+    const auto index_remappings_end = index_remappings_offsets[table_idx + 1];
+    const auto capacity = index_remappings_end - index_remappings_start;
 
-  if (capacity > 0) {
-    dense_indices[idx] = static_cast<index_t>(
-        index_remappings[index_remappings_start + row_idx]);
-  } else {
-    dense_indices[idx] = row_idx;
+    if (capacity > 0) {
+      dense_indices[idx] = static_cast<index_t>(
+          index_remappings[index_remappings_start + row_idx]);
+    } else {
+      dense_indices[idx] = row_idx;
+    }
   }
 }
 
@@ -418,9 +454,15 @@ Tensor pruned_array_lookup_from_row_idx_cuda(
             update_row_indices.scalar_type(),
             "pruned_array_lookup_from_row_idx_cuda_1",
             [&] {
+              // HIP enforces a hard limit of 2^32 total threads per launch.
+              // See: https://github.com/ROCm/hip/issues/2253
+              const auto blocks = utils::cuda::cap_grid_dim_x_from_workload(
+                  num_indices,
+                  kForwardMaxThreads,
+                  at::cuda::getCurrentCUDAStream());
               FBGEMM_LAUNCH_KERNEL(
                   (pruned_array_lookup_from_row_idx_kernel<index_t, remap_t>),
-                  nbit::div_round_up(num_indices, kForwardMaxThreads),
+                  blocks,
                   kForwardMaxThreads,
                   0,
                   at::cuda::getCurrentCUDAStream(),

--- a/fbgemm_gpu/test/tbe/utils/split_embeddings_test.py
+++ b/fbgemm_gpu/test/tbe/utils/split_embeddings_test.py
@@ -1136,5 +1136,103 @@ class PreallocatedHostBuffersTest(unittest.TestCase):
         self.assertEqual(momentum1_host.data_ptr(), momentum1_buffer.data_ptr())
 
 
+class PrunedArrayLookupFromRowIdxLargeGridTest(unittest.TestCase):
+    """
+    Regression tests for the grid-stride refactor of
+    ``pruned_array_lookup_from_row_idx_kernel`` (D105203915), which
+    lacked its own test method when landed.
+
+    Scope: these tests only exercise ``pruned_array_lookup_from_row_idx``
+    (it has both CPU and CUDA dispatches, so the GPU output can be checked
+    against the CPU reference). They verify the grid-stride loop over a
+    multi-block grid and that the launch survives once the host-side ROCm
+    grid cap is applied.
+
+    They do NOT exercise ``embedding_inplace_update_kernel_{1,2}`` and do
+    NOT reach the 2^32 thread cap-trip threshold that the ROCm fix guards
+    against: doing so would require >2^32 indices (a >16 GB int32 tensor),
+    which is infeasible in a unit test. A regression specific to the
+    embedding-update grid-stride loops is therefore not covered here.
+    """
+
+    @unittest.skipUnless(torch.cuda.is_available(), "GPU not available")
+    def test_pruned_array_lookup_from_row_idx_correctness(self) -> None:
+        """
+        Multi-block correctness check at small scale. Sentinel non-zero
+        values at start / middle / end of the index axis force the
+        grid-stride loop to iterate.
+        """
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        # num_indices > kForwardMaxThreads * 2 so the grid-stride loop
+        # iterates >= 2 times.
+        num_indices = 2 * 256 + 7
+        T = 2  # 2 tables.
+        # Single shared remapping per table.
+        remap_size = 16
+        update_row_indices_cpu = torch.zeros(num_indices, dtype=torch.int32)
+        update_row_indices_cpu[0] = 1
+        update_row_indices_cpu[num_indices // 2] = 5
+        update_row_indices_cpu[num_indices - 1] = 9
+        update_table_indices_cpu = torch.zeros(num_indices, dtype=torch.int32)
+        update_table_indices_cpu[num_indices // 2] = 1
+        # Identity remapping: index_remappings[i] = i.
+        index_remappings_cpu = torch.arange(T * remap_size, dtype=torch.int32)
+        index_remappings_offsets_cpu = torch.tensor(
+            [0, remap_size, T * remap_size], dtype=torch.int64
+        )
+
+        result_cpu = torch.ops.fbgemm.pruned_array_lookup_from_row_idx(
+            update_row_indices_cpu,
+            update_table_indices_cpu,
+            index_remappings_cpu,
+            index_remappings_offsets_cpu,
+        )
+        result_gpu = torch.ops.fbgemm.pruned_array_lookup_from_row_idx(
+            update_row_indices_cpu.to(device),
+            update_table_indices_cpu.to(device),
+            index_remappings_cpu.to(device),
+            index_remappings_offsets_cpu.to(device),
+        )
+        torch.testing.assert_close(result_gpu.cpu(), result_cpu)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "GPU not available")
+    def test_pruned_array_lookup_from_row_idx_large_grid(self) -> None:
+        """
+        Grid-stride + host-cap survival test at a multi-block scale.
+
+        Post-fix, ``pruned_array_lookup_from_row_idx_kernel`` grid-strides
+        over indices and the host caps grid_x on ROCm. This test runs the
+        op at a moderately large ``num_indices`` (many blocks) and checks
+        that the launch succeeds and returns the expected shape.
+
+        Note: this scale does NOT reach the 2^32 thread cap-trip that the
+        ROCm fix ultimately guards against -- that would require >2^32
+        indices (>16 GB), which is infeasible here. It verifies the grid-
+        stride / cap code path executes, not the overflow boundary itself.
+        """
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        num_indices = (1 << 22) + 1
+        T = 1
+        remap_size = 4
+        update_row_indices = torch.zeros(num_indices, dtype=torch.int32, device=device)
+        update_table_indices = torch.zeros(
+            num_indices, dtype=torch.int32, device=device
+        )
+        index_remappings = torch.arange(
+            T * remap_size, dtype=torch.int32, device=device
+        )
+        index_remappings_offsets = torch.tensor(
+            [0, remap_size], dtype=torch.int64, device=device
+        )
+
+        result = torch.ops.fbgemm.pruned_array_lookup_from_row_idx(
+            update_row_indices,
+            update_table_indices,
+            index_remappings,
+            index_remappings_offsets,
+        )
+        self.assertEqual(result.shape, (num_indices,))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2919

Diff 6/10 of the Tier-2 ROCm grid-overflow fix stack.

Three kernels in embedding_inplace_update.cu used flat early-return on
work-item bounds and lacked grid-stride loops:
- embedding_inplace_update_kernel_1 / _kernel_2 (warp-per-row, Pattern D),
  both call shared embedding_inplace_update_kernel_impl
- pruned_array_lookup_from_row_idx_kernel (1D thread-per-index, Pattern A)

This diff:
- Refactors embedding_inplace_update_kernel_impl to take the row index i as
  a parameter instead of computing it from blockIdx. The OOB check moves
  to the callers.
- Wraps both kernel_1 and kernel_2 in a warp-stride loop (i = blockIdx.x *
  blockDim.y + threadIdx.y; i < N; i += gridDim.x * blockDim.y).
- Wraps pruned_array_lookup_from_row_idx_kernel in an explicit int64_t
  grid-stride for-loop. The inner OOB check on update_table_indices.size(0)
  becomes a continue (it's a defensive skip, not a strict OOB).
- Adds the standard #ifdef USE_ROCM host-side cap at all 3 launch sites
  (lines 250, 318, 421).

Reviewed By: henrylhtsang

Differential Revision: D105203915


