### PR TITLE
Add grid-stride + ROCm cap to recat_copy_async_kernel (#6039)

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/layout_transform_ops.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/layout_transform_ops.cuh
@@ -24,37 +24,38 @@ __global__ void recat_copy_async_kernel(
     const int64_t T,
     const int64_t B,
     const int64_t dim_sum) {
-  const auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
-  const auto b = b_t % B;
-  const auto t = b_t / B;
+  const auto b_t_start = blockIdx.x * blockDim.y + threadIdx.y;
+  const auto stride = gridDim.x * blockDim.y;
+  // Grid-stride loop over (b, t) pairs so the kernel remains correct when the
+  // host caps gridDim.x to satisfy the HIP 2^32 thread-per-launch limit.
+  for (int64_t b_t = b_t_start; b_t < B * T; b_t += stride) {
+    const auto b = b_t % B;
+    const auto t = b_t / B;
+    const auto dim_current = dim_sum_per_rank[t];
+    const auto tgt_base_addr = B * cum_dim_sum_per_rank[t];
+    const auto src_base_addr = cum_dim_sum_per_rank[t];
 
-  if (b_t >= B * T) {
-    return;
-  }
-  const auto dim_current = dim_sum_per_rank[t];
-  const auto tgt_base_addr = B * cum_dim_sum_per_rank[t];
-  const auto src_base_addr = cum_dim_sum_per_rank[t];
-
-  if (fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(
-          &sgo[tgt_base_addr + b * dim_current]) &&
-      fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(
-          &go[src_base_addr + b * dim_sum])) {
-    int32_t d_base = dim_current / 4 * 4;
-    for (int32_t d = threadIdx.x * 4; d < d_base; d += blockDim.x * 4) {
-      fbgemm_gpu::Vec4T<scalar_t>::copy(
-          &go[src_base_addr + b * dim_sum + d],
-          &sgo[tgt_base_addr + b * dim_current + d]);
-    }
-    // Use elementwise access for the last incomplete vector.
-    for (int32_t d_left = threadIdx.x; d_base + d_left < dim_current;
-         d_left += blockDim.x) {
-      sgo[tgt_base_addr + b * dim_current + d_base + d_left] =
-          go[src_base_addr + b * dim_sum + d_base + d_left];
-    }
-  } else {
-    for (int32_t d = threadIdx.x; d < dim_current; d += blockDim.x) {
-      sgo[tgt_base_addr + b * dim_current + d] =
-          go[src_base_addr + b * dim_sum + d];
+    if (fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(
+            &sgo[tgt_base_addr + b * dim_current]) &&
+        fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(
+            &go[src_base_addr + b * dim_sum])) {
+      int32_t d_base = dim_current / 4 * 4;
+      for (auto d = threadIdx.x * 4; d < d_base; d += blockDim.x * 4) {
+        fbgemm_gpu::Vec4T<scalar_t>::copy(
+            &go[src_base_addr + b * dim_sum + d],
+            &sgo[tgt_base_addr + b * dim_current + d]);
+      }
+      // Use elementwise access for the last incomplete vector.
+      for (auto d_left = threadIdx.x; d_base + d_left < dim_current;
+           d_left += blockDim.x) {
+        sgo[tgt_base_addr + b * dim_current + d_base + d_left] =
+            go[src_base_addr + b * dim_sum + d_base + d_left];
+      }
+    } else {
+      for (auto d = threadIdx.x; d < dim_current; d += blockDim.x) {
+        sgo[tgt_base_addr + b * dim_current + d] =
+            go[src_base_addr + b * dim_sum + d];
+      }
     }
   }
 }
@@ -71,10 +72,9 @@ __global__ void permute_pooled_embs_kernel(
     const int64_t B,
     const int64_t T,
     const int64_t dim_sum) {
-  const int32_t t =
-      blockIdx.x * (blockDim.x / warpSize) + threadIdx.x / warpSize;
-  const int32_t b = blockIdx.y + gridDim.y * blockIdx.z;
-  const int32_t idx = threadIdx.x % warpSize;
+  const auto t = blockIdx.x * (blockDim.x / warpSize) + threadIdx.x / warpSize;
+  const auto b = blockIdx.y + gridDim.y * blockIdx.z;
+  const auto idx = threadIdx.x % warpSize;
   const int32_t blk = warpSize;
   if (b >= B) {
     return;

--- a/fbgemm_gpu/src/layout_transform_ops/layout_transform_ops.cu
+++ b/fbgemm_gpu/src/layout_transform_ops/layout_transform_ops.cu
@@ -21,6 +21,7 @@
 #include <torch/library.h>
 #include "fbgemm_gpu/layout_transform_ops.cuh"
 #include "fbgemm_gpu/sparse_ops.h"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 #include "fbgemm_gpu/utils/dispatch_macros.h"
 #include "fbgemm_gpu/utils/kernel_launcher.cuh"
 #include "fbgemm_gpu/utils/ops_utils.h"
@@ -140,10 +141,17 @@ Tensor recat_embedding_grad_output_mixed_D_batch_cuda(
   const dim3 threads(
       fbgemm_gpu::kWarpSizeHost(),
       fbgemm_gpu::kMaxThreads / fbgemm_gpu::kWarpSizeHost());
-  const dim3 blocks(
+  // HIP enforces a hard limit of 2^32 total threads per launch.
+  // recat_copy_async_kernel grid-strides over (b, t), so capping is
+  // correctness-preserving.
+  // See: https://github.com/ROCm/hip/issues/2253
+  const auto blocks_x = utils::cuda::cap_grid_dim_x(
       fbgemm_gpu::div_round_up(
           (B_local * dim_num),
-          fbgemm_gpu::kMaxThreads / fbgemm_gpu::kWarpSizeHost()));
+          fbgemm_gpu::kMaxThreads / fbgemm_gpu::kWarpSizeHost()),
+      fbgemm_gpu::kMaxThreads,
+      at::cuda::getCurrentCUDAStream());
+  const dim3 blocks(blocks_x);
 
   FBGEMM_DISPATCH_FLOAT_AND_HALF(
       grad_output.scalar_type(), "recat_embedding_gradients", [&] {

--- a/fbgemm_gpu/test/layout_transform_ops_test.py
+++ b/fbgemm_gpu/test/layout_transform_ops_test.py
@@ -19,10 +19,10 @@ try:
     from fbgemm_gpu import open_source  # noqa: F401
 
     # pyre-ignore[21]
-    from test_utils import gpu_unavailable
+    from test_utils import gpu_memory_lt_gb, gpu_unavailable
 
 except Exception:
-    from fbgemm_gpu.test.test_utils import gpu_unavailable
+    from fbgemm_gpu.test.test_utils import gpu_memory_lt_gb, gpu_unavailable
 
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
 
@@ -187,6 +187,80 @@ class LayoutTransformOpsTest(unittest.TestCase):
         torch.testing.assert_close(
             sharded_grad_output_impl.cpu(), sharded_grad_output.cpu()
         )
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-ignore[56]: Pyre cannot infer the type of `gpu_memory_lt_gb`
+    # through the open-source / non-open-source import branch above.
+    @unittest.skipIf(*gpu_memory_lt_gb(8))
+    def test_recat_embedding_grad_output_mixed_D_batch_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in recat_copy_async_kernel
+        (include/fbgemm_gpu/layout_transform_ops.cuh).
+
+        Block: dim3(kWarpSize=32, kMaxThreads/kWarpSize=32) = 1024 threads.
+        Grid: div_round_up(B_local * dim_num, 32). Total threads ~=
+        B_local * dim_num * kWarpSize. For B_local * dim_num > 2**27,
+        total threads exceed the HIP 2**32 limit, tripping
+        KernelLauncher::checkThreadCountNotExceeded on ROCm.
+
+        Pre-fix: AMD launch fails. Post-fix: passes (kernel grid-strides).
+        """
+        B_local = 8
+        dim_num = (1 << 24) + 1  # B_local * dim_num = 2**27 + 8 > 2**27
+        # All-zero dim_sum_per_rank means each rank contributes 0 elements,
+        # so per-tile copy work inside the kernel is empty. grad_output
+        # therefore has width 0 and the output tensor is also empty.
+        dim_sum_per_rank_tensor = torch.zeros(
+            dim_num, dtype=torch.int64, device=torch.accelerator.current_accelerator()
+        )
+        cumsum_dim_sum_per_rank_tensor = torch.zeros(
+            dim_num, dtype=torch.int64, device=torch.accelerator.current_accelerator()
+        )
+        grad_output = torch.zeros(
+            (B_local, 0),
+            dtype=torch.float32,
+            device=torch.accelerator.current_accelerator(),
+        )
+        sharded_grad_output = (
+            torch.ops.fbgemm.recat_embedding_grad_output_mixed_D_batch(
+                grad_output,
+                dim_sum_per_rank_tensor,
+                cumsum_dim_sum_per_rank_tensor,
+            )
+        )
+        self.assertEqual(sharded_grad_output.numel(), grad_output.numel())
+
+        # Tier-B Python-reference correctness check at small scale.
+        # Sentinel non-zero values force the kernel to do non-trivial copies.
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        small_B = 4
+        small_dim_sum_per_rank = [3, 5, 2]  # W = 3 ranks
+        small_total_D = sum(small_dim_sum_per_rank)
+        small_grad_output = torch.arange(
+            small_B * small_total_D, dtype=torch.float32, device=device
+        ).reshape(small_B, small_total_D)
+        small_dim_sum_tensor = torch.tensor(
+            small_dim_sum_per_rank, dtype=torch.int64, device=device
+        )
+        small_cumsum_tensor = torch.tensor(
+            [0] + list(np.cumsum(small_dim_sum_per_rank)[:-1]),
+            dtype=torch.int64,
+            device=device,
+        )
+
+        # Python reference: split grad_output column-wise per rank, then
+        # concatenate the per-rank flattened views.
+        ref_outputs_by_rank = small_grad_output.split(small_dim_sum_per_rank, dim=1)
+        ref_sharded = torch.cat(
+            [g.contiguous().view(-1) for g in ref_outputs_by_rank], dim=0
+        )
+
+        small_sharded = torch.ops.fbgemm.recat_embedding_grad_output_mixed_D_batch(
+            small_grad_output,
+            small_dim_sum_tensor,
+            small_cumsum_tensor,
+        )
+        torch.testing.assert_close(small_sharded, ref_sharded)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:

The audit at
/home/bensonma415/.llms/plans/permute_metric_layout_etc_rocm_grid_overflow_audit.plan.md
flagged `recat_copy_async_kernel` (Tier-2): the saturating dimension is
`gridDim.x`, and the kernel uses an early `if (b_t >= B * T) return`
bail-out that assumes the full grid is launched. On ROCm,
`KernelLauncher::checkThreadCountNotExceeded` (under `#ifdef USE_ROCM` in
`FBGEMM_LAUNCH_KERNEL`) fires a `TORCH_CHECK` once total threads exceed
2^32 (HIP enforces a hard limit; NVIDIA silently wraps).

This diff does the standard Tier-2 pair:

1. Kernel-side (`include/fbgemm_gpu/layout_transform_ops.cuh`): convert
   the `(b_t)` index from a single-pass early-return into a 2D-block
   grid-stride loop with stride `gridDim.x * blockDim.y` and bound
   `B * T`. All per-iteration registers (`b`, `t`, `dim_current`,
   `tgt_base_addr`, `src_base_addr`) are re-derived inside the loop
   body. No `__shared__`, `__syncthreads()`, or warp-shuffle
   dependencies, so the transform is mechanically safe. Reference pattern:
   `permute_2D_data_kernel` (sparse_permute_2d.cu:36).

2. Host-side (`src/layout_transform_ops/layout_transform_ops.cu`): apply
   the canonical `#ifdef USE_ROCM / std::min(blocks_x_uncapped,
   get_max_thread_blocks(stream))` cap to `gridDim.x`. Block dim
   (`dim3(kWarpSize, kMaxThreads/kWarpSize)`) is unchanged.

Parent fixes:
- D104903707 (sparse_permute_1d/2d Tier-1+2)
- D104937969 (sparse_block_bucketize_features Tier-2)

Reviewed By: cthi

Differential Revision: D105352349


