### PR TITLE
Fix HIP grid overflow in jagged_softmax (account for grid.y in cap) (#6038)

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
@@ -22,7 +22,7 @@
 namespace fbgemm_gpu::utils::cuda {
 
 /// Empirical multiplier on `#SMs` that gives a good grid-size cap across
-/// kernels: `max_blocks = MAX_THREAD_BLOCKS_FACTOR * #SMs`.
+/// kernels: `perf_block_cap = MAX_THREAD_BLOCKS_FACTOR * #SMs`.
 constexpr int32_t MAX_THREAD_BLOCKS_FACTOR = 64;
 
 /// The grid x-dimension is limited to 2^31 - 1 on both CUDA and HIP; a launch
@@ -93,13 +93,16 @@ inline uint32_t cap_grid_dim_x(
     return to_grid_dim(blocks_uncapped);
   }
 
-  const auto max_blocks = static_cast<int64_t>(
+  // Occupancy/perf heuristic (64 * #SMs), not a correctness bound: caps grid.x
+  // to a few waves per SM. Used directly by `Always` and as one of the caps in
+  // the ROCm overflow branch below.
+  const auto perf_block_cap = static_cast<int64_t>(
       MAX_THREAD_BLOCKS_FACTOR *
       at::cuda::getDeviceProperties(stream.device_index())
           ->multiProcessorCount);
 
   if (policy == BlockCapPolicy::Always) {
-    return to_grid_dim(std::min(blocks_uncapped, max_blocks));
+    return to_grid_dim(std::min(blocks_uncapped, perf_block_cap));
   }
 
   // policy == OverflowOnly
@@ -108,7 +111,14 @@ inline uint32_t cap_grid_dim_x(
   // kMaxThreadsPerLaunch` (the product can exceed int64 for large grids).
   if (threads_per_block > 0 &&
       blocks_uncapped > kMaxThreadsPerLaunch / threads_per_block) {
-    return to_grid_dim(std::min(blocks_uncapped, max_blocks));
+    // Also clamp grid.x so the *total* launch stays within HIP's 2^32 thread
+    // limit (perf_block_cap alone can exceed it when threads_per_block folds in
+    // other grid dims, e.g. a large grid.y). Safe because callers grid-stride.
+    const auto overflow_block_cap =
+        static_cast<int64_t>(kMaxThreadsPerLaunch / threads_per_block);
+    return to_grid_dim(
+        std::min(
+            blocks_uncapped, std::min(perf_block_cap, overflow_block_cap)));
   }
 #endif
   return to_grid_dim(blocks_uncapped);

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_backward.cu
@@ -105,16 +105,23 @@ Tensor jagged_softmax_backward_cuda(
   if (B > 0 && D > 0) {
     constexpr int THREADS_PER_BLOCK = 128;
     // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
-    // which silently wraps). jagged_softmax_backward_kernel grid-strides over
-    // `d` (`for (uint32_t d = blockIdx.x; d < D; d += gridDim.x)`), so capping
-    // is correctness-preserving. y is already clamped to kMaxBlockYDim;
-    // kernel additionally grid-strides over `b`.
-    // See: https://github.com/ROCm/hip/issues/2253
+    // which silently wraps). The launch is dim3(D, blocks_y) x
+    // THREADS_PER_BLOCK, so the total thread count is D * blocks_y *
+    // THREADS_PER_BLOCK. The y dimension must be included in the overflow
+    // check: a large D combined with a large blocks_y overflows even when D *
+    // THREADS_PER_BLOCK alone does not. Pass the full per-grid-x thread count
+    // (THREADS_PER_BLOCK * blocks_y) so cap_grid_dim_x clamps grid.x when the
+    // *total* launch would exceed 2^32. Capping grid.x is
+    // correctness-preserving because jagged_softmax_backward_kernel
+    // grid-strides over `d` (`for (uint32_t d = blockIdx.x; d < D; d +=
+    // gridDim.x)`) and over `b`. See: https://github.com/ROCm/hip/issues/2253
+    const auto blocks_y = static_cast<int32_t>(
+        std::min<int64_t>(B, static_cast<int64_t>(kMaxBlockYDim)));
     const auto blocks_x = utils::cuda::cap_grid_dim_x(
         static_cast<uint32_t>(D),
-        THREADS_PER_BLOCK,
+        static_cast<int64_t>(THREADS_PER_BLOCK) * blocks_y,
         at::cuda::getCurrentCUDAStream());
-    const dim3 grid(blocks_x, std::min((int32_t)B, (int32_t)kMaxBlockYDim), 1);
+    const dim3 grid(blocks_x, blocks_y, 1);
 
     AT_DISPATCH_INDEX_TYPES(
         offsets.scalar_type(), "jagged_softmax_backward_kernel_1", [&] {

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_forward.cu
@@ -128,16 +128,23 @@ Tensor jagged_softmax_forward_cuda(
   if (B > 0 && D > 0) {
     constexpr int THREADS_PER_BLOCK = 128;
     // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
-    // which silently wraps). jagged_softmax_kernel grid-strides over `d`
-    // (`for (uint32_t d = blockIdx.x; d < D; d += gridDim.x)`), so capping
-    // is correctness-preserving. y is already clamped to kMaxBlockYDim;
-    // kernel additionally grid-strides over `b`.
-    // See: https://github.com/ROCm/hip/issues/2253
+    // which silently wraps). The launch is dim3(D, blocks_y) x
+    // THREADS_PER_BLOCK, so the total thread count is D * blocks_y *
+    // THREADS_PER_BLOCK. The y dimension must be included in the overflow
+    // check: a large D combined with a large blocks_y overflows even when D *
+    // THREADS_PER_BLOCK alone does not. Pass the full per-grid-x thread count
+    // (THREADS_PER_BLOCK * blocks_y) so cap_grid_dim_x clamps grid.x when the
+    // *total* launch would exceed 2^32. Capping grid.x is
+    // correctness-preserving because jagged_softmax_kernel grid-strides over
+    // `d` (`for (uint32_t d = blockIdx.x; d < D; d += gridDim.x)`) and over
+    // `b`. See: https://github.com/ROCm/hip/issues/2253
+    const auto blocks_y = static_cast<int32_t>(
+        std::min<int64_t>(B, static_cast<int64_t>(kMaxBlockYDim)));
     const auto blocks_x = utils::cuda::cap_grid_dim_x(
         static_cast<uint32_t>(D),
-        THREADS_PER_BLOCK,
+        static_cast<int64_t>(THREADS_PER_BLOCK) * blocks_y,
         at::cuda::getCurrentCUDAStream());
-    const dim3 grid(blocks_x, std::min((int32_t)B, (int32_t)kMaxBlockYDim), 1);
+    const dim3 grid(blocks_x, blocks_y, 1);
 
     AT_DISPATCH_INDEX_TYPES(
         offsets.scalar_type(), "jagged_softmax_kernel_1", [&] {


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2941

test_jagged_softmax_{forward,backward}_large_grid (+ their opcheck variants) fail on
ROCm/MI300 with a HIP launch error. The existing grid-overflow guard for
jagged_softmax is incomplete in two ways:

1. Call site (jagged_softmax_{forward,backward}.cu): the launch is
   dim3(D, blocks_y) x THREADS_PER_BLOCK, but cap_grid_dim_x was passed only
   THREADS_PER_BLOCK as the per-grid-x thread count. So the overflow check saw
   D * 128 and missed the blocks_y (= min(B, 65535)) factor entirely. For
   D=20000, B=2047 the check computed 2.56M (< 2^32, no cap) while the real launch
   is 20000 * 2047 * 128 = 5.24e9 > 2^32 -> HIP rejects it. Fix: compute blocks_y
   first and pass THREADS_PER_BLOCK * blocks_y so the check reflects the full launch.

2. Utility (cuda_utilities.cuh, cap_grid_dim_x OverflowOnly): when overflow was
   detected it capped grid.x to max_blocks = 64 * #SMs, a *perf* heuristic that is
   not a *correctness* bound -- on MI300X (~304 CUs -> 19456) the capped launch
   19456 * 2047 * 128 still exceeds 2^32. Fix: also clamp to the overflow-safe
   maximum floor(UINT32_MAX / threads_per_block) so blocks_x * threads_per_block
   <= UINT32_MAX is guaranteed. This is backward-compatible: for existing callers
   with a small threads_per_block, the safe max is far above max_blocks so behavior
   is unchanged; it only tightens the cap when threads_per_block folds in extra
   grid dims (the overflowing case).

Capping grid.x is correctness-preserving because both kernels grid-stride over `d`
(`for (uint32_t d = blockIdx.x; d < D; d += gridDim.x)`) and over `b`.
CUDA is unaffected: the overflow logic is under `#ifdef USE_ROCM` and the extra
threads_per_block argument is `[[maybe_unused]]` on CUDA.

Reviewed By: henrylhtsang

Differential Revision: D112487674


