### PR TITLE
Clamp cap_grid_dim_x to the 2^31-1 grid-x limit (+ unit test)

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
@@ -25,6 +25,15 @@ namespace fbgemm_gpu::utils::cuda {
 /// kernels: `max_blocks = MAX_THREAD_BLOCKS_FACTOR * #SMs`.
 constexpr int32_t MAX_THREAD_BLOCKS_FACTOR = 64;
 
+/// The grid x-dimension is limited to 2^31 - 1 on both CUDA and HIP; a launch
+/// with `gridDim.x` above this is rejected by the driver.
+constexpr int64_t kMaxGridDimX = std::numeric_limits<int32_t>::max();
+
+/// HIP additionally caps the *total* threads per launch at 2^32 (CUDA silently
+/// wraps). Used only as the `OverflowOnly` threshold, and is distinct from the
+/// grid-x dimension limit above. See: https://github.com/ROCm/hip/issues/2253
+constexpr int64_t kMaxThreadsPerLaunch = std::numeric_limits<uint32_t>::max();
+
 /// Selects how `cap_grid_dim_x{,_from_workload}` clamps the requested grid.
 ///
 /// - `Always`: cap on both CUDA and ROCm at `MAX_THREAD_BLOCKS_FACTOR * #SMs`.
@@ -53,7 +62,12 @@ enum class BlockCapPolicy { Always, OverflowOnly, Never };
 /// - HIP 2^32 thread-per-launch limit: https://github.com/ROCm/hip/issues/2253
 /// - Pre-existing unconditional-cap pattern: D75543767, D65009966
 ///
-/// @param blocks_uncapped     Pre-computed unclamped grid-x dimension.
+/// @param blocks_uncapped     Pre-computed unclamped grid-x dimension. Taken
+///                            as 64-bit so callers whose uncapped block count
+///                            can exceed `uint32_t` (the exact overflow case
+///                            this cap guards against) do not have to narrow it
+///                            first; the returned dimension is always clamped
+///                            into the valid grid-x range `[1, 2^31 - 1]`.
 /// @param threads_per_block   Full per-block thread count
 ///                            (`block.x * block.y * block.z`), used only by
 ///                            the `OverflowOnly` threshold check.
@@ -62,32 +76,42 @@ enum class BlockCapPolicy { Always, OverflowOnly, Never };
 ///                            `OverflowOnly`.
 /// @return Grid-x dimension to pass to the kernel launch.
 inline uint32_t cap_grid_dim_x(
-    uint32_t blocks_uncapped,
+    int64_t blocks_uncapped,
     [[maybe_unused]] int64_t threads_per_block,
     const c10::cuda::CUDAStream& stream,
     BlockCapPolicy policy = BlockCapPolicy::OverflowOnly) {
+  // Clamp into the valid launch range [1, kMaxGridDimX]. Every caller
+  // grid-strides over its saturating dimension, so a clamped grid still covers
+  // all work; this also prevents a bogus (negative, or int64-overflowed) count
+  // from wrapping into an out-of-range dimension.
+  const auto to_grid_dim = [](int64_t blocks) {
+    return static_cast<uint32_t>(
+        std::clamp<int64_t>(blocks, int64_t{1}, kMaxGridDimX));
+  };
+
   if (policy == BlockCapPolicy::Never) {
-    return blocks_uncapped;
+    return to_grid_dim(blocks_uncapped);
   }
 
-  const auto max_blocks = static_cast<uint32_t>(
+  const auto max_blocks = static_cast<int64_t>(
       MAX_THREAD_BLOCKS_FACTOR *
       at::cuda::getDeviceProperties(stream.device_index())
           ->multiProcessorCount);
 
   if (policy == BlockCapPolicy::Always) {
-    return std::min<uint32_t>(blocks_uncapped, max_blocks);
+    return to_grid_dim(std::min(blocks_uncapped, max_blocks));
   }
 
   // policy == OverflowOnly
 #ifdef USE_ROCM
-  const auto threads_total = static_cast<uint64_t>(blocks_uncapped) *
-      static_cast<uint64_t>(threads_per_block);
-  if (threads_total > std::numeric_limits<uint32_t>::max()) {
-    return std::min<uint32_t>(blocks_uncapped, max_blocks);
+  // Overflow-safe form of `blocks_uncapped * threads_per_block >
+  // kMaxThreadsPerLaunch` (the product can exceed int64 for large grids).
+  if (threads_per_block > 0 &&
+      blocks_uncapped > kMaxThreadsPerLaunch / threads_per_block) {
+    return to_grid_dim(std::min(blocks_uncapped, max_blocks));
   }
 #endif
-  return blocks_uncapped;
+  return to_grid_dim(blocks_uncapped);
 }
 
 /// Sugar over `cap_grid_dim_x` for the common case where the block-count

--- a/fbgemm_gpu/test/utils/cap_grid_dim_x_test.cu
+++ b/fbgemm_gpu/test/utils/cap_grid_dim_x_test.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAStream.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
+
+namespace fbgemm_gpu::utils::cuda {
+
+// The grid x-dimension launch limit is 2^31 - 1 on both CUDA and HIP.
+static_assert(kMaxGridDimX == 2147483647, "grid.x max must be 2^31 - 1");
+
+// BlockCapPolicy::Never exercises the final clamp in isolation, without
+// touching device properties (#SMs) or the ROCm overflow threshold, so these
+// assertions hold identically on CUDA and ROCm.
+
+TEST(CapGridDimXTest, ClampsOutOfRangeCountsToGridXMax) {
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  // Just past the grid.x limit (2^31) is clamped down instead of passing
+  // through as an invalid dimension.
+  EXPECT_EQ(
+      cap_grid_dim_x(
+          int64_t{1} << 31,
+          /*threads_per_block=*/1024,
+          stream,
+          BlockCapPolicy::Never),
+      static_cast<uint32_t>(kMaxGridDimX));
+
+  // uint32_t max (2^32 - 1): the exact value the launcher rejected before the
+  // fix ("grid.x value 4294967295 is not within the range (0, 2147483647]").
+  EXPECT_EQ(
+      cap_grid_dim_x(
+          std::numeric_limits<uint32_t>::max(),
+          1024,
+          stream,
+          BlockCapPolicy::Never),
+      static_cast<uint32_t>(kMaxGridDimX));
+
+  // An arbitrarily large 64-bit count is still clamped into range (guards the
+  // int64-overflow path that produced the wrapped dimension).
+  EXPECT_EQ(
+      cap_grid_dim_x(
+          std::numeric_limits<int64_t>::max(),
+          1024,
+          stream,
+          BlockCapPolicy::Never),
+      static_cast<uint32_t>(kMaxGridDimX));
+}
+
+TEST(CapGridDimXTest, PassesThroughValidCounts) {
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  // Exactly at the limit is valid and returned unchanged.
+  EXPECT_EQ(
+      cap_grid_dim_x(kMaxGridDimX, 1024, stream, BlockCapPolicy::Never),
+      static_cast<uint32_t>(kMaxGridDimX));
+
+  // A normal small count is returned as-is.
+  EXPECT_EQ(
+      cap_grid_dim_x(1234, 1024, stream, BlockCapPolicy::Never),
+      uint32_t{1234});
+}
+
+TEST(CapGridDimXTest, FloorsNonPositiveCountsToOne) {
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  // grid.x must be >= 1; a zero or negative (e.g. int-overflowed) count is
+  // floored to 1 rather than wrapping to a huge value via the uint32_t cast.
+  EXPECT_EQ(
+      cap_grid_dim_x(0, 1024, stream, BlockCapPolicy::Never), uint32_t{1});
+  EXPECT_EQ(
+      cap_grid_dim_x(-1, 1024, stream, BlockCapPolicy::Never), uint32_t{1});
+}
+
+} // namespace fbgemm_gpu::utils::cuda


### PR DESCRIPTION
Summary:
Part of the Tier-2 ROCm grid-overflow fix stack. Split out of D105204171 so the shared-helper fix is reviewable on its own.

Problem
`cap_grid_dim_x` clamped the returned grid-x dimension to `uint32_t` max (2^32 - 1), but the CUDA/HIP grid x-dimension is limited to 2^31 - 1. A block count at or above 2^31 (or a negative / int64-overflowed count) therefore produced an out-of-range `grid.x` (observed: 4294967295), which the kernel launcher rejects at runtime:

  grid.x value 4294967295 is not within the range (0, 2147483647]
  (checkGridSizesInRange, fbgemm_gpu/utils/kernel_launcher.cuh)

This surfaced as a ROCm crash in host_device_coallesced_projection_test via reorder_batched_ad_lengths_gpu, which calls this shared helper.

Change
- Split the two distinct limits into namespace-scope constants:
  - `kMaxGridDimX = 2^31 - 1`  (grid x-dimension bound)
  - `kMaxThreadsPerLaunch = 2^32 - 1`  (HIP threads-per-launch threshold)
- Route every return path through `to_grid_dim()`, which clamps into the valid launch range [1, kMaxGridDimX]. Grid-stride callers still cover all work, so clamping is correctness-preserving; this also stops a bogus (negative / overflowed) count from wrapping into an out-of-range dimension.
- Make the ROCm `OverflowOnly` threshold check overflow-safe (division form instead of `blocks * threads_per_block`, which could overflow int64).
- Add a `cap_grid_dim_x` unit test (the helper previously had none).

Reviewed By: henrylhtsang

Differential Revision: D105204171


