### PR TITLE
Load fbgemm_gpu_embedding_inplace_ops .so in OSS __init__

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/__init__.py
@@ -149,6 +149,7 @@ fbgemm_gpu_libraries = [
     "fbgemm_gpu_tbe_training_backward_split_host",
     "fbgemm_gpu_tbe_training_backward_gwd",
     "fbgemm_gpu_tbe_training_backward_vbe",
+    "fbgemm_gpu_embedding_inplace_ops",
     "fbgemm_gpu_py",
 ]
 


### PR DESCRIPTION
Summary:
The ops `pruned_array_lookup_from_row_idx` and `emb_inplace_update` are
registered via a TORCH_LIBRARY_FRAGMENT static initializer in
embedding_inplace_update_cpu.cpp, which the OSS build compiles into a
separate shared library `fbgemm_gpu_embedding_inplace_ops`
(FbgemmGpu.cmake). That .so is only a link-time DEP of fbgemm_gpu_py, so
with --as-needed linking its DT_NEEDED entry is dropped (nothing
references its symbols directly) and it is never dlopen'd at runtime. The
static initializer therefore never runs and the ops are never registered.

OSS __init__.py works around this for every other split-out op library by
explicitly torch.ops.load_library-ing each .so in fbgemm_gpu_libraries,
but fbgemm_gpu_embedding_inplace_ops was the one DEP of fbgemm_gpu_py
missing from that list. Add it so the ops register in OSS.

This was latent because no OSS test called either op directly until the
new PrunedArrayLookupFromRowIdxLargeGridTest was added, which failed with:
  AttributeError: '_OpNamespace' 'fbgemm' object has no attribute
  'pruned_array_lookup_from_row_idx'

Differential Revision: D112990311


