### PR TITLE
Migrate contained C10_LIKELY/C10_UNLIKELY to [[likely]]/[[unlikely]] (pytorch/FBGEMM)

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
@@ -255,7 +255,7 @@ struct __attribute__((visibility("hidden"))) KernelLauncher {
     const auto cuda_kernel_failure =
         c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().has_failed();
 
-    if (C10_LIKELY(cuda_error == cudaSuccess && !cuda_kernel_failure)) {
+    if (cuda_error == cudaSuccess && !cuda_kernel_failure) [[likely]] {
       return;
     }
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2921

Migrates fully-contained uses of the `C10_LIKELY`/`C10_UNLIKELY` macros -- where the macro is the entire controlling condition of an `if`/`else if`/`while`/`for` -- to the standard C++20 `[[likely]]`/`[[unlikely]]` branch-prediction attributes, e.g. `if (C10_LIKELY(x))` becomes `if (x) [[likely]]`.

This diff is one of several split out from D111576576 by GitHub project, and contains only the changes under `fbcode/deeplearning/fbgemm/`. Conditions where the macro is only one clause of a compound condition (`if (a && C10_LIKELY(b))`), `return C10_LIKELY(x);` forms, macro definitions, and `generated` files are deliberately left untouched.

The migration was performed by the `c10_likely_to_attr` codemod, landed as a companion diff.

This diff was authored with the assistance of an AI coding agent.

Differential Revision: D111945040


