### PR TITLE
Fix HIP grid overflow in _compute_msfp_shared_exponent_cuda_kernel

### DIFF
--- a/fbgemm_gpu/src/quantize_ops/quantize_msfp.cu
+++ b/fbgemm_gpu/src/quantize_ops/quantize_msfp.cu
@@ -7,6 +7,7 @@
  */
 
 #include "common.cuh"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 
 using Tensor = at::Tensor;
 
@@ -151,7 +152,15 @@ DLL_PUBLIC at::Tensor _float_to_msfp_gpu(
 
   const int blockDim_x = std::min(ncols, threads_per_block);
   const dim3 blockDim(blockDim_x, threads_per_block / blockDim_x);
-  const int gridDim_x = (ncols + blockDim.x - 1) / blockDim.x;
+  // HIP enforces a hard limit of 2^32 total threads per launch.
+  // The kernel grid-strides on both dims (over row and col), so capping is
+  // correctness-preserving. gridDim.y is already manually capped below at
+  // 65535 — leave it untouched.
+  // See: https://github.com/ROCm/hip/issues/2253
+  const int gridDim_x = utils::cuda::cap_grid_dim_x(
+      (ncols + blockDim.x - 1) / blockDim.x,
+      threads_per_block,
+      at::cuda::getCurrentCUDAStream());
   const int gridDim_y = std::min((nrows + blockDim.y - 1) / blockDim.y, 65535u);
   const dim3 gridDim(gridDim_x, gridDim_y);
 

--- a/fbgemm_gpu/test/quantize/msfp_test.py
+++ b/fbgemm_gpu/test/quantize/msfp_test.py
@@ -21,9 +21,9 @@ from .common import open_source
 # pyre-fixme[16]: Module `common` has no attribute `open_source`.
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_unavailable
+    from test_utils import gpu_memory_lt_gb, gpu_unavailable
 else:
-    from fbgemm_gpu.test.test_utils import gpu_unavailable
+    from fbgemm_gpu.test.test_utils import gpu_memory_lt_gb, gpu_unavailable
 
 
 class TestMSFPQuantizationConversion(unittest.TestCase):
@@ -56,6 +56,61 @@ class TestMSFPQuantizationConversion(unittest.TestCase):
             quantized_data.cuda(), ebits, mbits, bias
         )
         torch.testing.assert_close(dequantized_data.cpu(), input_data, rtol=1, atol=0)
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-ignore[56]: Pyre cannot infer the type of `gpu_memory_lt_gb`
+    # through the open-source / non-open-source import branch above.
+    @unittest.skipIf(*gpu_memory_lt_gb(2))
+    def test_float_to_msfp_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in
+        `_compute_msfp_shared_exponent_cuda_kernel`
+        (quantize_ops/quantize_msfp.cu line ~161).
+
+        Block: dim3(blockDim_x, threads_per_block / blockDim_x), with
+        threads_per_block = 256 and blockDim_x = min(ncols, 256).
+        gridDim.y is already manually capped at 65535. gridDim.x =
+        ceil(ncols / blockDim.x) is uncapped pre-fix. Total threads ~=
+        gridDim.x * gridDim.y * threads_per_block. For ncols >= ~65536
+        with nrows large enough to saturate gridDim.y at 65535, total
+        threads can exceed HIP's 2**32 cap and trip
+        `KernelLauncher::checkThreadCountNotExceeded`.
+
+        The kernel grid-strides on both dims (line 87 over row, line 90
+        over col), so the cap is correctness-preserving.
+
+        Note: at nrows=1024, ncols=65792 the input, output, and internal
+        shared_exponents tensors are each nrows*ncols*4 bytes (~257 MiB),
+        for a peak of ~0.8 GiB (well within the gpu_memory_lt_gb(2)
+        guard). This scale does not itself trip the 2**32 thread limit --
+        that requires nrows and ncols both near their caps (tens of GiB) --
+        it exercises the gridDim.x cap / grid-stride code path, which is
+        hygienic for grid-striding kernels. FloatToMSFPQuantized is a
+        CUDA-only op (no CPU/Meta dispatch), so this is a launch-success
+        regression test with no CPU oracle.
+        """
+        nrows = 1024
+        ncols = 65792  # > 256 * 256 + 256: forces gridDim.x >= 257
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        input_data = torch.zeros((nrows, ncols), dtype=torch.float32, device=device)
+        ebits = 8
+        mbits = 7
+        bias = 127
+        max_pos = (1 << ((1 << ebits) - 2 - bias)) * (2 - 2 ** (-mbits))
+        min_pos = 2 ** (1 - bias - mbits)
+        bounding_box_size = 16
+        output = torch.ops.fbgemm.FloatToMSFPQuantized(
+            input_data,
+            bounding_box_size,
+            ebits,
+            mbits,
+            bias,
+            min_pos,
+            max_pos,
+        )
+        # If we reach this point, the cap path is in place and the
+        # kernel launched successfully.
+        self.assertEqual(output.shape, input_data.shape)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Tier-1 follow-up to D104903707 / D104937969 / D105282095 / D105286434 /
D105286713 — apply the canonical ROCm grid-overflow cap to a
`quantize_ops/` launch site identified by the audit at:
`/home/bensonma415/.llms/plans/permute_metric_layout_etc_rocm_grid_overflow_audit.plan.md`

`_compute_msfp_shared_exponent_cuda_kernel` is launched with grid
`dim3(gridDim_x, gridDim_y)` where `gridDim_y = std::min(..., 65535u)`
is already manually capped, but `gridDim_x = (ncols + blockDim.x - 1)
/ blockDim.x` was uncapped pre-fix. Block size is 256 (`dim3(blockDim_x,
threads_per_block / blockDim_x)`). Total threads ~= gridDim_x *
gridDim_y * 256. For `ncols >= ~65792` with `nrows` saturating
gridDim_y at 65535, total threads exceed HIP's 2**32 hard limit,
tripping `KernelLauncher::checkThreadCountNotExceeded`.

The kernel grid-strides on both dims (line 87 over row, line 90 over
col), so capping gridDim.x is correctness-preserving. gridDim.y is
left untouched (already manually capped at 65535).

NVIDIA codegen sees the host-side `#ifdef USE_ROCM` block as a plain
alias and remains a no-op delta in PTX/SASS.

Reviewed By: cthi

Differential Revision: D105286878


