### PR TITLE
derive TBE cache associativity from device warp size (#6037)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
@@ -394,10 +394,6 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             f"Feature Gates: {[(feature.name, feature.is_enabled()) for feature in FeatureGateName]}"
         )
 
-        # 64 for AMD
-        if cache_assoc == 32 and torch.version.hip is not None:
-            cache_assoc = 64
-
         if device is None:
             self.current_device: torch.device = torch.device(
                 torch.cuda.current_device()
@@ -407,6 +403,20 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         else:
             self.current_device = torch.device(device)
         self.use_cpu: bool = self.current_device.type == "cpu"
+
+        # Cache associativity must equal the device warp size (see the training
+        # module's _apply_cache_state for the rationale). Only query a live CUDA
+        # device: on CPU, a meta device (tracing/sharding/publish), or a
+        # CUDA-typed device on a host with no driver, get_device_properties
+        # raises, so fall back to the default associativity in those cases.
+        if (
+            cache_assoc == 32
+            and self.current_device.type == "cuda"
+            and torch.cuda.is_available()
+        ):
+            cache_assoc = torch.cuda.get_device_properties(
+                self.current_device
+            ).warp_size
 
         self.scale_bias_size_in_bytes = scale_bias_size_in_bytes
         self.pooling_mode = pooling_mode

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -92,7 +92,9 @@ except Exception:
     pass
 
 
-DEFAULT_ASSOC = 32 if torch.version.hip is None else 64
+# Default cache associativity. Overridden to 64 in each module's
+# __init__ on AMD devices that have 64-lane waves.
+DEFAULT_ASSOC = 32
 INT8_EMB_ROW_DIM_OFFSET = 8
 
 
@@ -3730,6 +3732,20 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.timestep = 1
         self.timesteps_prefetched = []
 
+        # Cache associativity (ways per set) must equal the device warp size:
+        # the cache kernels use one warp to cooperatively scan the ways of a
+        # single set. CDNA (gfx9xx) is warp 64, RDNA (gfx11xx) is warp 32, and
+        # NVIDIA is warp 32. Query the actual device when a live CUDA device is
+        # present, so a single multi-arch ROCm build is correct on both wave
+        # sizes. On CPU, a meta device (tracing/sharding/publish), or a
+        # CUDA-typed device on a host with no driver, get_device_properties
+        # raises, so fall back to the module-level DEFAULT_ASSOC in those cases.
+        self.cache_assoc: int = DEFAULT_ASSOC
+        if self.current_device.type == "cuda" and torch.cuda.is_available():
+            self.cache_assoc = torch.cuda.get_device_properties(
+                self.current_device
+            ).warp_size
+
         self.max_prefetch_depth = MAX_PREFETCH_DEPTH
         self.lxu_cache_locations_list = []
         self.lxu_cache_locations_empty = torch.empty(
@@ -3812,24 +3828,24 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             assert free_memory > 0
             cache_sets = (
                 int(cache_state.total_cache_hash_size * cache_load_factor)
-                + DEFAULT_ASSOC
+                + self.cache_assoc
                 - 1
-            ) // DEFAULT_ASSOC
+            ) // self.cache_assoc
             cache_sets = 1 if cache_sets == 0 else cache_sets
-            cache_size = cache_sets * DEFAULT_ASSOC * element_size * self.max_D_cache
+            cache_size = cache_sets * self.cache_assoc * element_size * self.max_D_cache
             if cache_size > free_memory:
                 cache_sets = (
                     int(1.0 * free_memory / self.max_D_cache / element_size)
-                    + DEFAULT_ASSOC
+                    + self.cache_assoc
                     - 1
-                ) // DEFAULT_ASSOC
+                ) // self.cache_assoc
         cache_load_factor = (
-            1.0 * cache_sets * DEFAULT_ASSOC / int(cache_state.total_cache_hash_size)
+            1.0 * cache_sets * self.cache_assoc / int(cache_state.total_cache_hash_size)
         )
         assert cache_sets > 0
         if cache_algorithm == CacheAlgorithm.LFU:
             assert cache_sets < 2**24 - 1
-        cache_size = cache_sets * DEFAULT_ASSOC * element_size * self.max_D_cache
+        cache_size = cache_sets * self.cache_assoc * element_size * self.max_D_cache
         self.log(
             f"Using on-device cache with admission algorithm "
             f"{cache_algorithm}, {cache_sets} sets, "
@@ -3862,14 +3878,17 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.register_buffer(
             "lxu_cache_state",
             torch.zeros(
-                cache_sets, DEFAULT_ASSOC, device=self.current_device, dtype=torch.int64
+                cache_sets,
+                self.cache_assoc,
+                device=self.current_device,
+                dtype=torch.int64,
             ).fill_(-1),
         )
         # Cache itself, not auxiliary size
         self.register_buffer(
             "lxu_cache_weights",
             torch.zeros(
-                cache_sets * DEFAULT_ASSOC,
+                cache_sets * self.cache_assoc,
                 self.max_D_cache,
                 device=self.current_device,
                 dtype=dtype,
@@ -3883,7 +3902,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 size=(
                     (self.total_cache_hash_size + 1,)
                     if cache_algorithm == CacheAlgorithm.LFU
-                    else (cache_sets, DEFAULT_ASSOC)
+                    else (cache_sets, self.cache_assoc)
                 ),
                 device=self.current_device,
                 dtype=torch.int64,
@@ -4028,7 +4047,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 "lxu_cache_locking_counter",
                 torch.zeros(
                     cache_sets,
-                    DEFAULT_ASSOC,
+                    self.cache_assoc,
                     device=self.current_device,
                     dtype=torch.int32,
                 ),

--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/cache_config.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/cache_config.py
@@ -30,13 +30,12 @@ from __future__ import annotations
 import enum
 from typing import NamedTuple
 
-import torch
-
 # Import from config module
 from fbgemm_gpu.tbe.config import EmbeddingLocation
 
-# Default associativity for the UVM cache (32 for CUDA, 64 for ROCm)
-DEFAULT_ASSOC: int = 32 if torch.version.hip is None else 64
+# Default cache associativity. Overridden to 64 in each module's
+# __init__ on AMD devices that have 64-lane waves.
+DEFAULT_ASSOC: int = 32
 
 
 class CacheAlgorithm(enum.Enum):

--- a/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_find.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_find.cu
@@ -124,9 +124,9 @@ std::pair<Tensor, Tensor> lfu_cache_find_uncached_cuda(
         FBGEMM_LAUNCH_KERNEL(
             (lfu_cache_find_uncached_kernel<index_t>),
             std::min(
-                div_round_up(N, kMaxThreads / kWarpSize),
+                div_round_up(N, kMaxThreads / kWarpSizeHost()),
                 get_max_thread_blocks_for_cache_kernels_()),
-            dim3(kWarpSize, kMaxThreads / kWarpSize),
+            dim3(kWarpSizeHost(), kMaxThreads / kWarpSizeHost()),
             0,
             at::cuda::getCurrentCUDAStream(),
             PTA_B(unique_indices, index_t, 1, 32),

--- a/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate.cu
@@ -200,9 +200,9 @@ void lfu_cache_insert_cuda(
         FBGEMM_LAUNCH_KERNEL(
             (lfu_cache_insert_kernel<emb_t, cache_t>),
             std::min(
-                div_round_up(N, kCacheMaxThreads / kWarpSize),
+                div_round_up(N, kCacheMaxThreads / kWarpSizeHost()),
                 get_max_thread_blocks_for_cache_kernels_()),
-            dim3(kWarpSize, kCacheMaxThreads / kWarpSize),
+            dim3(kWarpSizeHost(), kCacheMaxThreads / kWarpSizeHost()),
             0,
             at::cuda::getCurrentCUDAStream(),
             PTA_B(weights, emb_t, 1, 64),
@@ -247,15 +247,6 @@ DLL_PUBLIC void lfu_cache_populate_cuda(
       lfu_state);
 
   CUDA_DEVICE_GUARD(weights);
-
-#ifdef USE_ROCM
-  TORCH_CHECK(
-      at::cuda::warp_size() == 64,
-      __func__,
-      ": TBE cache requires warpSize 64 on ROCm (got ",
-      at::cuda::warp_size(),
-      "); warpSize 32 devices are not yet supported");
-#endif
 
   TORCH_CHECK(
       linear_cache_indices.numel() < std::numeric_limits<int32_t>::max());

--- a/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate_byte.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate_byte.cu
@@ -176,9 +176,9 @@ void lfu_cache_insert_byte_cuda(
         FBGEMM_LAUNCH_KERNEL(
             (lfu_cache_insert_byte_kernel<index_t>),
             std::min(
-                div_round_up(N, kCacheMaxThreads / kWarpSize),
+                div_round_up(N, kCacheMaxThreads / kWarpSizeHost()),
                 get_max_thread_blocks_for_cache_kernels_()),
-            dim3(kWarpSize, kCacheMaxThreads / kWarpSize),
+            dim3(kWarpSizeHost(), kCacheMaxThreads / kWarpSizeHost()),
             0,
             at::cuda::getCurrentCUDAStream(),
             PTA_B(weights, uint8_t, 1, 64),

--- a/fbgemm_gpu/src/split_embeddings_cache/lru_cache_find.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lru_cache_find.cu
@@ -214,7 +214,7 @@ lru_cache_find_uncached_cuda(
         constexpr int PREFETCH_KERNEL_MAX_BLOCKS = 8;
 
         auto grid_size = std::min(
-            div_round_up(N, kMaxThreads / kWarpSize),
+            div_round_up(N, kMaxThreads / kWarpSizeHost()),
             lock_cache_line ? PREFETCH_KERNEL_MAX_BLOCKS
                             : get_max_thread_blocks_for_cache_kernels_());
 
@@ -222,7 +222,7 @@ lru_cache_find_uncached_cuda(
         FBGEMM_LAUNCH_KERNEL(
             (lru_cache_find_uncached_kernel<index_t>),
             grid_size,
-            dim3(kWarpSize, kMaxThreads / kWarpSize),
+            dim3(kWarpSizeHost(), kMaxThreads / kWarpSizeHost()),
             0,
             at::cuda::getCurrentCUDAStream(),
             PTA_B(unique_indices, index_t, 1, 32),

--- a/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate.cu
@@ -226,7 +226,7 @@ void lru_cache_insert_cuda(
 
         const auto grid_size_uncapped = lock_cache_line
             ? div_round_up(get_device_sm_cnt_(), ALL_TO_PREFETCH_SM_RATIO)
-            : div_round_up(N, kMaxThreads / kWarpSize);
+            : div_round_up(N, kMaxThreads / kWarpSizeHost());
         // HIP enforces a hard limit of 2^32 total threads per launch.
         // lru_cache_insert_kernel grid-strides over n, so capping is
         // correctness-preserving. The lock_cache_line=true branch is already
@@ -240,7 +240,7 @@ void lru_cache_insert_cuda(
         FBGEMM_LAUNCH_KERNEL(
             (lru_cache_insert_kernel<emb_t, cache_t>),
             grid_size,
-            dim3(kWarpSize, kMaxThreads / kWarpSize),
+            dim3(kWarpSizeHost(), kMaxThreads / kWarpSizeHost()),
             0,
             at::cuda::getCurrentCUDAStream(),
             PTA_B(weights, emb_t, 1, 64),
@@ -310,15 +310,6 @@ DLL_PUBLIC void lru_cache_populate_cuda(
   }
 
   CUDA_DEVICE_GUARD(weights);
-
-#ifdef USE_ROCM
-  TORCH_CHECK(
-      at::cuda::warp_size() == 64,
-      __func__,
-      ": TBE cache requires warpSize 64 on ROCm (got ",
-      at::cuda::warp_size(),
-      "); warpSize 32 devices are not yet supported");
-#endif
 
   TORCH_CHECK(
       linear_cache_indices.numel() < std::numeric_limits<int32_t>::max());

--- a/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate_byte.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate_byte.cu
@@ -397,9 +397,9 @@ void lru_cache_insert_byte_cuda(
         FBGEMM_LAUNCH_KERNEL(
             (lru_cache_insert_byte_kernel<index_t>),
             std::min(
-                div_round_up(N, kMaxThreads / kWarpSize),
+                div_round_up(N, kMaxThreads / kWarpSizeHost()),
                 get_max_thread_blocks_for_cache_kernels_()),
-            dim3(kWarpSize, kMaxThreads / kWarpSize),
+            dim3(kWarpSizeHost(), kMaxThreads / kWarpSizeHost()),
             0,
             at::cuda::getCurrentCUDAStream(),
             PTA_B(weights, uint8_t, 1, 64),
@@ -462,9 +462,9 @@ void direct_mapped_lru_cache_insert_byte_cuda(
         FBGEMM_LAUNCH_KERNEL(
             (direct_mapped_lru_cache_insert_byte_kernel<index_t>),
             std::min(
-                div_round_up(N, kMaxThreads / kWarpSize),
+                div_round_up(N, kMaxThreads / kWarpSizeHost()),
                 get_max_thread_blocks_for_cache_kernels_()),
-            dim3(kWarpSize, kMaxThreads / kWarpSize),
+            dim3(kWarpSizeHost(), kMaxThreads / kWarpSizeHost()),
             0,
             at::cuda::getCurrentCUDAStream(),
             PTA_B(weights, uint8_t, 1, 64),

--- a/fbgemm_gpu/src/split_embeddings_cache/lxu_cache.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lxu_cache.cu
@@ -224,8 +224,8 @@ void lxu_cache_locking_counter_decrement_cuda(
 
   auto count = at::zeros_like(lxu_cache_locking_counter);
   const int32_t C = lxu_cache_locking_counter.size(0);
-  TORCH_CHECK(lxu_cache_locking_counter.size(1) == kWarpSize);
-  auto fd = FixedDivisor(kWarpSize);
+  TORCH_CHECK(lxu_cache_locking_counter.size(1) == kWarpSizeHost());
+  auto fd = FixedDivisor(kWarpSizeHost());
 
   const dim3 blocks(
       std::min(
@@ -245,9 +245,9 @@ void lxu_cache_locking_counter_decrement_cuda(
   FBGEMM_LAUNCH_KERNEL(
       lxu_cache_locking_counter_decrement_kernel,
       std::min(
-          div_round_up(C, kMaxThreads / kWarpSize),
+          div_round_up(C, kMaxThreads / kWarpSizeHost()),
           get_max_thread_blocks_for_cache_kernels_()),
-      dim3(kWarpSize, kMaxThreads / kWarpSize),
+      dim3(kWarpSizeHost(), kMaxThreads / kWarpSizeHost()),
       0,
       at::cuda::getCurrentCUDAStream(),
       PTA_B(lxu_cache_locking_counter, int32_t, 2, 32),
@@ -435,19 +435,6 @@ DLL_PUBLIC Tensor lxu_cache_lookup_cuda(
 
   CUDA_DEVICE_GUARD(linear_cache_indices);
 
-#ifdef USE_ROCM
-  // Cache kernels use kWarpSize as the stride for indexing cache rows.
-  // On warpSize 32 ROCm devices (e.g. gfx1100) this produces wrong
-  // addresses because DEFAULT_ASSOC (kWarpSize on host) is 64.
-  // D102579845 introduces kCacheAssoc to fix this; until then, guard.
-  TORCH_CHECK(
-      at::cuda::warp_size() == 64,
-      __func__,
-      ": TBE cache requires warpSize 64 on ROCm (got ",
-      at::cuda::warp_size(),
-      "); warpSize 32 devices are not yet supported");
-#endif
-
   const auto lxu_cache_locations =
       lxu_cache_locations_output.value_or(empty_like(
           linear_cache_indices,
@@ -459,7 +446,7 @@ DLL_PUBLIC Tensor lxu_cache_lookup_cuda(
     return lxu_cache_locations;
   }
 
-  const dim3 threads(kWarpSize, kMaxThreads / kWarpSize);
+  const dim3 threads(kWarpSizeHost(), kMaxThreads / kWarpSizeHost());
   const dim3 blocks(div_round_up(N, kMaxThreads));
 
   AT_DISPATCH_INDEX_TYPES(

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_embeddings_cache_cuda.cu
@@ -447,8 +447,8 @@ ssd_cache_populate_actions_cuda(
 
   FBGEMM_LAUNCH_DSA_KERNEL(
       ssd_cache_actions_insert_kernel,
-      div_round_up(N, kMaxThreads / kWarpSize),
-      dim3(kWarpSize, kMaxThreads / kWarpSize),
+      div_round_up(N, kMaxThreads / kWarpSizeHost()),
+      dim3(kWarpSizeHost(), kMaxThreads / kWarpSizeHost()),
       0,
       at::cuda::getCurrentCUDAStream(),
       PTA_B(lxu_cache_state, int64_t, 2, 32),
@@ -558,7 +558,7 @@ std::tuple<Tensor, Tensor> ssd_generate_row_addrs_cuda(
       lxu_cache_locations.options().dtype(at::kLong));
   const auto post_bwd_evicted_indices = at::empty_like(ssd_row_addrs);
 
-  constexpr auto kNumWarps = kMaxThreads / kWarpSize;
+  const auto kNumWarps = kMaxThreads / kWarpSizeHost();
   const auto cache_row_bytes =
       lxu_cache_weights.size(1) * lxu_cache_weights.element_size();
   const auto lxu_cache_weights_addr =
@@ -578,7 +578,7 @@ std::tuple<Tensor, Tensor> ssd_generate_row_addrs_cuda(
         FBGEMM_LAUNCH_KERNEL(
             (ssd_generate_row_addrs_kernel<index_t>),
             div_round_up(lxu_cache_locations.numel(), kNumWarps),
-            dim3(kWarpSize, kNumWarps),
+            dim3(kWarpSizeHost(), kNumWarps),
             0,
             at::cuda::getCurrentCUDAStream(),
             PTA_B(ssd_row_addrs, int64_t, 1, 32),
@@ -684,12 +684,12 @@ void ssd_update_row_addrs_cuda(
       reinterpret_cast<uint64_t>(inserted_ssd_weights_next.data_ptr());
   const auto cache_row_bytes =
       lxu_cache_weights.size(1) * lxu_cache_weights.element_size();
-  constexpr auto kNumWarps = kMaxThreads / kWarpSize;
+  const auto kNumWarps = kMaxThreads / kWarpSizeHost();
 
   FBGEMM_LAUNCH_KERNEL(
       (ssd_update_row_addrs_kernel),
       div_round_up(ssd_row_addrs_curr.numel(), kNumWarps),
-      dim3(kWarpSize, kNumWarps),
+      dim3(kWarpSizeHost(), kNumWarps),
       0,
       at::cuda::getCurrentCUDAStream(),
       PTA_B(ssd_row_addrs_curr, int64_t, 1, 32),

--- a/fbgemm_gpu/test/tbe/cache/cache_overflow_test.py
+++ b/fbgemm_gpu/test/tbe/cache/cache_overflow_test.py
@@ -22,6 +22,16 @@ from hypothesis import given, settings
 from ..common import assert_torch_equal, MAX_EXAMPLES
 from .cache_common import assert_cache, generate_cache_tbes, gpu_unavailable, VERBOSITY
 
+# TBE cache associativity equals the device warp size (64 on CDNA, 32 on RDNA
+# and NVIDIA). DEFAULT_ASSOC is the static fallback; query the actual device
+# so the cache-sizing math is correct on warpSize 32 ROCm devices.
+if torch.cuda.is_available():
+    WARP_SIZE: int = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).warp_size
+else:
+    WARP_SIZE = DEFAULT_ASSOC
+
 
 class CacheOverflowTest(unittest.TestCase):
     @unittest.skipIf(*gpu_unavailable)
@@ -45,7 +55,7 @@ class CacheOverflowTest(unittest.TestCase):
         # Weight and cache precisions are fixed to FP16
         element_size = 2
         # Adjust cache_sets based on free memory
-        while cache_sets * DEFAULT_ASSOC * D * element_size > free_memory:
+        while cache_sets * WARP_SIZE * D * element_size > free_memory:
             cache_sets = cache_sets // 10
 
         # Generate TBEs
@@ -62,7 +72,7 @@ class CacheOverflowTest(unittest.TestCase):
 
         # Accessing the last cache slot
         last_cache_set = cache_sets - 1
-        cache_idx = last_cache_set * DEFAULT_ASSOC + (DEFAULT_ASSOC - 1)
+        cache_idx = last_cache_set * WARP_SIZE + (WARP_SIZE - 1)
         if cache_idx * D < (2**31) - 1:
             logging.warning("test_cache_int32_overflow does not test int32 overflowing")
         else:

--- a/fbgemm_gpu/test/tbe/cache/cache_test.py
+++ b/fbgemm_gpu/test/tbe/cache/cache_test.py
@@ -50,6 +50,17 @@ from .cache_common import (
     VERBOSITY,
 )
 
+# TBE cache associativity equals the device warp size (64 on CDNA, 32 on RDNA
+# and NVIDIA). DEFAULT_ASSOC is the static fallback; query the actual device so
+# the direct-op cache tests below allocate cache geometry that matches the
+# kernel's per-arch kWarpSize row stride.
+if torch.cuda.is_available():
+    WARP_SIZE: int = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).warp_size
+else:
+    WARP_SIZE = DEFAULT_ASSOC
+
 
 @optests.generate_opcheck_tests(fast=True)
 class CacheTest(unittest.TestCase):
@@ -1044,7 +1055,7 @@ class CacheTest(unittest.TestCase):
 
         Block: dim3(kWarpSize, kMaxThreads/kWarpSize) = 1024 threads
         (kWarpSize = 32 on NVIDIA, 64 on AMD; cache associativity ==
-        kWarpSize == DEFAULT_ASSOC).
+        kWarpSize == the device warp size).
         Grid: div_round_up(N, kMaxThreads / kWarpSize). Total threads
         ~= N * kWarpSize. For N >= 2**27 this exceeds the HIP 2**32 limit
         on both warp sizes, causing FBGEMM_LAUNCH_KERNEL ->
@@ -1074,21 +1085,21 @@ class CacheTest(unittest.TestCase):
         # kernel grid size.
         linear_cache_indices = torch.arange(N, dtype=torch.int64, device=device)
         # Small cache -> tiny lxu_cache_state / weights / lru_state.
-        # Cache associativity == warp size (DEFAULT_ASSOC: 32 on NVIDIA,
-        # 64 on AMD). The insert kernel strides cache rows by kWarpSize, so
-        # the slot dimension MUST match or the kernel indexes out of bounds
-        # on wavefront-64 hardware.
+        # Cache associativity == the device warp size (32 on NVIDIA/RDNA, 64
+        # on CDNA). The insert kernel strides cache rows by kWarpSize, so the
+        # slot dimension MUST match or the kernel indexes out of bounds on
+        # wavefront-64 hardware.
         num_cache_sets = 1024
         lxu_cache_state = torch.full(
-            (num_cache_sets, DEFAULT_ASSOC), -1, dtype=torch.int64, device=device
+            (num_cache_sets, WARP_SIZE), -1, dtype=torch.int64, device=device
         )
         # Flat weights tensor for the single table.
         weights = torch.zeros(N * D, dtype=torch.float32, device=device)
         lxu_cache_weights = torch.zeros(
-            (num_cache_sets * DEFAULT_ASSOC, D), dtype=torch.float32, device=device
+            (num_cache_sets * WARP_SIZE, D), dtype=torch.float32, device=device
         )
         lru_state = torch.zeros(
-            (num_cache_sets, DEFAULT_ASSOC), dtype=torch.int64, device=device
+            (num_cache_sets, WARP_SIZE), dtype=torch.int64, device=device
         )
 
         torch.ops.fbgemm.lru_cache_populate(
@@ -1111,14 +1122,14 @@ class CacheTest(unittest.TestCase):
         )
         # Tier C structural invariants on the populated cache:
         # 1. shape preserved.
-        self.assertEqual(lxu_cache_state.shape, (num_cache_sets, DEFAULT_ASSOC))
-        # 2. Cache is fully populated. With N >> num_cache_sets * DEFAULT_ASSOC,
+        self.assertEqual(lxu_cache_state.shape, (num_cache_sets, WARP_SIZE))
+        # 2. Cache is fully populated. With N >> num_cache_sets * WARP_SIZE,
         #    every cache slot should hold a valid key (not the -1 sentinel)
         #    after the insert kernel runs. Pre-fix the kernel never runs;
         #    post-fix it grid-strides over all N indices and populates
         #    every slot.
         num_filled = int((lxu_cache_state != -1).sum().item())
-        self.assertEqual(num_filled, num_cache_sets * DEFAULT_ASSOC)
+        self.assertEqual(num_filled, num_cache_sets * WARP_SIZE)
         # 3. Every populated slot holds a valid linear cache index in
         #    [0, N). This catches "kernel wrote wrong key" bugs.
         populated = lxu_cache_state[lxu_cache_state != -1]

--- a/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
+++ b/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
@@ -27,27 +27,37 @@ from .cache_common import generate_cache_tbes, gpu_unavailable, optests
 
 VERBOSITY: Verbosity = Verbosity.verbose
 
+# TBE cache associativity equals the device warp size (64 on CDNA, 32 on
+# RDNA and NVIDIA). DEFAULT_ASSOC is the static fallback; query the actual
+# device so these cache-layout tests are correct on warpSize 32 ROCm devices.
+if torch.cuda.is_available():
+    WARP_SIZE: int = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).warp_size
+else:
+    WARP_SIZE = DEFAULT_ASSOC
+
 
 @optests.generate_opcheck_tests(fast=True)
 class LXUCacheTest(unittest.TestCase):
     @unittest.skipIf(*gpu_unavailable)
     @given(
-        # lxu_cache_lookup is a set-associative lookup whose kernel reads
-        # exactly kWarpSize (== DEFAULT_ASSOC) ways per set. Any other
-        # associativity makes the kernel read past the cache state row
-        # (out of bounds), which on ROCm wavefront64 yields spurious hits.
-        # The direct-mapped (associativity 1) path is a separate op,
-        # direct_mapped_lxu_cache_lookup, exercised end-to-end (cache_assoc=1)
-        # by nbit_cache_test.test_nbit_direct_mapped_uvm_cache_stats.
-        associativity=st.sampled_from([DEFAULT_ASSOC]),
+        associativity=st.sampled_from([1, WARP_SIZE]),
     )
     @settings(deadline=None)
     def test_lxu_cache_lookup(self, associativity: int) -> None:
         max_index: int = 8000
         # Use single cache set to avoid dealing with cache set hash algorithm.
-        lxu_cache_state_gpu = (
-            torch.arange(associativity, dtype=torch.int64).unsqueeze(0).cuda()
+        # The lookup kernel scans a full warp of ways per set, so the cache
+        # state row must be warpSize wide; `associativity` is how many ways are
+        # populated and the remainder are the empty sentinel (-1), matching how
+        # the real cache represents unpopulated ways. (A row narrower than the
+        # warp would make the kernel read past the row.)
+        lxu_cache_state_gpu = torch.full((1, WARP_SIZE), -1, dtype=torch.int64)
+        lxu_cache_state_gpu[0, :associativity] = torch.arange(
+            associativity, dtype=torch.int64
         )
+        lxu_cache_state_gpu = lxu_cache_state_gpu.cuda()
 
         # Testing all miss.
         linear_cache_indices_0 = (
@@ -113,7 +123,7 @@ class LXUCacheTest(unittest.TestCase):
         self,
         cache_sets: int,
     ) -> None:
-        warp_size = DEFAULT_ASSOC
+        warp_size = WARP_SIZE
         N = cache_sets * warp_size
         lxu_cache_locking_counter = torch.randint(
             low=1,
@@ -318,7 +328,7 @@ class LXUCacheTest(unittest.TestCase):
         cache_sets = int((E * T) * 0.2)
         lxu_cache_state = torch.zeros(
             cache_sets,
-            DEFAULT_ASSOC,
+            WARP_SIZE,
             device=torch.accelerator.current_accelerator(),
             dtype=torch.int64,
         ).fill_(-1)
@@ -351,7 +361,7 @@ class LXUCacheTest(unittest.TestCase):
             if c not in slots:
                 slots[c] = 0
             slot = slots[c]
-            if slot < DEFAULT_ASSOC:
+            if slot < WARP_SIZE:
                 lxu_cache_state[c][slot] = idx
             slots[c] = slot + 1
 

--- a/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
@@ -27,7 +27,6 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
-from fbgemm_gpu.split_table_batched_embeddings_ops_training import DEFAULT_ASSOC
 from fbgemm_gpu.tbe.utils import get_table_batched_offsets_from_dense
 from hypothesis import given, settings, Verbosity
 
@@ -265,7 +264,7 @@ class NBitCacheTest(unittest.TestCase):
         )
         cc1.fill_random_weights()
 
-        associativty = DEFAULT_ASSOC  # 32 for NVidia / 64 for AMD.
+        associativty = cc1.cache_assoc
         repetition = 17
         indices1 = torch.Tensor(
             [[list(range(0, associativty))] * repetition]


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2940

The TBE LRU/LFU/LXU cache hardcoded associativity (ways per set) to 64 on ROCm (`DEFAULT_ASSOC`) and guarded the populate/lookup kernels with `TORCH_CHECK(warp_size() == 64)`, refusing to run on wave32 ROCm devices. Cache associativity must equal the device warp size because one warp cooperatively scans the ways of a single set. The cache kernels are not templated on warp size: device code uses the per-arch `kWarpSize` constant for row indexing, so a multi-arch fat binary already contains correct per-arch device code. Only the host-allocated cache geometry was wrong.

Derive per-instance associativity from the running device (`torch.cuda.get_device_properties(dev).warp_size`) in the training and nbit inference modules, so cache-state tensors match the device kernel's per-arch indexing, and remove the wave64-only `TORCH_CHECK` guards. `DEFAULT_ASSOC` stays as the CPU/no-device fallback. Host-side cache kernel launch configs move to `kWarpSizeHost()`. The cache tests query the device warp size instead of assuming `DEFAULT_ASSOC`, and `lxu_cache_test` now also covers the direct-mapped (associativity 1) path.

Because `DEFAULT_ASSOC` no longer equals the device warp size on ROCm, `cache_test.py`'s `test_lru_cache_insert_large_grid` (which drives the low-level `lru_cache_populate` op directly and must allocate cache geometry matching the kernel's `kWarpSize` row stride) is updated to query the device warp size. Left unchanged it allocates a 32-wide cache on a wave64 device and the kernel, striding by 64, leaves half the slots unpopulated.

One deviation from the combined change (pytorch/FBGEMM#5804): in `ssd_cache_actions_insert_kernel`, the flat cache-slot index (`cache_set * kWarpSize + insert_slot`) and the conflict-miss stride are `__device__` code and must use the per-arch device constant `kWarpSize`. https://github.com/pytorch/FBGEMM/issues/5804 changed these to `kWarpSizeHost()`, which calls `at::cuda::warp_size()` -- a host-only function not callable from device code. It is masked on single-arch builds only because `kWarpSizeHost() == kWarpSize` there. These sites are kept as `kWarpSize`; only the host-side launch configs in that file use `kWarpSizeHost()`.

Third in the chain splitting pytorch/FBGEMM#5804 into reviewable pieces; stacked on https://github.com/pytorch/FBGEMM/issues/6031.

Authored with assistance from Claude (Anthropic).


Reviewed By: henrylhtsang

Differential Revision: D112940757

Pulled By: q10


