### PR TITLE
Add grid-stride loops + ROCm cap to jagged_jagged_bmm_kernel (#6023)

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_jagged_bmm_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_jagged_bmm_forward.cu
@@ -36,8 +36,9 @@ __global__ __launch_bounds__(kMaxThreads) void jagged_jagged_bmm_kernel(
   const auto M = x_values.size(1);
   const auto N = y_values.size(1);
 
-  const auto block_row = blockIdx.y;
-  const auto block_col = blockIdx.x;
+  const auto NUM_BLOCK_COLS = (N + BLOCK_TILE_N - 1) / BLOCK_TILE_N;
+  const auto NUM_BLOCK_ROWS = (M + BLOCK_TILE_M - 1) / BLOCK_TILE_M;
+
   const auto tx = threadIdx.x;
 
   const auto THREADS_X_PER_BLOCK = BLOCK_TILE_N / THREAD_TILE_N;
@@ -46,110 +47,125 @@ __global__ __launch_bounds__(kMaxThreads) void jagged_jagged_bmm_kernel(
   const auto thread_row = tx / THREADS_X_PER_BLOCK;
   const auto thread_col = tx % THREADS_X_PER_BLOCK;
 
-  // Once we remove ROCm<=5.3 support, we should replace uint32_t with auto.
-  // See #1655
-  for (uint32_t b = blockIdx.z; b < B; b += gridDim.z) {
-    const index_t row_start = offsets[b];
-    const index_t row_end = offsets[b + 1];
-    const auto length = min(row_end - row_start, (index_t)max_L);
+  // Grid-stride over (block_col, block_row, b) so a capped grid (used on
+  // ROCm to avoid the 2^32 launch-side limit) still covers every output
+  // tile.
+  for (auto block_col = blockIdx.x; block_col < NUM_BLOCK_COLS;
+       block_col += gridDim.x) {
+    for (auto block_row = blockIdx.y; block_row < NUM_BLOCK_ROWS;
+         block_row += gridDim.y) {
+      // Once we remove ROCm<=5.3 support, we should replace uint32_t with auto.
+      // See #1655
+      for (uint32_t b = blockIdx.z; b < B; b += gridDim.z) {
+        const index_t row_start = offsets[b];
+        const index_t row_end = offsets[b + 1];
+        const auto length = min(row_end - row_start, (index_t)max_L);
 
-    if (length > 0) {
-      __shared__ scalar_t As[BLOCK_TILE_M][BLOCK_TILE_K];
-      __shared__ scalar_t Bs[BLOCK_TILE_K][BLOCK_TILE_N];
+        if (length > 0) {
+          __shared__ scalar_t As[BLOCK_TILE_M][BLOCK_TILE_K];
+          __shared__ scalar_t Bs[BLOCK_TILE_K][BLOCK_TILE_N];
 
-      const auto NUM_K_BLOCKS = (length + BLOCK_TILE_K - 1) / BLOCK_TILE_K;
+          const auto NUM_K_BLOCKS = (length + BLOCK_TILE_K - 1) / BLOCK_TILE_K;
 
-      // The indices that this thread are in the current block tile
-      const auto inner_row_a = tx / BLOCK_TILE_K;
-      const auto inner_col_a = tx % BLOCK_TILE_K;
-      // The number of rows of As that will be loaded per step by a thread block
-      const auto A_TILE_ROW_STRIDE = THREADS_PER_BLOCK / BLOCK_TILE_K;
+          // The indices that this thread are in the current block tile
+          const auto inner_row_a = tx / BLOCK_TILE_K;
+          const auto inner_col_a = tx % BLOCK_TILE_K;
+          // The number of rows of As that will be loaded per step by a thread
+          // block
+          const auto A_TILE_ROW_STRIDE = THREADS_PER_BLOCK / BLOCK_TILE_K;
 
-      const auto inner_row_b = tx / BLOCK_TILE_N;
-      const auto inner_col_b = tx % BLOCK_TILE_N;
-      const auto B_TILE_ROW_STRIDE = THREADS_PER_BLOCK / BLOCK_TILE_N;
+          const auto inner_row_b = tx / BLOCK_TILE_N;
+          const auto inner_col_b = tx % BLOCK_TILE_N;
+          const auto B_TILE_ROW_STRIDE = THREADS_PER_BLOCK / BLOCK_TILE_N;
 
-      // Registers for C
-      scalar_t accum[THREAD_TILE_M][THREAD_TILE_N] = {0};
+          // Registers for C
+          scalar_t accum[THREAD_TILE_M][THREAD_TILE_N] = {0};
 
-      // Registers for As and Bs
-      scalar_t fragment_a[THREAD_TILE_M] = {0};
-      scalar_t fragment_b[THREAD_TILE_N] = {0};
+          // Registers for As and Bs
+          scalar_t fragment_a[THREAD_TILE_M] = {0};
+          scalar_t fragment_b[THREAD_TILE_N] = {0};
 
-      for (auto block = 0; block < NUM_K_BLOCKS; block++) {
-        // Load a block of x_values from global memory to shared memory
-        // apply tiling for threads in a block
+          for (auto block = 0; block < NUM_K_BLOCKS; block++) {
+            // Load a block of x_values from global memory to shared memory
+            // apply tiling for threads in a block
 #pragma unroll
-        for (auto offset = 0; offset < BLOCK_TILE_M;
-             offset += A_TILE_ROW_STRIDE) {
-          auto x_row_offset = block_row * BLOCK_TILE_M + inner_row_a + offset;
-          auto x_col_offset = block * BLOCK_TILE_K + inner_col_a;
-          if ((x_row_offset < M) && (x_col_offset < length)) {
-            As[inner_row_a + offset][inner_col_a] =
-                x_values[row_start + x_col_offset][x_row_offset];
-          } else {
-            As[inner_row_a + offset][inner_col_a] = 0;
-          }
-        }
+            for (auto offset = 0; offset < BLOCK_TILE_M;
+                 offset += A_TILE_ROW_STRIDE) {
+              auto x_row_offset =
+                  block_row * BLOCK_TILE_M + inner_row_a + offset;
+              auto x_col_offset = block * BLOCK_TILE_K + inner_col_a;
+              if ((x_row_offset < M) && (x_col_offset < length)) {
+                As[inner_row_a + offset][inner_col_a] =
+                    x_values[row_start + x_col_offset][x_row_offset];
+              } else {
+                As[inner_row_a + offset][inner_col_a] = 0;
+              }
+            }
 
-        // Load a block of y from global memory to shared memory
-        // apply tiling for threads in a block
+            // Load a block of y from global memory to shared memory
+            // apply tiling for threads in a block
 #pragma unroll
-        for (auto offset = 0; offset < BLOCK_TILE_K;
-             offset += B_TILE_ROW_STRIDE) {
-          auto y_row_offset = block * BLOCK_TILE_K + inner_row_b + offset;
-          auto y_col_offset = block_col * BLOCK_TILE_N + inner_col_b;
-          if ((y_row_offset < length) && (y_col_offset < N)) {
-            Bs[inner_row_b + offset][inner_col_b] =
-                y_values[row_start + y_row_offset][y_col_offset];
-          } else {
-            Bs[inner_row_b + offset][inner_col_b] = 0;
-          }
-        }
+            for (auto offset = 0; offset < BLOCK_TILE_K;
+                 offset += B_TILE_ROW_STRIDE) {
+              auto y_row_offset = block * BLOCK_TILE_K + inner_row_b + offset;
+              auto y_col_offset = block_col * BLOCK_TILE_N + inner_col_b;
+              if ((y_row_offset < length) && (y_col_offset < N)) {
+                Bs[inner_row_b + offset][inner_col_b] =
+                    y_values[row_start + y_row_offset][y_col_offset];
+              } else {
+                Bs[inner_row_b + offset][inner_col_b] = 0;
+              }
+            }
 
-        // Wait for the data in shared memoty to be available
-        __syncthreads();
+            // Wait for the data in shared memoty to be available
+            __syncthreads();
 
-        // Calculate the results per thread
+            // Calculate the results per thread
 #pragma unroll
-        for (auto k = 0; k < BLOCK_TILE_K; k++) {
-          // Load values from shared memory to registers for x_values
-          for (auto row = 0; row < THREAD_TILE_M; row++) {
-            fragment_a[row] = As[thread_row * THREAD_TILE_M + row][k];
-          }
+            for (auto k = 0; k < BLOCK_TILE_K; k++) {
+              // Load values from shared memory to registers for x_values
+              for (auto row = 0; row < THREAD_TILE_M; row++) {
+                fragment_a[row] = As[thread_row * THREAD_TILE_M + row][k];
+              }
 
-          // Load values from shared memory to registers for y
+              // Load values from shared memory to registers for y
 #pragma unroll
-          for (auto col = 0; col < THREAD_TILE_N; col++) {
-            fragment_b[col] = Bs[k][thread_col * THREAD_TILE_N + col];
+              for (auto col = 0; col < THREAD_TILE_N; col++) {
+                fragment_b[col] = Bs[k][thread_col * THREAD_TILE_N + col];
+              }
+
+              // Each thread calcualtes THREAD_TILE_M * THREAD_TILE_N elements
+#pragma unroll
+              for (auto row = 0; row < THREAD_TILE_M; row++) {
+#pragma unroll
+                for (auto col = 0; col < THREAD_TILE_N; col++) {
+                  accum[row][col] += fragment_a[row] * fragment_b[col];
+                }
+              }
+            }
+
+            // Wait for the current tile to finish before going to the next one
+            __syncthreads();
           }
 
-          // Each thread calcualtes THREAD_TILE_M * THREAD_TILE_N elements
+          // Write the result to the output
 #pragma unroll
           for (auto row = 0; row < THREAD_TILE_M; row++) {
 #pragma unroll
             for (auto col = 0; col < THREAD_TILE_N; col++) {
-              accum[row][col] += fragment_a[row] * fragment_b[col];
+              auto out_row_offset =
+                  block_row * BLOCK_TILE_M + thread_row * THREAD_TILE_M + row;
+              auto out_col_offset =
+                  block_col * BLOCK_TILE_N + thread_col * THREAD_TILE_N + col;
+              if ((out_row_offset < M) && (out_col_offset < N)) {
+                output[b][out_row_offset][out_col_offset] = accum[row][col];
+              }
             }
           }
-        }
-
-        // Wait for the current tile to finish before going to the next one
-        __syncthreads();
-      }
-
-      // Write the result to the output
-#pragma unroll
-      for (auto row = 0; row < THREAD_TILE_M; row++) {
-#pragma unroll
-        for (auto col = 0; col < THREAD_TILE_N; col++) {
-          auto out_row_offset =
-              block_row * BLOCK_TILE_M + thread_row * THREAD_TILE_M + row;
-          auto out_col_offset =
-              block_col * BLOCK_TILE_N + thread_col * THREAD_TILE_N + col;
-          if ((out_row_offset < M) && (out_col_offset < N)) {
-            output[b][out_row_offset][out_col_offset] = accum[row][col];
-          }
+          // Fence shared memory between (block_col, block_row, b) iterations
+          // so the next iteration's tile load doesn't race with the previous
+          // read.
+          __syncthreads();
         }
       }
     }
@@ -196,7 +212,14 @@ Tensor jagged_jagged_bmm_forward_cuda(
           THREADS_PER_BLOCK % BLOCK_TILE_N == 0,
           "THREADS_PER_BLOCK needs to be multiple of BLOCK_TILE_N");
 
-      const auto grid_dim_x = div_round_up(N, BLOCK_TILE_N);
+      // HIP enforces a hard limit of 2^32 total threads per launch.
+      // The kernel grid-strides over (block_col, block_row, b), so capping
+      // is correctness-preserving.
+      // See: https://github.com/ROCm/hip/issues/2253
+      const auto grid_dim_x = utils::cuda::cap_grid_dim_x(
+          div_round_up(N, BLOCK_TILE_N),
+          THREADS_PER_BLOCK,
+          at::cuda::getCurrentCUDAStream());
       const auto grid_dim_y = div_round_up(M, BLOCK_TILE_M);
       TORCH_CHECK(
           grid_dim_y <= kMaxBlockYDim,
@@ -243,7 +266,14 @@ Tensor jagged_jagged_bmm_forward_cuda(
           THREADS_PER_BLOCK % BLOCK_TILE_N == 0,
           "THREADS_PER_BLOCK needs to be multiple of BLOCK_TILE_N");
 
-      const auto grid_dim_x = div_round_up(N, BLOCK_TILE_N);
+      // HIP enforces a hard limit of 2^32 total threads per launch.
+      // The kernel grid-strides over (block_col, block_row, b), so capping
+      // is correctness-preserving.
+      // See: https://github.com/ROCm/hip/issues/2253
+      const auto grid_dim_x = utils::cuda::cap_grid_dim_x(
+          div_round_up(N, BLOCK_TILE_N),
+          THREADS_PER_BLOCK,
+          at::cuda::getCurrentCUDAStream());
       const auto grid_dim_y = div_round_up(M, BLOCK_TILE_M);
       TORCH_CHECK(
           grid_dim_y <= kMaxBlockYDim,

--- a/fbgemm_gpu/test/jagged/dense_bmm_test.py
+++ b/fbgemm_gpu/test/jagged/dense_bmm_test.py
@@ -292,6 +292,48 @@ class DenseBmmTest(unittest.TestCase):
         # default tolerance.
         torch.testing.assert_close(out_gpu.cpu(), out_cpu, rtol=1e-3, atol=1e-1)
 
+    @unittest.skipUnless(torch.cuda.is_available(), "GPU not available")
+    def test_jagged_jagged_bmm_correctness(self) -> None:
+        """
+        Regression test for the HIP grid-overflow bug in
+        ``jagged_jagged_bmm_kernel`` (D105205055 / Subplan D Diff #29),
+        which lacked its own test method when landed.
+
+        Verifies end-to-end correctness vs. CPU dispatch using
+        sentinel non-zero lengths (including a zero-length entry).
+        """
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        max_L = 8
+        M = 16
+        N = 8
+
+        lengths_cpu = torch.tensor([3, 0, 5, 2], dtype=torch.int64)
+        offsets_cpu = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths_cpu)
+        total_length = int(lengths_cpu.sum().item())
+
+        x_values_init = torch.arange(total_length * M, dtype=torch.float32).reshape(
+            total_length, M
+        )
+        y_values_init = (
+            torch.arange(total_length * N, dtype=torch.float32).reshape(total_length, N)
+            * 0.01
+        )
+
+        # CPU oracle.
+        out_cpu = torch.ops.fbgemm.jagged_jagged_bmm(
+            x_values_init, y_values_init, offsets_cpu, max_L
+        )
+
+        # GPU op under test.
+        out_gpu = torch.ops.fbgemm.jagged_jagged_bmm(
+            x_values_init.to(device),
+            y_values_init.to(device),
+            offsets_cpu.to(device),
+            max_L,
+        )
+
+        torch.testing.assert_close(out_gpu.cpu(), out_cpu)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2929

Diff 9/10 of the Tier-2 ROCm grid-overflow fix stack.

Identical structure and fix recipe to Diff 8 (jagged_dense_bmm). Wraps the
kernel body in the same triple-nested grid-stride loop over block_col (x),
block_row (y), and b (z). Adds the standard #ifdef USE_ROCM host-side cap
on grid_dim_x at both launch sites (M>N and M<=N branches).

Reviewed By: henrylhtsang

Differential Revision: D105205055


