### PR TITLE
Fix HIP grid overflow in jagged_softmax forward/backward

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_backward.cu
@@ -106,15 +106,18 @@ Tensor jagged_softmax_backward_cuda(
     constexpr int THREADS_PER_BLOCK = 128;
     // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
     // which silently wraps). jagged_softmax_backward_kernel grid-strides over
-    // `d` (`for (uint32_t d = blockIdx.x; d < D; d += gridDim.x)`), so capping
-    // is correctness-preserving. y is already clamped to kMaxBlockYDim;
-    // kernel additionally grid-strides over `b`.
+    // both `d` (blockIdx.x) and `b` (blockIdx.y), so capping grid.x is
+    // correctness-preserving. The 2^32 limit is on the full product
+    // grid.x * grid.y * block, so the overflow threshold must fold in grid.y
+    // (not just the per-block thread count); otherwise a large B * D still
+    // overflows (see test_jagged_softmax_backward_large_grid).
     // See: https://github.com/ROCm/hip/issues/2253
+    const uint32_t blocks_y = std::min((int32_t)B, (int32_t)kMaxBlockYDim);
     const auto blocks_x = utils::cuda::cap_grid_dim_x(
         static_cast<uint32_t>(D),
-        THREADS_PER_BLOCK,
+        static_cast<int64_t>(THREADS_PER_BLOCK) * blocks_y,
         at::cuda::getCurrentCUDAStream());
-    const dim3 grid(blocks_x, std::min((int32_t)B, (int32_t)kMaxBlockYDim), 1);
+    const dim3 grid(blocks_x, blocks_y, 1);
 
     AT_DISPATCH_INDEX_TYPES(
         offsets.scalar_type(), "jagged_softmax_backward_kernel_1", [&] {

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_forward.cu
@@ -128,16 +128,19 @@ Tensor jagged_softmax_forward_cuda(
   if (B > 0 && D > 0) {
     constexpr int THREADS_PER_BLOCK = 128;
     // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
-    // which silently wraps). jagged_softmax_kernel grid-strides over `d`
-    // (`for (uint32_t d = blockIdx.x; d < D; d += gridDim.x)`), so capping
-    // is correctness-preserving. y is already clamped to kMaxBlockYDim;
-    // kernel additionally grid-strides over `b`.
+    // which silently wraps). jagged_softmax_kernel grid-strides over both `d`
+    // (blockIdx.x) and `b` (blockIdx.y), so capping grid.x is
+    // correctness-preserving. The 2^32 limit is on the full product
+    // grid.x * grid.y * block, so the overflow threshold must fold in grid.y
+    // (not just the per-block thread count); otherwise a large B * D still
+    // overflows (see test_jagged_softmax_forward_large_grid).
     // See: https://github.com/ROCm/hip/issues/2253
+    const uint32_t blocks_y = std::min((int32_t)B, (int32_t)kMaxBlockYDim);
     const auto blocks_x = utils::cuda::cap_grid_dim_x(
         static_cast<uint32_t>(D),
-        THREADS_PER_BLOCK,
+        static_cast<int64_t>(THREADS_PER_BLOCK) * blocks_y,
         at::cuda::getCurrentCUDAStream());
-    const dim3 grid(blocks_x, std::min((int32_t)B, (int32_t)kMaxBlockYDim), 1);
+    const dim3 grid(blocks_x, blocks_y, 1);
 
     AT_DISPATCH_INDEX_TYPES(
         offsets.scalar_type(), "jagged_softmax_kernel_1", [&] {


### PR DESCRIPTION
Summary:
The ROCm CI (gfx942 / MI300, ROCm 7.1) fails test_jagged_softmax_forward_large_grid
and test_jagged_softmax_backward_large_grid with:

  RuntimeError: [jagged_softmax_forward.hip(162)] [jagged_softmax_kernel]
  [grid dim 20000 x 2047 x 1] [block dim 128 x 1 x 1]: Total number of threads
  5240320000 is greater than the HIP limit of 2^32

HIP enforces a hard 2^32 total-threads-per-launch limit (grid.x * grid.y * grid.z
* block), unlike CUDA which silently wraps. Both launchers already cap grid.x via
cap_grid_dim_x(), but they passed only THREADS_PER_BLOCK (128) as the per-x
thread count, so the overflow check was grid.x * 128 and ignored grid.y
(= min(B, kMaxBlockYDim), up to 2047). For large B * D the real product
grid.x * grid.y * 128 still exceeds 2^32 and HIP rejects the launch.

Fix: compute grid.y first and fold it into the cap threshold, i.e. pass
THREADS_PER_BLOCK * blocks_y as the per-x thread count to cap_grid_dim_x(). The
kernels grid-stride over both d (blockIdx.x) and b (blockIdx.y), so clamping
grid.x remains correctness-preserving. No change on CUDA (cap is ROCm-only,
OverflowOnly policy).

Differential Revision: D112174650


