### PR TITLE
[ROCm] gate warpReduceAllSum DPP path to gfx942/gfx90a/gfx950

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_prelude.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_prelude.cuh
@@ -162,11 +162,22 @@ DEVICE_INLINE uint32_t ballot_sync(
 }
 
 /// Sums a register value across all warp threads
+//
+// The rocm::wave_reduce DPP path is only correct on the CDNA archs whose
+// hand-tuned assembly / row_bcast DPP controls it relies on (gfx942, gfx90a,
+// gfx950); on other archs dpp_reduction compiles to a no-op and wave_reduce
+// would return an un-reduced lane value. RDNA (wave 32) also lacks the
+// row_bcast DPP controls. Everywhere except those CDNA archs, use the portable
+// shfl_xor butterfly, which is correct for any ReduceWidth and arch (and is the
+// CUDA path). __shfl_xor on ROCm adjusts internally for the device warp size.
+// The arch macros are device-pass-only, so per-arch device code in a multi-arch
+// fat binary selects the right path automatically.
 template <typename T, int ReduceWidth = kWarpSize>
 DEVICE_INLINE T warpReduceAllSum(
     T val,
     unsigned shfl_sync_mask = static_cast<unsigned>(kFullWarpMask)) {
-#ifdef USE_ROCM
+#if defined(USE_ROCM) && \
+    (defined(__gfx942__) || defined(__gfx90a__) || defined(__gfx950__))
   return rocm::wave_reduce<
       rocm::reduce_op::sum, // Sum reduction
       T, // Data type


### PR DESCRIPTION
On ROCm, `warpReduceAllSum` dispatched unconditionally to `rocm::wave_reduce`, whose inner `dpp_reduction` is compiled only when one of `__gfx942__`, `__gfx90a__`, or `__gfx950__` is defined and is a no-op on every other arch. On gfx1100 (and any gfx9 not in that list, e.g. gfx908) `wave_reduce` therefore returned `readlane(warpSize-1)` of un-reduced data instead of the warp sum, silently corrupting every `warpReduceAllSum` caller (notably the `grad_indice_weights` reduction in the TBE backward).

The CDNA row_bcast DPP controls the fast path relies on cannot be reused on RDNA, so restrict the `rocm::wave_reduce` path to exactly the archs where `dpp_reduction` is implemented (gfx942/gfx90a/gfx950) and fall back to the portable `shfl_xor` butterfly everywhere else. That fallback is correct for any ReduceWidth and warp size and is the same path CUDA already uses; `__shfl_xor` on ROCm adjusts internally for the device warp size. The arch macros are device-pass-only, so per-arch device code in a multi-arch fat binary selects the right path automatically. The gate here must stay in sync with the `dpp_reduction` gate it mirrors.

This is the first in a chain splitting pytorch/FBGEMM#5804 into independently reviewable pieces.

Authored with assistance from Claude (Anthropic).
