### PR TITLE
Simplify redundant grid-cap clamp in embedding_inplace_update

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
@@ -25,6 +25,15 @@ namespace fbgemm_gpu::utils::cuda {
 /// kernels: `max_blocks = MAX_THREAD_BLOCKS_FACTOR * #SMs`.
 constexpr int32_t MAX_THREAD_BLOCKS_FACTOR = 64;
 
+/// The grid x-dimension is limited to 2^31 - 1 on both CUDA and HIP; a launch
+/// with `gridDim.x` above this is rejected by the driver.
+constexpr int64_t kMaxGridDimX = std::numeric_limits<int32_t>::max();
+
+/// HIP additionally caps the *total* threads per launch at 2^32 (CUDA silently
+/// wraps). Used only as the `OverflowOnly` threshold, and is distinct from the
+/// grid-x dimension limit above. See: https://github.com/ROCm/hip/issues/2253
+constexpr int64_t kMaxThreadsPerLaunch = std::numeric_limits<uint32_t>::max();
+
 /// Selects how `cap_grid_dim_x{,_from_workload}` clamps the requested grid.
 ///
 /// - `Always`: cap on both CUDA and ROCm at `MAX_THREAD_BLOCKS_FACTOR * #SMs`.
@@ -53,7 +62,12 @@ enum class BlockCapPolicy { Always, OverflowOnly, Never };
 /// - HIP 2^32 thread-per-launch limit: https://github.com/ROCm/hip/issues/2253
 /// - Pre-existing unconditional-cap pattern: D75543767, D65009966
 ///
-/// @param blocks_uncapped     Pre-computed unclamped grid-x dimension.
+/// @param blocks_uncapped     Pre-computed unclamped grid-x dimension. Taken
+///                            as 64-bit so callers whose uncapped block count
+///                            can exceed `uint32_t` (the exact overflow case
+///                            this cap guards against) do not have to narrow it
+///                            first; the returned dimension is always clamped
+///                            into the valid grid-x range `[1, 2^31 - 1]`.
 /// @param threads_per_block   Full per-block thread count
 ///                            (`block.x * block.y * block.z`), used only by
 ///                            the `OverflowOnly` threshold check.
@@ -62,32 +76,42 @@ enum class BlockCapPolicy { Always, OverflowOnly, Never };
 ///                            `OverflowOnly`.
 /// @return Grid-x dimension to pass to the kernel launch.
 inline uint32_t cap_grid_dim_x(
-    uint32_t blocks_uncapped,
+    int64_t blocks_uncapped,
     [[maybe_unused]] int64_t threads_per_block,
     const c10::cuda::CUDAStream& stream,
     BlockCapPolicy policy = BlockCapPolicy::OverflowOnly) {
+  // Clamp into the valid launch range [1, kMaxGridDimX]. Every caller
+  // grid-strides over its saturating dimension, so a clamped grid still covers
+  // all work; this also prevents a bogus (negative, or int64-overflowed) count
+  // from wrapping into an out-of-range dimension.
+  const auto to_grid_dim = [](int64_t blocks) {
+    return static_cast<uint32_t>(
+        std::clamp<int64_t>(blocks, int64_t{1}, kMaxGridDimX));
+  };
+
   if (policy == BlockCapPolicy::Never) {
-    return blocks_uncapped;
+    return to_grid_dim(blocks_uncapped);
   }
 
-  const auto max_blocks = static_cast<uint32_t>(
+  const auto max_blocks = static_cast<int64_t>(
       MAX_THREAD_BLOCKS_FACTOR *
       at::cuda::getDeviceProperties(stream.device_index())
           ->multiProcessorCount);
 
   if (policy == BlockCapPolicy::Always) {
-    return std::min<uint32_t>(blocks_uncapped, max_blocks);
+    return to_grid_dim(std::min(blocks_uncapped, max_blocks));
   }
 
   // policy == OverflowOnly
 #ifdef USE_ROCM
-  const auto threads_total = static_cast<uint64_t>(blocks_uncapped) *
-      static_cast<uint64_t>(threads_per_block);
-  if (threads_total > std::numeric_limits<uint32_t>::max()) {
-    return std::min<uint32_t>(blocks_uncapped, max_blocks);
+  // Overflow-safe form of `blocks_uncapped * threads_per_block >
+  // kMaxThreadsPerLaunch` (the product can exceed int64 for large grids).
+  if (threads_per_block > 0 &&
+      blocks_uncapped > kMaxThreadsPerLaunch / threads_per_block) {
+    return to_grid_dim(std::min(blocks_uncapped, max_blocks));
   }
 #endif
-  return blocks_uncapped;
+  return to_grid_dim(blocks_uncapped);
 }
 
 /// Sugar over `cap_grid_dim_x` for the common case where the block-count

--- a/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update.cu
+++ b/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update.cu
@@ -252,20 +252,12 @@ void embedding_inplace_update_cuda(
       update_row_idx.scalar_type(), "embedding_inplace_update_kernel_1", [&] {
         // HIP enforces a hard limit of 2^32 total threads per launch.
         // See: https://github.com/ROCm/hip/issues/2253
-        // Compute the uncapped block count in 64-bit and clamp to uint32_t
-        // max before handing it to cap_grid_dim_x. A bare
-        // static_cast<uint32_t> would truncate for N >= ~2^32 * warpsPerBlock
-        // and could wrap to 0, which would make the cap's overflow check
-        // (blocks * threads) pass and silently launch no work. Clamping keeps
-        // the value above the cap threshold so the ROCm cap engages; the
+        // cap_grid_dim_x takes the 64-bit uncapped block count and clamps it
+        // into grid-x range, engaging the ROCm overflow cap when needed; the
         // grid-stride loop then still covers all N rows.
         const int64_t blocks_uncapped = nbit::div_round_up(N, warpsPerBlock);
         const auto blocks = utils::cuda::cap_grid_dim_x(
-            static_cast<uint32_t>(std::min<int64_t>(
-                blocks_uncapped,
-                static_cast<int64_t>(std::numeric_limits<uint32_t>::max()))),
-            kMaxThreads,
-            at::cuda::getCurrentCUDAStream());
+            blocks_uncapped, kMaxThreads, at::cuda::getCurrentCUDAStream());
         FBGEMM_LAUNCH_KERNEL(
             (embedding_inplace_update_kernel_1<index_t>),
             blocks, // number of blocks needed
@@ -336,16 +328,11 @@ void embedding_inplace_update_single_placement_cuda(
       update_row_idx.scalar_type(), "embedding_inplace_update_kernel_2", [&] {
         // HIP enforces a hard limit of 2^32 total threads per launch.
         // See: https://github.com/ROCm/hip/issues/2253
-        // See embedding_inplace_update_kernel_1 above: clamp the uncapped
-        // block count in 64-bit so a huge N cannot truncate/wrap the
-        // uint32_t and defeat the ROCm overflow cap.
+        // See embedding_inplace_update_kernel_1 above: cap_grid_dim_x takes the
+        // 64-bit uncapped block count and clamps it into grid-x range.
         const int64_t blocks_uncapped = nbit::div_round_up(N, warpsPerBlock);
         const auto blocks = utils::cuda::cap_grid_dim_x(
-            static_cast<uint32_t>(std::min<int64_t>(
-                blocks_uncapped,
-                static_cast<int64_t>(std::numeric_limits<uint32_t>::max()))),
-            kMaxThreads,
-            at::cuda::getCurrentCUDAStream());
+            blocks_uncapped, kMaxThreads, at::cuda::getCurrentCUDAStream());
         FBGEMM_LAUNCH_KERNEL(
             (embedding_inplace_update_kernel_2<index_t>),
             blocks, // number of blocks needed

--- a/fbgemm_gpu/test/utils/cap_grid_dim_x_test.cu
+++ b/fbgemm_gpu/test/utils/cap_grid_dim_x_test.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAStream.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
+
+namespace fbgemm_gpu::utils::cuda {
+
+// The grid x-dimension launch limit is 2^31 - 1 on both CUDA and HIP.
+static_assert(kMaxGridDimX == 2147483647, "grid.x max must be 2^31 - 1");
+
+// BlockCapPolicy::Never exercises the final clamp in isolation, without
+// touching device properties (#SMs) or the ROCm overflow threshold, so these
+// assertions hold identically on CUDA and ROCm.
+
+TEST(CapGridDimXTest, ClampsOutOfRangeCountsToGridXMax) {
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  // Just past the grid.x limit (2^31) is clamped down instead of passing
+  // through as an invalid dimension.
+  EXPECT_EQ(
+      cap_grid_dim_x(
+          int64_t{1} << 31,
+          /*threads_per_block=*/1024,
+          stream,
+          BlockCapPolicy::Never),
+      static_cast<uint32_t>(kMaxGridDimX));
+
+  // uint32_t max (2^32 - 1): the exact value the launcher rejected before the
+  // fix ("grid.x value 4294967295 is not within the range (0, 2147483647]").
+  EXPECT_EQ(
+      cap_grid_dim_x(
+          std::numeric_limits<uint32_t>::max(),
+          1024,
+          stream,
+          BlockCapPolicy::Never),
+      static_cast<uint32_t>(kMaxGridDimX));
+
+  // An arbitrarily large 64-bit count is still clamped into range (guards the
+  // int64-overflow path that produced the wrapped dimension).
+  EXPECT_EQ(
+      cap_grid_dim_x(
+          std::numeric_limits<int64_t>::max(),
+          1024,
+          stream,
+          BlockCapPolicy::Never),
+      static_cast<uint32_t>(kMaxGridDimX));
+}
+
+TEST(CapGridDimXTest, PassesThroughValidCounts) {
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  // Exactly at the limit is valid and returned unchanged.
+  EXPECT_EQ(
+      cap_grid_dim_x(kMaxGridDimX, 1024, stream, BlockCapPolicy::Never),
+      static_cast<uint32_t>(kMaxGridDimX));
+
+  // A normal small count is returned as-is.
+  EXPECT_EQ(
+      cap_grid_dim_x(1234, 1024, stream, BlockCapPolicy::Never),
+      uint32_t{1234});
+}
+
+TEST(CapGridDimXTest, FloorsNonPositiveCountsToOne) {
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  // grid.x must be >= 1; a zero or negative (e.g. int-overflowed) count is
+  // floored to 1 rather than wrapping to a huge value via the uint32_t cast.
+  EXPECT_EQ(
+      cap_grid_dim_x(0, 1024, stream, BlockCapPolicy::Never), uint32_t{1});
+  EXPECT_EQ(
+      cap_grid_dim_x(-1, 1024, stream, BlockCapPolicy::Never), uint32_t{1});
+}
+
+} // namespace fbgemm_gpu::utils::cuda


### PR DESCRIPTION
Summary:
cap_grid_dim_x now takes a 64-bit blocks_uncapped and clamps it into grid-x
range internally (widened helper in D105204171). The per-caller
std::min(blocks_uncapped, UINT32_MAX) clamp in embedding_inplace_update_kernel_1
and _kernel_2 is therefore redundant, so pass the int64_t block count directly.

No behavior change: the helper performs the identical clamp/overflow-cap, and
both kernels already grid-stride over N.

Depends on D105204171 (widened cap_grid_dim_x).

Reviewed By: henrylhtsang

Differential Revision: D112018989


