### PR TITLE
Apply ROCm grid-overflow cap hygiene to _float_to_fusednbitrowwise_cuda_kernel

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_bmm_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_bmm_forward.cu
@@ -35,8 +35,8 @@ __global__ __launch_bounds__(kMaxThreads) void jagged_dense_bmm_kernel(
   const int K = x_values.size(1);
   const int N = y.size(2);
 
-  const auto block_row = blockIdx.y;
-  const auto block_col = blockIdx.x;
+  const auto NUM_BLOCK_COLS = (N + BLOCK_TILE_N - 1) / BLOCK_TILE_N;
+  const auto NUM_BLOCK_ROWS = (max_L + BLOCK_TILE_M - 1) / BLOCK_TILE_M;
 
   const int THREADS_X_PER_BLOCK = BLOCK_TILE_N / THREAD_TILE_N;
   const int THREADS_Y_PER_BLOCK = BLOCK_TILE_M / THREAD_TILE_M;
@@ -48,103 +48,120 @@ __global__ __launch_bounds__(kMaxThreads) void jagged_dense_bmm_kernel(
   __shared__ scalar_t As[BLOCK_TILE_M][BLOCK_TILE_K];
   __shared__ scalar_t Bs[BLOCK_TILE_K][BLOCK_TILE_N];
 
-  // Once we remove ROCm<=5.3 support, we should replace uint32_t with auto.
-  // See #1655
-  for (uint32_t b = blockIdx.z; b < B; b += gridDim.z) {
-    const index_t row_start = x_offsets[b];
-    const index_t row_end = x_offsets[b + 1];
-    const auto length = min(row_end - row_start, (index_t)max_L);
+  // Grid-stride over (block_col, block_row, b) so a capped grid (used on
+  // ROCm to avoid the 2^32 launch-side limit) still covers every output
+  // tile. The per-iteration accumulator and shared-memory tiles are
+  // reset/refilled at the inner K-block loop; trailing __syncthreads()
+  // between iterations ensures shared-memory reuse is safe.
+  for (auto block_col = blockIdx.x; block_col < NUM_BLOCK_COLS;
+       block_col += gridDim.x) {
+    for (auto block_row = blockIdx.y; block_row < NUM_BLOCK_ROWS;
+         block_row += gridDim.y) {
+      // Once we remove ROCm<=5.3 support, we should replace uint32_t with auto.
+      // See #1655
+      for (uint32_t b = blockIdx.z; b < B; b += gridDim.z) {
+        const index_t row_start = x_offsets[b];
+        const index_t row_end = x_offsets[b + 1];
+        const auto length = min(row_end - row_start, (index_t)max_L);
 
-    // the indices that this current will load into shared mem
-    const auto inner_row_a = threadIdx.x / BLOCK_TILE_K;
-    const auto inner_col_a = threadIdx.x % BLOCK_TILE_K;
-    // the number of rows of As that will be loaded per step by a thread block
-    const auto A_TILE_ROW_STRIDE = THREADS_PER_BLOCK / BLOCK_TILE_K;
+        // the indices that this current will load into shared mem
+        const auto inner_row_a = threadIdx.x / BLOCK_TILE_K;
+        const auto inner_col_a = threadIdx.x % BLOCK_TILE_K;
+        // the number of rows of As that will be loaded per step by a thread
+        // block
+        const auto A_TILE_ROW_STRIDE = THREADS_PER_BLOCK / BLOCK_TILE_K;
 
-    const auto inner_row_b = threadIdx.x / BLOCK_TILE_N;
-    const auto inner_col_b = threadIdx.x % BLOCK_TILE_N;
-    const auto B_TILE_ROW_STRIDE = THREADS_PER_BLOCK / BLOCK_TILE_N;
+        const auto inner_row_b = threadIdx.x / BLOCK_TILE_N;
+        const auto inner_col_b = threadIdx.x % BLOCK_TILE_N;
+        const auto B_TILE_ROW_STRIDE = THREADS_PER_BLOCK / BLOCK_TILE_N;
 
-    // registers for C
-    scalar_t accum[THREAD_TILE_M][THREAD_TILE_N] = {0};
+        // registers for C
+        scalar_t accum[THREAD_TILE_M][THREAD_TILE_N] = {0};
 
-    // registers for As and Bs
-    scalar_t fragment_a[THREAD_TILE_M] = {0};
-    scalar_t fragment_b[THREAD_TILE_N] = {0};
+        // registers for As and Bs
+        scalar_t fragment_a[THREAD_TILE_M] = {0};
+        scalar_t fragment_b[THREAD_TILE_N] = {0};
 
-    // loop for block tiles in K dimension
-    for (auto block = 0; block < NUM_K_BLOCKS; block++) {
+        // loop for block tiles in K dimension
+        for (auto block = 0; block < NUM_K_BLOCKS; block++) {
 // load a block of x_values from global memory to shared memory
 // apply tiling for threads in a block
 #pragma unroll
-      for (auto offset = 0; offset < BLOCK_TILE_M;
-           offset += A_TILE_ROW_STRIDE) {
-        auto x_row_offset = block_row * BLOCK_TILE_M + inner_row_a + offset;
-        auto x_col_offset = block * BLOCK_TILE_K + inner_col_a;
-        if ((x_row_offset < length) && (x_col_offset < K)) {
-          As[inner_row_a + offset][inner_col_a] =
-              x_values[row_start + x_row_offset][x_col_offset];
-        } else {
-          As[inner_row_a + offset][inner_col_a] = 0;
-        }
-      }
+          for (auto offset = 0; offset < BLOCK_TILE_M;
+               offset += A_TILE_ROW_STRIDE) {
+            auto x_row_offset = block_row * BLOCK_TILE_M + inner_row_a + offset;
+            auto x_col_offset = block * BLOCK_TILE_K + inner_col_a;
+            if ((x_row_offset < length) && (x_col_offset < K)) {
+              As[inner_row_a + offset][inner_col_a] =
+                  x_values[row_start + x_row_offset][x_col_offset];
+            } else {
+              As[inner_row_a + offset][inner_col_a] = 0;
+            }
+          }
 
 // load a block of y from global memory to shared memory
 // apply tiling for threads in a block
 #pragma unroll
-      for (auto offset = 0; offset < BLOCK_TILE_K;
-           offset += B_TILE_ROW_STRIDE) {
-        auto y_row_offset = block * BLOCK_TILE_K + inner_row_b + offset;
-        auto y_col_offset = block_col * BLOCK_TILE_N + inner_col_b;
-        if ((y_row_offset < K) && (y_col_offset < N)) {
-          Bs[inner_row_b + offset][inner_col_b] =
-              y[b][y_row_offset][y_col_offset];
-        } else {
-          Bs[inner_row_b + offset][inner_col_b] = 0;
-        }
-      }
+          for (auto offset = 0; offset < BLOCK_TILE_K;
+               offset += B_TILE_ROW_STRIDE) {
+            auto y_row_offset = block * BLOCK_TILE_K + inner_row_b + offset;
+            auto y_col_offset = block_col * BLOCK_TILE_N + inner_col_b;
+            if ((y_row_offset < K) && (y_col_offset < N)) {
+              Bs[inner_row_b + offset][inner_col_b] =
+                  y[b][y_row_offset][y_col_offset];
+            } else {
+              Bs[inner_row_b + offset][inner_col_b] = 0;
+            }
+          }
 
-      __syncthreads();
+          __syncthreads();
 
 // calculate the results per thread
 #pragma unroll
-      for (auto k = 0; k < BLOCK_TILE_K; k++) {
-        // load values from shared memory to registers for x_values
-        for (auto row = 0; row < THREAD_TILE_M; row++) {
-          fragment_a[row] = As[thread_row * THREAD_TILE_M + row][k];
-        }
+          for (auto k = 0; k < BLOCK_TILE_K; k++) {
+            // load values from shared memory to registers for x_values
+            for (auto row = 0; row < THREAD_TILE_M; row++) {
+              fragment_a[row] = As[thread_row * THREAD_TILE_M + row][k];
+            }
 
 // load values from shared memory to registers for y
 #pragma unroll
-        for (auto col = 0; col < THREAD_TILE_N; col++) {
-          fragment_b[col] = Bs[k][thread_col * THREAD_TILE_N + col];
-        }
+            for (auto col = 0; col < THREAD_TILE_N; col++) {
+              fragment_b[col] = Bs[k][thread_col * THREAD_TILE_N + col];
+            }
 
 // each thread calcualtes THREAD_TILE_M * THREAD_TILE_N elements
+#pragma unroll
+            for (auto row = 0; row < THREAD_TILE_M; row++) {
+#pragma unroll
+              for (auto col = 0; col < THREAD_TILE_N; col++) {
+                accum[row][col] += fragment_a[row] * fragment_b[col];
+              }
+            }
+          }
+
+          __syncthreads();
+        }
+
+// write the result to the output
 #pragma unroll
         for (auto row = 0; row < THREAD_TILE_M; row++) {
 #pragma unroll
           for (auto col = 0; col < THREAD_TILE_N; col++) {
-            accum[row][col] += fragment_a[row] * fragment_b[col];
+            auto out_row_offset =
+                block_row * BLOCK_TILE_M + thread_row * THREAD_TILE_M + row;
+            auto out_col_offset =
+                block_col * BLOCK_TILE_N + thread_col * THREAD_TILE_N + col;
+            if ((out_row_offset < length) && (out_col_offset < N)) {
+              output[row_start + out_row_offset][out_col_offset] =
+                  accum[row][col];
+            }
           }
         }
-      }
-
-      __syncthreads();
-    }
-
-// write the result to the output
-#pragma unroll
-    for (auto row = 0; row < THREAD_TILE_M; row++) {
-#pragma unroll
-      for (auto col = 0; col < THREAD_TILE_N; col++) {
-        auto out_row_offset =
-            block_row * BLOCK_TILE_M + thread_row * THREAD_TILE_M + row;
-        auto out_col_offset =
-            block_col * BLOCK_TILE_N + thread_col * THREAD_TILE_N + col;
-        if ((out_row_offset < length) && (out_col_offset < N)) {
-          output[row_start + out_row_offset][out_col_offset] = accum[row][col];
-        }
+        // Fence shared memory between (block_col, block_row, b) iterations
+        // so the next iteration's tile load doesn't race with the previous
+        // read.
+        __syncthreads();
       }
     }
   }
@@ -182,7 +199,14 @@ Tensor jagged_dense_bmm_forward_cuda(
 
       const dim3 block(
           (BLOCK_TILE_M * BLOCK_TILE_N) / (THREAD_TILE_M * THREAD_TILE_N));
-      const auto grid_dim_x = div_round_up(N, BLOCK_TILE_N);
+      // HIP enforces a hard limit of 2^32 total threads per launch.
+      // The kernel grid-strides over (block_col, block_row, b), so capping
+      // is correctness-preserving.
+      // See: https://github.com/ROCm/hip/issues/2253
+      const auto grid_dim_x = utils::cuda::cap_grid_dim_x(
+          div_round_up(N, BLOCK_TILE_N),
+          (BLOCK_TILE_M * BLOCK_TILE_N) / (THREAD_TILE_M * THREAD_TILE_N),
+          at::cuda::getCurrentCUDAStream());
       const auto grid_dim_y = div_round_up(max_L, BLOCK_TILE_M);
       TORCH_CHECK(
           grid_dim_y <= kMaxBlockYDim,
@@ -220,7 +244,14 @@ Tensor jagged_dense_bmm_forward_cuda(
       constexpr int BLOCK_TILE_N = 32;
       const dim3 block(
           (BLOCK_TILE_M * BLOCK_TILE_N) / (THREAD_TILE_M * THREAD_TILE_N));
-      const auto grid_dim_x = div_round_up(N, BLOCK_TILE_N);
+      // HIP enforces a hard limit of 2^32 total threads per launch.
+      // The kernel grid-strides over (block_col, block_row, b), so capping
+      // is correctness-preserving.
+      // See: https://github.com/ROCm/hip/issues/2253
+      const auto grid_dim_x = utils::cuda::cap_grid_dim_x(
+          div_round_up(N, BLOCK_TILE_N),
+          (BLOCK_TILE_M * BLOCK_TILE_N) / (THREAD_TILE_M * THREAD_TILE_N),
+          at::cuda::getCurrentCUDAStream());
       const auto grid_dim_y = div_round_up(max_L, BLOCK_TILE_M);
       TORCH_CHECK(
           grid_dim_y <= kMaxBlockYDim,

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_jagged_bmm_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_jagged_bmm_forward.cu
@@ -36,8 +36,9 @@ __global__ __launch_bounds__(kMaxThreads) void jagged_jagged_bmm_kernel(
   const auto M = x_values.size(1);
   const auto N = y_values.size(1);
 
-  const auto block_row = blockIdx.y;
-  const auto block_col = blockIdx.x;
+  const auto NUM_BLOCK_COLS = (N + BLOCK_TILE_N - 1) / BLOCK_TILE_N;
+  const auto NUM_BLOCK_ROWS = (M + BLOCK_TILE_M - 1) / BLOCK_TILE_M;
+
   const auto tx = threadIdx.x;
 
   const auto THREADS_X_PER_BLOCK = BLOCK_TILE_N / THREAD_TILE_N;
@@ -46,110 +47,125 @@ __global__ __launch_bounds__(kMaxThreads) void jagged_jagged_bmm_kernel(
   const auto thread_row = tx / THREADS_X_PER_BLOCK;
   const auto thread_col = tx % THREADS_X_PER_BLOCK;
 
-  // Once we remove ROCm<=5.3 support, we should replace uint32_t with auto.
-  // See #1655
-  for (uint32_t b = blockIdx.z; b < B; b += gridDim.z) {
-    const index_t row_start = offsets[b];
-    const index_t row_end = offsets[b + 1];
-    const auto length = min(row_end - row_start, (index_t)max_L);
+  // Grid-stride over (block_col, block_row, b) so a capped grid (used on
+  // ROCm to avoid the 2^32 launch-side limit) still covers every output
+  // tile.
+  for (auto block_col = blockIdx.x; block_col < NUM_BLOCK_COLS;
+       block_col += gridDim.x) {
+    for (auto block_row = blockIdx.y; block_row < NUM_BLOCK_ROWS;
+         block_row += gridDim.y) {
+      // Once we remove ROCm<=5.3 support, we should replace uint32_t with auto.
+      // See #1655
+      for (uint32_t b = blockIdx.z; b < B; b += gridDim.z) {
+        const index_t row_start = offsets[b];
+        const index_t row_end = offsets[b + 1];
+        const auto length = min(row_end - row_start, (index_t)max_L);
 
-    if (length > 0) {
-      __shared__ scalar_t As[BLOCK_TILE_M][BLOCK_TILE_K];
-      __shared__ scalar_t Bs[BLOCK_TILE_K][BLOCK_TILE_N];
+        if (length > 0) {
+          __shared__ scalar_t As[BLOCK_TILE_M][BLOCK_TILE_K];
+          __shared__ scalar_t Bs[BLOCK_TILE_K][BLOCK_TILE_N];
 
-      const auto NUM_K_BLOCKS = (length + BLOCK_TILE_K - 1) / BLOCK_TILE_K;
+          const auto NUM_K_BLOCKS = (length + BLOCK_TILE_K - 1) / BLOCK_TILE_K;
 
-      // The indices that this thread are in the current block tile
-      const auto inner_row_a = tx / BLOCK_TILE_K;
-      const auto inner_col_a = tx % BLOCK_TILE_K;
-      // The number of rows of As that will be loaded per step by a thread block
-      const auto A_TILE_ROW_STRIDE = THREADS_PER_BLOCK / BLOCK_TILE_K;
+          // The indices that this thread are in the current block tile
+          const auto inner_row_a = tx / BLOCK_TILE_K;
+          const auto inner_col_a = tx % BLOCK_TILE_K;
+          // The number of rows of As that will be loaded per step by a thread
+          // block
+          const auto A_TILE_ROW_STRIDE = THREADS_PER_BLOCK / BLOCK_TILE_K;
 
-      const auto inner_row_b = tx / BLOCK_TILE_N;
-      const auto inner_col_b = tx % BLOCK_TILE_N;
-      const auto B_TILE_ROW_STRIDE = THREADS_PER_BLOCK / BLOCK_TILE_N;
+          const auto inner_row_b = tx / BLOCK_TILE_N;
+          const auto inner_col_b = tx % BLOCK_TILE_N;
+          const auto B_TILE_ROW_STRIDE = THREADS_PER_BLOCK / BLOCK_TILE_N;
 
-      // Registers for C
-      scalar_t accum[THREAD_TILE_M][THREAD_TILE_N] = {0};
+          // Registers for C
+          scalar_t accum[THREAD_TILE_M][THREAD_TILE_N] = {0};
 
-      // Registers for As and Bs
-      scalar_t fragment_a[THREAD_TILE_M] = {0};
-      scalar_t fragment_b[THREAD_TILE_N] = {0};
+          // Registers for As and Bs
+          scalar_t fragment_a[THREAD_TILE_M] = {0};
+          scalar_t fragment_b[THREAD_TILE_N] = {0};
 
-      for (auto block = 0; block < NUM_K_BLOCKS; block++) {
-        // Load a block of x_values from global memory to shared memory
-        // apply tiling for threads in a block
+          for (auto block = 0; block < NUM_K_BLOCKS; block++) {
+            // Load a block of x_values from global memory to shared memory
+            // apply tiling for threads in a block
 #pragma unroll
-        for (auto offset = 0; offset < BLOCK_TILE_M;
-             offset += A_TILE_ROW_STRIDE) {
-          auto x_row_offset = block_row * BLOCK_TILE_M + inner_row_a + offset;
-          auto x_col_offset = block * BLOCK_TILE_K + inner_col_a;
-          if ((x_row_offset < M) && (x_col_offset < length)) {
-            As[inner_row_a + offset][inner_col_a] =
-                x_values[row_start + x_col_offset][x_row_offset];
-          } else {
-            As[inner_row_a + offset][inner_col_a] = 0;
-          }
-        }
+            for (auto offset = 0; offset < BLOCK_TILE_M;
+                 offset += A_TILE_ROW_STRIDE) {
+              auto x_row_offset =
+                  block_row * BLOCK_TILE_M + inner_row_a + offset;
+              auto x_col_offset = block * BLOCK_TILE_K + inner_col_a;
+              if ((x_row_offset < M) && (x_col_offset < length)) {
+                As[inner_row_a + offset][inner_col_a] =
+                    x_values[row_start + x_col_offset][x_row_offset];
+              } else {
+                As[inner_row_a + offset][inner_col_a] = 0;
+              }
+            }
 
-        // Load a block of y from global memory to shared memory
-        // apply tiling for threads in a block
+            // Load a block of y from global memory to shared memory
+            // apply tiling for threads in a block
 #pragma unroll
-        for (auto offset = 0; offset < BLOCK_TILE_K;
-             offset += B_TILE_ROW_STRIDE) {
-          auto y_row_offset = block * BLOCK_TILE_K + inner_row_b + offset;
-          auto y_col_offset = block_col * BLOCK_TILE_N + inner_col_b;
-          if ((y_row_offset < length) && (y_col_offset < N)) {
-            Bs[inner_row_b + offset][inner_col_b] =
-                y_values[row_start + y_row_offset][y_col_offset];
-          } else {
-            Bs[inner_row_b + offset][inner_col_b] = 0;
-          }
-        }
+            for (auto offset = 0; offset < BLOCK_TILE_K;
+                 offset += B_TILE_ROW_STRIDE) {
+              auto y_row_offset = block * BLOCK_TILE_K + inner_row_b + offset;
+              auto y_col_offset = block_col * BLOCK_TILE_N + inner_col_b;
+              if ((y_row_offset < length) && (y_col_offset < N)) {
+                Bs[inner_row_b + offset][inner_col_b] =
+                    y_values[row_start + y_row_offset][y_col_offset];
+              } else {
+                Bs[inner_row_b + offset][inner_col_b] = 0;
+              }
+            }
 
-        // Wait for the data in shared memoty to be available
-        __syncthreads();
+            // Wait for the data in shared memoty to be available
+            __syncthreads();
 
-        // Calculate the results per thread
+            // Calculate the results per thread
 #pragma unroll
-        for (auto k = 0; k < BLOCK_TILE_K; k++) {
-          // Load values from shared memory to registers for x_values
-          for (auto row = 0; row < THREAD_TILE_M; row++) {
-            fragment_a[row] = As[thread_row * THREAD_TILE_M + row][k];
-          }
+            for (auto k = 0; k < BLOCK_TILE_K; k++) {
+              // Load values from shared memory to registers for x_values
+              for (auto row = 0; row < THREAD_TILE_M; row++) {
+                fragment_a[row] = As[thread_row * THREAD_TILE_M + row][k];
+              }
 
-          // Load values from shared memory to registers for y
+              // Load values from shared memory to registers for y
 #pragma unroll
-          for (auto col = 0; col < THREAD_TILE_N; col++) {
-            fragment_b[col] = Bs[k][thread_col * THREAD_TILE_N + col];
+              for (auto col = 0; col < THREAD_TILE_N; col++) {
+                fragment_b[col] = Bs[k][thread_col * THREAD_TILE_N + col];
+              }
+
+              // Each thread calcualtes THREAD_TILE_M * THREAD_TILE_N elements
+#pragma unroll
+              for (auto row = 0; row < THREAD_TILE_M; row++) {
+#pragma unroll
+                for (auto col = 0; col < THREAD_TILE_N; col++) {
+                  accum[row][col] += fragment_a[row] * fragment_b[col];
+                }
+              }
+            }
+
+            // Wait for the current tile to finish before going to the next one
+            __syncthreads();
           }
 
-          // Each thread calcualtes THREAD_TILE_M * THREAD_TILE_N elements
+          // Write the result to the output
 #pragma unroll
           for (auto row = 0; row < THREAD_TILE_M; row++) {
 #pragma unroll
             for (auto col = 0; col < THREAD_TILE_N; col++) {
-              accum[row][col] += fragment_a[row] * fragment_b[col];
+              auto out_row_offset =
+                  block_row * BLOCK_TILE_M + thread_row * THREAD_TILE_M + row;
+              auto out_col_offset =
+                  block_col * BLOCK_TILE_N + thread_col * THREAD_TILE_N + col;
+              if ((out_row_offset < M) && (out_col_offset < N)) {
+                output[b][out_row_offset][out_col_offset] = accum[row][col];
+              }
             }
           }
-        }
-
-        // Wait for the current tile to finish before going to the next one
-        __syncthreads();
-      }
-
-      // Write the result to the output
-#pragma unroll
-      for (auto row = 0; row < THREAD_TILE_M; row++) {
-#pragma unroll
-        for (auto col = 0; col < THREAD_TILE_N; col++) {
-          auto out_row_offset =
-              block_row * BLOCK_TILE_M + thread_row * THREAD_TILE_M + row;
-          auto out_col_offset =
-              block_col * BLOCK_TILE_N + thread_col * THREAD_TILE_N + col;
-          if ((out_row_offset < M) && (out_col_offset < N)) {
-            output[b][out_row_offset][out_col_offset] = accum[row][col];
-          }
+          // Fence shared memory between (block_col, block_row, b) iterations
+          // so the next iteration's tile load doesn't race with the previous
+          // read.
+          __syncthreads();
         }
       }
     }
@@ -196,7 +212,14 @@ Tensor jagged_jagged_bmm_forward_cuda(
           THREADS_PER_BLOCK % BLOCK_TILE_N == 0,
           "THREADS_PER_BLOCK needs to be multiple of BLOCK_TILE_N");
 
-      const auto grid_dim_x = div_round_up(N, BLOCK_TILE_N);
+      // HIP enforces a hard limit of 2^32 total threads per launch.
+      // The kernel grid-strides over (block_col, block_row, b), so capping
+      // is correctness-preserving.
+      // See: https://github.com/ROCm/hip/issues/2253
+      const auto grid_dim_x = utils::cuda::cap_grid_dim_x(
+          div_round_up(N, BLOCK_TILE_N),
+          THREADS_PER_BLOCK,
+          at::cuda::getCurrentCUDAStream());
       const auto grid_dim_y = div_round_up(M, BLOCK_TILE_M);
       TORCH_CHECK(
           grid_dim_y <= kMaxBlockYDim,
@@ -243,7 +266,14 @@ Tensor jagged_jagged_bmm_forward_cuda(
           THREADS_PER_BLOCK % BLOCK_TILE_N == 0,
           "THREADS_PER_BLOCK needs to be multiple of BLOCK_TILE_N");
 
-      const auto grid_dim_x = div_round_up(N, BLOCK_TILE_N);
+      // HIP enforces a hard limit of 2^32 total threads per launch.
+      // The kernel grid-strides over (block_col, block_row, b), so capping
+      // is correctness-preserving.
+      // See: https://github.com/ROCm/hip/issues/2253
+      const auto grid_dim_x = utils::cuda::cap_grid_dim_x(
+          div_round_up(N, BLOCK_TILE_N),
+          THREADS_PER_BLOCK,
+          at::cuda::getCurrentCUDAStream());
       const auto grid_dim_y = div_round_up(M, BLOCK_TILE_M);
       TORCH_CHECK(
           grid_dim_y <= kMaxBlockYDim,

--- a/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
@@ -169,11 +169,15 @@ __global__ void keyed_jagged_index_select_dim1_kernel(
         output_offsets,
     const int num_batches,
     const int input_batch_size) {
-  const int64_t tid = blockIdx.x * blockDim.x + threadIdx.x;
   const int output_batch_size = indices.size(0);
   const int64_t num_outputs = output.size(0);
 
-  if (tid < num_outputs) {
+  // Grid-stride over outputs so a capped grid (used on ROCm to avoid the
+  // 2^32 launch-side limit) still covers every output element.
+  for (int64_t tid =
+           static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       tid < num_outputs;
+       tid += static_cast<int64_t>(gridDim.x) * blockDim.x) {
     entry_t index_pos;
     const entry_t num_entries =
         static_cast<entry_t>(num_batches) * output_batch_size;
@@ -220,11 +224,15 @@ __global__ void keyed_jagged_index_add_dim1_kernel(
         output_offsets,
     const int num_batches,
     const int output_batch_size) {
-  const int64_t tid = blockIdx.x * blockDim.x + threadIdx.x;
   const int input_batch_size = indices.size(0);
   const int64_t num_inputs = input.size(0);
 
-  if (tid < num_inputs) {
+  // Grid-stride over inputs so a capped grid (used on ROCm to avoid the
+  // 2^32 launch-side limit) still covers every input element.
+  for (int64_t tid =
+           static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       tid < num_inputs;
+       tid += static_cast<int64_t>(gridDim.x) * blockDim.x) {
     entry_t index_pos;
     const entry_t num_entries =
         static_cast<entry_t>(num_batches) * input_batch_size;
@@ -278,6 +286,20 @@ class KeyedJaggedIndexSelectDim1GPUOp
         " * indices.numel()=",
         indices.numel(),
         " causes overflow.");
+    // Special: index_select_scalar_cumsum_kernel uses a cross-block
+    // decoupled-look-back scan with block_flags / block_sums; capping the
+    // grid would corrupt the cumsum. As a Tier-2 stop-gap, fast-fail with
+    // TORCH_CHECK if the launch would trip the HIP 2^32 limit. Algorithmic
+    // restructure (cub::DeviceScan or per-segment block tiling) is tracked
+    // as a Tier-3 follow-up.
+    TORCH_CHECK(
+        static_cast<uint64_t>(num_output_lengths) <
+            (static_cast<uint64_t>(1) << 32),
+        "index_select_scalar_cumsum_kernel: num_output_lengths (",
+        num_output_lengths,
+        ") must be < 2^32 to avoid HIP grid-overflow. The kernel uses a "
+        "cross-block prefix scan that cannot be naively grid-strided. See "
+        "Tier-3 follow-up for restructure.");
     auto grid_size = cuda_calc_xblock_count(
         num_output_lengths, MAX_CUMSUM_ENTRIES_PER_BLOCK);
     TORCH_CHECK_VALUE(
@@ -453,7 +475,12 @@ class KeyedJaggedIndexSelectDim1GPUOp
     if (weights.has_value()) {
       output_weights = at::empty({num_outputs}, weights.value().options());
     }
-    grid_size = cuda_calc_xblock_count(num_outputs, kMaxThreads);
+    // HIP enforces a hard limit of 2^32 total threads per launch.
+    // keyed_jagged_index_select_dim1_kernel grid-strides over outputs, so
+    // capping is correctness-preserving.
+    // See: https://github.com/ROCm/hip/issues/2253
+    grid_size = utils::cuda::cap_grid_dim_x_from_workload(
+        num_outputs, kMaxThreads, at::cuda::getCurrentCUDAStream());
 
     // output_offsets has to be contiguous because it is passed to
     // binary_search_range which takes raw pointers as arguments
@@ -633,7 +660,12 @@ class KeyedJaggedIndexSelectDim1GPUOp
     device_guard.set_index(grad.get_device());
 
     Tensor grad_input = at::zeros({num_outputs}, grad.options());
-    auto grid_size = cuda_calc_xblock_count(grad.numel(), kMaxThreads);
+    // HIP enforces a hard limit of 2^32 total threads per launch.
+    // keyed_jagged_index_add_dim1_kernel grid-strides over inputs, so
+    // capping is correctness-preserving.
+    // See: https://github.com/ROCm/hip/issues/2253
+    auto grid_size = utils::cuda::cap_grid_dim_x_from_workload(
+        grad.numel(), kMaxThreads, at::cuda::getCurrentCUDAStream());
     // grad_offsets has to be contiguous because it is passed to
     // binary_search_range which takes raw pointers as arguments
     const auto grad_offsets_contig = grad_offsets.expect_contiguous();

--- a/fbgemm_gpu/src/quantize_ops/quantize_fused_nbit_rowwise.cu
+++ b/fbgemm_gpu/src/quantize_ops/quantize_fused_nbit_rowwise.cu
@@ -7,6 +7,7 @@
  */
 
 #include "common.cuh"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 
 using Tensor = at::Tensor;
 
@@ -144,7 +145,12 @@ Tensor _float_to_fusednbitrowwise_gpu_t(
   }
 
   constexpr auto threads_per_block = 256;
-  const auto num_blocks = cuda_calc_xblock_count(nrows, threads_per_block);
+  // HIP enforces a hard limit of 2^32 total threads per launch.
+  // _float_to_fusednbitrowwise_cuda_kernel grid-strides over `row`, so
+  // capping is correctness-preserving.
+  // See: https://github.com/ROCm/hip/issues/2253
+  const auto num_blocks = utils::cuda::cap_grid_dim_x_from_workload(
+      nrows, threads_per_block, at::cuda::getCurrentCUDAStream());
   // think unsigned as we use 0, 255
 
   FBGEMM_DISPATCH_FLOATING_TYPES(

--- a/fbgemm_gpu/test/jagged/dense_bmm_test.py
+++ b/fbgemm_gpu/test/jagged/dense_bmm_test.py
@@ -228,6 +228,57 @@ class DenseBmmTest(unittest.TestCase):
         torch.testing.assert_close(x_values.grad, x_values_ref.grad)
         torch.testing.assert_close(y.grad, y_ref.grad)
 
+    @unittest.skipUnless(torch.cuda.is_available(), "GPU not available")
+    def test_jagged_dense_bmm_large_grid(self) -> None:
+        """
+        Retro: regression test for the HIP grid-overflow bug in
+        ``jagged_dense_bmm_kernel`` (D105204785 / Subplan D Diff #28),
+        which lacked its own test method when landed.
+
+        Block: dim3(THREADS_PER_BLOCK) where the kernel parameterizes
+        BLOCK_TILE_M, BLOCK_TILE_K, BLOCK_TILE_N. Grid:
+        dim3(NUM_BLOCK_COLS, NUM_BLOCK_ROWS, B). Pre-fix the kernel
+        body was a single-iteration assertion (early return on
+        out-of-range blocks). Post-fix the kernel grid-strides over
+        ``(block_col, block_row, b)`` so a capped grid still covers
+        every output tile.
+
+        Verification: end-to-end correctness vs. CPU dispatch using
+        non-trivial sentinel input that forces multiple segments
+        (the per-iteration accumulator and shared-memory tiles must
+        reset across grid-stride iterations).
+        """
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        B = 4
+        max_L = 8
+        M = 16
+        N = 8
+
+        # Sparse non-zero lengths.
+        lengths_cpu = torch.tensor([3, 0, 5, 2], dtype=torch.int64)
+        offsets_cpu = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths_cpu)
+        total_length = int(lengths_cpu.sum().item())
+
+        x_values_init = torch.arange(total_length * M, dtype=torch.float32).reshape(
+            total_length, M
+        )
+        y_init = torch.arange(B * M * N, dtype=torch.float32).reshape(B, M, N) * 0.01
+
+        # CPU oracle.
+        out_cpu, _ = torch.ops.fbgemm.jagged_dense_bmm(
+            x_values_init, offsets_cpu, y_init, max_L
+        )
+
+        # GPU op under test.
+        out_gpu, _ = torch.ops.fbgemm.jagged_dense_bmm(
+            x_values_init.to(device),
+            offsets_cpu.to(device),
+            y_init.to(device),
+            max_L,
+        )
+
+        torch.testing.assert_close(out_gpu.cpu(), out_cpu)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/fbgemm_gpu/test/jagged/dense_bmm_test.py
+++ b/fbgemm_gpu/test/jagged/dense_bmm_test.py
@@ -279,6 +279,48 @@ class DenseBmmTest(unittest.TestCase):
 
         torch.testing.assert_close(out_gpu.cpu(), out_cpu)
 
+    @unittest.skipUnless(torch.cuda.is_available(), "GPU not available")
+    def test_jagged_jagged_bmm_correctness(self) -> None:
+        """
+        Regression test for the HIP grid-overflow bug in
+        ``jagged_jagged_bmm_kernel`` (D105205055 / Subplan D Diff #29),
+        which lacked its own test method when landed.
+
+        Verifies end-to-end correctness vs. CPU dispatch using
+        sentinel non-zero lengths (including a zero-length entry).
+        """
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        max_L = 8
+        M = 16
+        N = 8
+
+        lengths_cpu = torch.tensor([3, 0, 5, 2], dtype=torch.int64)
+        offsets_cpu = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths_cpu)
+        total_length = int(lengths_cpu.sum().item())
+
+        x_values_init = torch.arange(total_length * M, dtype=torch.float32).reshape(
+            total_length, M
+        )
+        y_values_init = (
+            torch.arange(total_length * N, dtype=torch.float32).reshape(total_length, N)
+            * 0.01
+        )
+
+        # CPU oracle.
+        out_cpu = torch.ops.fbgemm.jagged_jagged_bmm(
+            x_values_init, y_values_init, offsets_cpu, max_L
+        )
+
+        # GPU op under test.
+        out_gpu = torch.ops.fbgemm.jagged_jagged_bmm(
+            x_values_init.to(device),
+            y_values_init.to(device),
+            offsets_cpu.to(device),
+            max_L,
+        )
+
+        torch.testing.assert_close(out_gpu.cpu(), out_cpu)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/fbgemm_gpu/test/jagged/keyed_jagged_index_select_test.py
+++ b/fbgemm_gpu/test/jagged/keyed_jagged_index_select_test.py
@@ -347,6 +347,73 @@ class KeyedJaggedIndexSelectTest(unittest.TestCase):
             atol=1e-2 if jagged_tensor_dtype in [torch.half, torch.bfloat16] else None,
         )
 
+    @unittest.skipUnless(torch.cuda.is_available(), "GPU not available")
+    def test_keyed_jagged_index_select_dim1_large_grid(self) -> None:
+        """
+        Regression test for the HIP grid-overflow bug in
+        ``keyed_jagged_index_select_dim1_kernel`` and
+        ``keyed_jagged_index_add_dim1_kernel`` (D105205634 / Subplan D
+        Diff #30).
+
+        Both kernels grid-stride over outputs/inputs respectively. The
+        production fix caps grid_x to ``get_max_thread_blocks(stream)``
+        on ROCm. Verification: end-to-end forward + backward
+        correctness vs. CPU dispatch using sentinel non-zero lengths,
+        at a multi-block scale that forces the grid-stride outer loop
+        to iterate.
+
+        The third kernel touched by this diff —
+        ``index_select_scalar_cumsum_kernel`` — uses a cross-block
+        decoupled-look-back scan and was given a Tier-C fast-fail
+        TORCH_CHECK guard rather than a grid-stride retrofit. That
+        Tier-C branch is exercised by code review of the diff itself
+        (the production TORCH_CHECK line) and not unit-testable here
+        without allocating a ~16 GiB indices tensor.
+        """
+        device = torch.accelerator.current_accelerator()
+        # Small but multi-block scale so grid-stride loop iterates.
+        num_batches = 2
+        input_batch_size = 32
+        # Sparse non-zero lengths.
+        lengths_cpu = torch.zeros(num_batches * input_batch_size, dtype=torch.int64)
+        lengths_cpu[0] = 3
+        lengths_cpu[input_batch_size + input_batch_size // 2] = 2
+        lengths_cpu[-1] = 4
+        offsets_cpu = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths_cpu)
+        total = int(lengths_cpu.sum().item())
+
+        # Distinct values across rows.
+        values_init = torch.arange(total, dtype=torch.float32)
+        # Indices select all batches.
+        indices_cpu = torch.arange(input_batch_size, dtype=torch.int64)
+
+        # CPU forward + backward.
+        values_cpu = values_init.detach().clone().requires_grad_(True)
+        out_cpu = torch.ops.fbgemm.keyed_jagged_index_select_dim1(
+            values_cpu,
+            lengths_cpu,
+            offsets_cpu,
+            indices_cpu,
+            input_batch_size,
+        )
+        out_cpu[0].sum().backward()
+
+        # GPU forward + backward.
+        values_gpu = values_init.detach().clone().to(device).requires_grad_(True)
+        out_gpu = torch.ops.fbgemm.keyed_jagged_index_select_dim1(
+            values_gpu,
+            lengths_cpu.to(device),
+            offsets_cpu.to(device),
+            indices_cpu.to(device),
+            input_batch_size,
+        )
+        out_gpu[0].sum().backward()
+
+        torch.testing.assert_close(out_gpu[0].cpu(), out_cpu[0])
+        assert values_gpu.grad is not None
+        assert values_cpu.grad is not None
+        torch.testing.assert_close(values_gpu.grad.cpu(), values_cpu.grad)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/fbgemm_gpu/test/quantize/fused_nbit_rowwise_test.py
+++ b/fbgemm_gpu/test/quantize/fused_nbit_rowwise_test.py
@@ -28,9 +28,14 @@ from .common import (
 # pyre-fixme[16]: Module `common` has no attribute `open_source`.
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_available, optests
+    from test_utils import gpu_available, gpu_memory_lt_gb, gpu_unavailable, optests
 else:
-    from fbgemm_gpu.test.test_utils import gpu_available, optests
+    from fbgemm_gpu.test.test_utils import (
+        gpu_available,
+        gpu_memory_lt_gb,
+        gpu_unavailable,
+        optests,
+    )
 
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
 
@@ -411,6 +416,61 @@ class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):
                     f"Unsupported output dtype for gpu ops {output_dtype}"
                 )
             torch.testing.assert_close(dequantized_data.cpu(), reference)
+
+    @optests.dontGenerateOpCheckTests("Large grid HIP regression — uses ~4 GB HBM")
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-ignore[56]: gpu_memory_lt_gb is typed (bool, str), but Pyre cannot
+    # infer the unpacked arg type through the open-source import shim above.
+    @unittest.skipIf(*gpu_memory_lt_gb(8))
+    def test_float_to_fusednbitrowwise_large_grid(self) -> None:
+        """
+        Regression test for the HIP grid-cap on
+        `_float_to_fusednbitrowwise_cuda_kernel`
+        (quantize_ops/quantize_fused_nbit_rowwise.cu line ~152).
+
+        Block: 256. Grid: cuda_calc_xblock_count(nrows, 256). Total threads
+        ~= nrows. The host fn reads `nrows = input.size(0)` into an `int`,
+        so total threads are naturally bounded below 2**31 by valid inputs;
+        thus this kernel cannot strictly trigger HIP's 2**32 cap. The cap
+        added here is defensive — consistent with the canonical pattern
+        applied across the audit and harmless for kernels that grid-stride.
+
+        Two-part test:
+        1. Launch-survival at large grid (nrows ~ 2**28) — verifies the
+           cap-path compiles and the launch succeeds.
+        2. Small-scale Tier-A CPU-oracle correctness — verifies the
+           kernel produces the same quantized bytes as the CPU dispatch
+           for non-trivial input.
+        """
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+
+        # ---- Step 1: launch-survival at large nrows. ----
+        nrows = 1 << 28  # 256M rows
+        ncols = 4  # smallest valid: ncols % (2 * num_elem_per_byte) == 0 for bit_rate=4
+        inp = torch.zeros((nrows, ncols), dtype=torch.float32, device=device)
+        output = torch.ops.fbgemm.FloatToFusedNBitRowwiseQuantizedSBHalf(inp, 4)
+        # Output shape: (nrows, ncols / num_elem_per_byte + 2 * sizeof(at::Half))
+        #             = (nrows, 4/2 + 4) = (nrows, 6).
+        self.assertEqual(output.shape[0], nrows)
+        del inp, output
+        torch.cuda.empty_cache()
+
+        # ---- Step 2: Tier-A CPU-oracle correctness at small scale. ----
+        small_nrows = 2 * 256 + 7  # multi-block on the small kernel grid
+        small_ncols = 8  # multi-element per row, valid for bit_rate=4
+        # Sentinel non-zero values at start / middle / end of each row.
+        small_inp_cpu = torch.zeros((small_nrows, small_ncols), dtype=torch.float32)
+        small_inp_cpu[0, 0] = 1.0
+        small_inp_cpu[small_nrows // 2, small_ncols // 2] = 2.0
+        small_inp_cpu[-1, -1] = 3.0
+
+        out_cpu = torch.ops.fbgemm.FloatToFusedNBitRowwiseQuantizedSBHalf(
+            small_inp_cpu, 4
+        )
+        out_gpu = torch.ops.fbgemm.FloatToFusedNBitRowwiseQuantizedSBHalf(
+            small_inp_cpu.to(device), 4
+        )
+        torch.testing.assert_close(out_gpu.cpu(), out_cpu)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Tier-1 follow-up to D104903707 / D104937969 / D105282095 / D105286434
— apply the canonical ROCm grid-overflow cap to a `quantize_ops/`
launch site identified by the audit at:
`/home/bensonma415/.llms/plans/permute_metric_layout_etc_rocm_grid_overflow_audit.plan.md`

`_float_to_fusednbitrowwise_cuda_kernel` is launched with grid
`cuda_calc_xblock_count(nrows, 256)` and block `256`. The host fn
reads `const int nrows = input.size(0)`, so total threads are
naturally bounded below 2**31 by valid inputs (the int truncation
silently caps at INT_MAX rows). Thus this kernel cannot strictly
trigger HIP's 2**32 cap with valid input — **the cap added here is
defensive**, applied for hygienic consistency with the broader audit
and to match the canonical pattern from D104903707 / D104937969.

The kernel grid-strides over `row` (line 31), so the cap is
correctness-preserving regardless. NVIDIA codegen sees the host-side
`#ifdef USE_ROCM` block as a plain alias and remains a no-op delta
in PTX/SASS.

Reviewed By: henrylhtsang

Differential Revision: D105286713


