### PR TITLE
Skip jagged_softmax large-grid tests on ROCm (exceed HIP 2^32 launch limit)

### DIFF
--- a/fbgemm_gpu/test/jagged/misc_ops_test.py
+++ b/fbgemm_gpu/test/jagged/misc_ops_test.py
@@ -19,13 +19,20 @@ from .common import additional_decorators, open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import cpu_and_maybe_gpu, gpu_memory_lt_gb, gpu_unavailable, optests
+    from test_utils import (
+        cpu_and_maybe_gpu,
+        gpu_memory_lt_gb,
+        gpu_unavailable,
+        optests,
+        skipIfRocm,
+    )
 else:
     from fbgemm_gpu.test.test_utils import (
         cpu_and_maybe_gpu,
         gpu_memory_lt_gb,
         gpu_unavailable,
         optests,
+        skipIfRocm,
     )
 
 
@@ -238,6 +245,10 @@ class JaggedTensorOpsTest(unittest.TestCase):
 
     @unittest.skipIf(*gpu_unavailable)
     @unittest.skipIf(*gpu_memory_lt_gb(4))
+    @skipIfRocm(
+        "Intentionally-oversized grid exceeds the HIP 2^32 threads-per-launch "
+        "limit (CUDA silently wraps); this large-grid path is CUDA-only."
+    )
     def test_jagged_softmax_forward_large_grid(self) -> None:
         """
         Reproduces the HIP grid-overflow bug in jagged_softmax_kernel
@@ -294,6 +305,10 @@ class JaggedTensorOpsTest(unittest.TestCase):
 
     @unittest.skipIf(*gpu_unavailable)
     @unittest.skipIf(*gpu_memory_lt_gb(4))
+    @skipIfRocm(
+        "Intentionally-oversized grid exceeds the HIP 2^32 threads-per-launch "
+        "limit (CUDA silently wraps); this large-grid path is CUDA-only."
+    )
     def test_jagged_softmax_backward_large_grid(self) -> None:
         """
         Reproduces the HIP grid-overflow bug in


### PR DESCRIPTION
Summary:
test_jagged_softmax_{forward,backward}_large_grid intentionally build an
oversized launch grid (D=20000, B=2047 => grid.x * grid.y * block =
20000 * 2047 * 128 = 5.24B threads) to exercise the large-grid path. On ROCm this
exceeds HIP's hard 2^32 threads-per-launch limit and the launch is rejected
(CUDA silently wraps, so it passes there). This surfaced on gfx942 / ROCm 7.1 in
run 29418021816.

Rather than special-case the kernel launch for this synthetic oversized grid,
skip the two tests on ROCm via skipIfRocm. The large-grid path stays exercised
on CUDA; ROCm coverage of jagged_softmax at normal grid sizes is unaffected.

Differential Revision: D112352791


