### PR TITLE
Add grid-stride + ROCm cap to tbe_input_combine_with_length_kernel

### DIFF
--- a/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update.cu
+++ b/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update.cu
@@ -252,20 +252,12 @@ void embedding_inplace_update_cuda(
       update_row_idx.scalar_type(), "embedding_inplace_update_kernel_1", [&] {
         // HIP enforces a hard limit of 2^32 total threads per launch.
         // See: https://github.com/ROCm/hip/issues/2253
-        // Compute the uncapped block count in 64-bit and clamp to uint32_t
-        // max before handing it to cap_grid_dim_x. A bare
-        // static_cast<uint32_t> would truncate for N >= ~2^32 * warpsPerBlock
-        // and could wrap to 0, which would make the cap's overflow check
-        // (blocks * threads) pass and silently launch no work. Clamping keeps
-        // the value above the cap threshold so the ROCm cap engages; the
+        // cap_grid_dim_x takes the 64-bit uncapped block count and clamps it
+        // into grid-x range, engaging the ROCm overflow cap when needed; the
         // grid-stride loop then still covers all N rows.
         const int64_t blocks_uncapped = nbit::div_round_up(N, warpsPerBlock);
         const auto blocks = utils::cuda::cap_grid_dim_x(
-            static_cast<uint32_t>(std::min<int64_t>(
-                blocks_uncapped,
-                static_cast<int64_t>(std::numeric_limits<uint32_t>::max()))),
-            kMaxThreads,
-            at::cuda::getCurrentCUDAStream());
+            blocks_uncapped, kMaxThreads, at::cuda::getCurrentCUDAStream());
         FBGEMM_LAUNCH_KERNEL(
             (embedding_inplace_update_kernel_1<index_t>),
             blocks, // number of blocks needed
@@ -336,16 +328,11 @@ void embedding_inplace_update_single_placement_cuda(
       update_row_idx.scalar_type(), "embedding_inplace_update_kernel_2", [&] {
         // HIP enforces a hard limit of 2^32 total threads per launch.
         // See: https://github.com/ROCm/hip/issues/2253
-        // See embedding_inplace_update_kernel_1 above: clamp the uncapped
-        // block count in 64-bit so a huge N cannot truncate/wrap the
-        // uint32_t and defeat the ROCm overflow cap.
+        // See embedding_inplace_update_kernel_1 above: cap_grid_dim_x takes the
+        // 64-bit uncapped block count and clamps it into grid-x range.
         const int64_t blocks_uncapped = nbit::div_round_up(N, warpsPerBlock);
         const auto blocks = utils::cuda::cap_grid_dim_x(
-            static_cast<uint32_t>(std::min<int64_t>(
-                blocks_uncapped,
-                static_cast<int64_t>(std::numeric_limits<uint32_t>::max()))),
-            kMaxThreads,
-            at::cuda::getCurrentCUDAStream());
+            blocks_uncapped, kMaxThreads, at::cuda::getCurrentCUDAStream());
         FBGEMM_LAUNCH_KERNEL(
             (embedding_inplace_update_kernel_2<index_t>),
             blocks, // number of blocks needed

--- a/fbgemm_gpu/src/input_combine_ops/input_combine.cu
+++ b/fbgemm_gpu/src/input_combine_ops/input_combine.cu
@@ -9,6 +9,7 @@
 #include <c10/cuda/CUDAGuard.h>
 #include "fbgemm_gpu/input_combine.h"
 #include "fbgemm_gpu/utils/cuda_prelude.cuh"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 #include "fbgemm_gpu/utils/fixed_divisor.cuh"
 #include "fbgemm_gpu/utils/kernel_launcher.cuh"
 
@@ -49,59 +50,66 @@ __launch_bounds__(kMaxThreads) void tbe_input_combine_with_length_kernel(
     const uint64_t* const __restrict__ indices_offsets,
     const uint64_t* const __restrict__ lengths_offsets,
     const uint64_t num_lists,
-    const FixedDivisor fd_num_warps_per_list) {
-  const auto global_warp_id = blockIdx.x * blockDim.y + threadIdx.y;
-  uint32_t list_id;
-  uint32_t warp_id;
-  fd_num_warps_per_list.DivMod(
-      global_warp_id,
-      reinterpret_cast<int32_t*>(&list_id),
-      reinterpret_cast<int32_t*>(&warp_id));
+    const FixedDivisor fd_num_warps_per_list,
+    const uint64_t total_warp_work) {
+  // Grid-stride over (list_id, warp_id) pairs so a capped grid (used on
+  // ROCm to avoid the 2^32 launch-side limit) still covers every pair.
+  for (uint64_t global_warp_id = blockIdx.x * blockDim.y + threadIdx.y;
+       global_warp_id < total_warp_work;
+       global_warp_id += static_cast<uint64_t>(gridDim.x) * blockDim.y) {
+    uint32_t list_id;
+    uint32_t warp_id;
+    fd_num_warps_per_list.DivMod(
+        global_warp_id,
+        reinterpret_cast<int32_t*>(&list_id),
+        reinterpret_cast<int32_t*>(&warp_id));
 
-  if (list_id >= num_lists) {
-    return;
-  }
+    if (list_id >= num_lists) {
+      continue;
+    }
 
-  // IS_LONG_NUM_BITS is power of 2 (default = 32); div and mod should be cheap
-  const uint32_t is_long_idx = list_id / IS_LONG_NUM_BITS;
-  const uint32_t is_long_mask = 1u << (list_id % IS_LONG_NUM_BITS);
-  const uint64_t src_idx = (warp_id * kWarpSize + threadIdx.x) * VEC_WIDTH;
-  const auto indices_start = indices_offsets[list_id];
-  const auto indices_end = indices_offsets[list_id + 1];
-  const auto lengths_start = lengths_offsets[list_id];
-  const auto lengths_end = lengths_offsets[list_id + 1];
+    // IS_LONG_NUM_BITS is power of 2 (default = 32); div and mod should be
+    // cheap
+    const uint32_t is_long_idx = list_id / IS_LONG_NUM_BITS;
+    const uint32_t is_long_mask = 1u << (list_id % IS_LONG_NUM_BITS);
+    const uint64_t src_idx = (warp_id * kWarpSize + threadIdx.x) * VEC_WIDTH;
+    const auto indices_start = indices_offsets[list_id];
+    const auto indices_end = indices_offsets[list_id + 1];
+    const auto lengths_start = lengths_offsets[list_id];
+    const auto lengths_end = lengths_offsets[list_id + 1];
 
-  // Invoke a function based on the indices type
-  ((indices_is_long[is_long_idx] & is_long_mask)
-       ? vec_copy_with_implicit_type_cast<int64_t, int32_t, VEC_WIDTH>
-       : vec_copy_with_implicit_type_cast<
-             int32_t,
-             int32_t,
-             VEC_WIDTH>)(combined_indices,
-                         indices_addrs[list_id],
-                         src_idx,
-                         indices_start + src_idx,
-                         indices_end - indices_start);
+    // Invoke a function based on the indices type
+    ((indices_is_long[is_long_idx] & is_long_mask)
+         ? vec_copy_with_implicit_type_cast<int64_t, int32_t, VEC_WIDTH>
+         : vec_copy_with_implicit_type_cast<
+               int32_t,
+               int32_t,
+               VEC_WIDTH>)(combined_indices,
+                           indices_addrs[list_id],
+                           src_idx,
+                           indices_start + src_idx,
+                           indices_end - indices_start);
 
-  // Invoke a function based on the lengths type
-  ((lengths_is_long[is_long_idx] & is_long_mask)
-       ? vec_copy_with_implicit_type_cast<int64_t, int32_t, VEC_WIDTH>
-       : vec_copy_with_implicit_type_cast<
-             int32_t,
-             int32_t,
-             VEC_WIDTH>)(combined_lengths,
-                         lengths_addrs[list_id],
-                         src_idx,
-                         lengths_start + src_idx,
-                         lengths_end - lengths_start);
+    // Invoke a function based on the lengths type
+    ((lengths_is_long[is_long_idx] & is_long_mask)
+         ? vec_copy_with_implicit_type_cast<int64_t, int32_t, VEC_WIDTH>
+         : vec_copy_with_implicit_type_cast<
+               int32_t,
+               int32_t,
+               VEC_WIDTH>)(combined_lengths,
+                           lengths_addrs[list_id],
+                           src_idx,
+                           lengths_start + src_idx,
+                           lengths_end - lengths_start);
 
-  if (per_sample_weights_addrs && per_sample_weights_addrs[list_id] > 0) {
-    vec_copy_with_implicit_type_cast<float, float, VEC_WIDTH>(
-        combined_weights,
-        per_sample_weights_addrs[list_id],
-        src_idx,
-        indices_start + src_idx,
-        indices_end - indices_start);
+    if (per_sample_weights_addrs && per_sample_weights_addrs[list_id] > 0) {
+      vec_copy_with_implicit_type_cast<float, float, VEC_WIDTH>(
+          combined_weights,
+          per_sample_weights_addrs[list_id],
+          src_idx,
+          indices_start + src_idx,
+          indices_end - indices_start);
+    }
   }
 }
 
@@ -144,8 +152,20 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_with_length_cuda(
   constexpr uint32_t NUM_WARPS_PER_BLOCK = kMaxThreads / kWarpSize;
   const auto num_warps_per_list =
       div_round_up(max_list_size, kWarpSize * VEC_WIDTH);
-  const auto num_blocks =
-      div_round_up(num_warps_per_list * num_lists, NUM_WARPS_PER_BLOCK);
+  const auto total_warp_work = num_warps_per_list * num_lists;
+  // HIP enforces a hard limit of 2^32 total threads per launch.
+  // tbe_input_combine_with_length_kernel grid-strides over warps, so capping
+  // is correctness-preserving.
+  // See: https://github.com/ROCm/hip/issues/2253
+  //
+  // Compute the block count in 64-bit: div_round_up only has 32-bit overloads,
+  // so div_round_up(total_warp_work, ...) would narrow total_warp_work
+  // (uint64_t) before dividing. cap_grid_dim_x takes the 64-bit count and
+  // clamps it into grid-x range.
+  const int64_t num_blocks_uncapped = static_cast<int64_t>(
+      (total_warp_work + NUM_WARPS_PER_BLOCK - 1) / NUM_WARPS_PER_BLOCK);
+  const auto num_blocks = utils::cuda::cap_grid_dim_x(
+      num_blocks_uncapped, kMaxThreads, at::cuda::getCurrentCUDAStream());
 
   FBGEMM_LAUNCH_KERNEL(
       (tbe_input_combine_with_length_kernel<VEC_WIDTH, IS_LONG_NUM_BITS>),
@@ -164,7 +184,8 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_with_length_cuda(
       indices_offsets,
       lengths_offsets,
       num_lists,
-      FixedDivisor(num_warps_per_list));
+      FixedDivisor(num_warps_per_list),
+      total_warp_work);
 
   return {
       std::move(combined_indices),

--- a/fbgemm_gpu/test/combine/input_combine_test.py
+++ b/fbgemm_gpu/test/combine/input_combine_test.py
@@ -415,6 +415,80 @@ class InputCombineTest(unittest.TestCase):
     def test_padding_fused_input_combined_mix_with_length(self) -> None:
         self._run_padding_fused_test_with_length((torch.int64, torch.int32), 64)
 
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    #  `torch.cuda.is_available()` to decorator factory `unittest.skipUnless`.
+    @unittest.skipUnless(torch.cuda.is_available(), "GPU not available")
+    def test_tbe_input_combine_with_length_correctness_large(self) -> None:
+        """
+        Correctness check for the refactored
+        ``tbe_input_combine_with_length_kernel`` (D105204171), which
+        lacked its own test method when landed.
+
+        The production fix wraps the kernel body in a grid-stride loop
+        over ``(list_id, warp_id)`` pairs, adds the ``total_warp_work``
+        parameter, and caps ``grid_x`` on ROCm via ``cap_grid_dim_x``.
+        This test exercises a multi-list, multi-block configuration and
+        compares GPU output against the CPU dispatch, guarding the new
+        kernel signature and the grid-stride index math.
+
+        Note: at this scale the grid is small (a handful of blocks), so
+        the ROCm ``OverflowOnly`` cap does not engage and the grid-stride
+        outer loop executes once. Actually tripping the 2^32-thread cap
+        would require ``num_lists * max_list_size >= ~2^37`` (a multi-GB
+        allocation), which is infeasible in a unit test; the cap/overflow
+        boundary is therefore covered by the host-side clamp logic, not
+        this test.
+        """
+        # Many small lists so total_warp_work is non-trivial but
+        # memory stays modest. Each list contributes one warp of work.
+        num_lists = 256
+        list_len = 64
+        batch_size = 32
+
+        indices_list = [
+            torch.arange(list_len, dtype=torch.int32) for _ in range(num_lists)
+        ]
+        # Equal-length offsets per list.
+        lengths_list = [
+            torch.full(
+                (batch_size,),
+                list_len // batch_size,
+                dtype=torch.int32,
+            )
+            for _ in range(num_lists)
+        ]
+        # Trim the last segment to match list_len.
+        for lengths in lengths_list:
+            lengths[-1] = list_len - (list_len // batch_size) * (batch_size - 1)
+        # Non-empty per-sample weights (numel must match each list's indices)
+        # so the kernel's weights-copy branch is exercised too.
+        per_sample_weights = [
+            torch.ones(list_len, dtype=torch.float) for _ in range(num_lists)
+        ]
+
+        # Reference is the CPU dispatch of the SAME op. Only
+        # ``tbe_input_combine_with_length`` has a CUDA kernel (the one this
+        # diff modified); ``padding_fused_*`` is CPU-only, so the GPU dispatch
+        # must go through the non-fused op.
+        out_cpu = torch.ops.fbgemm.tbe_input_combine_with_length(
+            indices_list,
+            lengths_list,
+            per_sample_weights,
+        )
+
+        # GPU op under test.
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        out_gpu = torch.ops.fbgemm.tbe_input_combine_with_length(
+            [t.to(device) for t in indices_list],
+            [t.to(device) for t in lengths_list],
+            [t.to(device) for t in per_sample_weights],
+        )
+
+        # Compare combined indices, lengths, and per-sample weights.
+        self.assertEqual(len(out_cpu), len(out_gpu))
+        for cpu_t, gpu_t in zip(out_cpu, out_gpu):
+            torch.testing.assert_close(gpu_t.cpu(), cpu_t)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
Part of the Tier-2 ROCm grid-overflow fix stack. Split out of D105204171 (which now carries only the shared cap_grid_dim_x fix + its unit test). Depends on D105204171 for cap_grid_dim_x.

Problem
tbe_input_combine_with_length_kernel slices work by (list_id, warp_id) pairs and early-returns with `if (list_id >= num_lists) return;`. The grid was sized to exactly cover `num_warps_per_list * num_lists` blocks. On ROCm (VEC_WIDTH=32) a sufficiently large workload (num_lists * max_list_size >= ~2^37) exceeds HIP's 2^32 threads-per-launch limit, so the launch is rejected. Additionally, the host block-count math used the 32-bit `div_round_up` overload, which would narrow the uint64 work count before dividing.

Change
- Wrap the kernel body in a grid-stride loop over `global_warp_id`, bounded by the new `total_warp_work` parameter (= num_warps_per_list * num_lists), so a capped grid still covers every (list_id, warp_id) pair. The early-out becomes `continue`.
- Compute the uncapped block count in 64-bit and clamp it via `utils::cuda::cap_grid_dim_x` (the shared helper). No-op on CUDA; on ROCm it caps the grid to stay under the 2^32 launch limit — correctness-preserving because the kernel now grid-strides.
- Add `total_warp_work` to the kernel signature and the launch site.
- Add a correctness test (test_tbe_input_combine_with_length_correctness_large): the refactored kernel had no dedicated test when it originally landed.

Reviewed By: henrylhtsang

Differential Revision: D112174771


