### PR TITLE
Add grid-stride + ROCm cap to permute_multi_embs_kernel (#6040)

### DIFF
--- a/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
@@ -17,6 +17,7 @@
 
 #include "fbgemm_gpu/permute_multi_embedding_function.h"
 #include "fbgemm_gpu/utils/cuda_prelude.cuh"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 #include "fbgemm_gpu/utils/kernel_launcher.cuh"
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
 #include "fbgemm_gpu/utils/vec4.cuh"
@@ -41,88 +42,90 @@ __global__ void permute_multi_embs_kernel(
     const int32_t permute_size) {
   // workers in a warp handle exact one permute (of a feature/key)
   const auto worker_id = threadIdx.x;
-  const auto permute_id = threadIdx.y + blockIdx.x * blockDim.y;
+  const auto permute_id_start = threadIdx.y + blockIdx.x * blockDim.y;
+  const auto permute_stride = gridDim.x * blockDim.y;
   const auto batch_id = blockIdx.y + gridDim.y * blockIdx.z;
   if (batch_id >= batch_size) {
     return;
   }
-  if (permute_id >= permute_size) {
-    return;
-  }
-
-  // parse permutes
-  int32_t in_tensor, out_tensor, in_offset, out_offset, length, next;
-  int32_t* __restrict__ pp = permutes[permute_id].data();
-  if (reverse_permute) {
-    out_tensor = pp[PermuteParam::in_tensor];
-    in_tensor = pp[PermuteParam::out_tensor];
-    out_offset = pp[PermuteParam::in_offset];
-    in_offset = pp[PermuteParam::out_offset];
-  } else {
-    in_tensor = pp[PermuteParam::in_tensor];
-    out_tensor = pp[PermuteParam::out_tensor];
-    in_offset = pp[PermuteParam::in_offset];
-    out_offset = pp[PermuteParam::out_offset];
-  }
-  length = pp[PermuteParam::length];
-  next = pp[PermuteParam::next];
-
-  if (worker_id >= length) {
-    return;
-  }
-  if (reverse_permute && next < 0) {
-    return;
-  }
-
-  // locate the batch_id
-  const auto in_length = in_lengths[in_tensor];
-  // Sometimes batch_id * length can go beyond 32-bit int (e.g., 3900 * 654060)
-  // so cast them to int64_t.
-  const scalar_t* __restrict__ input_ptr =
-      reinterpret_cast<const scalar_t*>(inputs[in_tensor]) +
-      static_cast<int64_t>(batch_id) * static_cast<int64_t>(in_length) +
-      in_offset;
-
-  const auto out_length = out_lengths[out_tensor];
-  scalar_t* __restrict__ output_ptr =
-      reinterpret_cast<scalar_t*>(outputs[out_tensor]) +
-      static_cast<int64_t>(batch_id) * static_cast<int64_t>(out_length) +
-      out_offset;
-
-  if (fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(output_ptr) &&
-      fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(input_ptr)) {
-    constexpr int32_t vec_size = 4;
-    const int32_t loop_end = round_down(length, vec_size);
-    for (int32_t i = worker_id * vec_size; i < loop_end;
-         i += blockDim.x * vec_size) {
-      fbgemm_gpu::Vec4T<scalar_t>::copy(&input_ptr[i], &output_ptr[i]);
+  // Grid-stride loop over permute_id so the kernel remains correct when the
+  // host caps gridDim.x to satisfy the HIP 2^32 thread-per-launch limit.
+  for (int32_t permute_id = permute_id_start; permute_id < permute_size;
+       permute_id += permute_stride) {
+    // parse permutes
+    int32_t in_tensor, out_tensor, in_offset, out_offset, length, next;
+    int32_t* __restrict__ pp = permutes[permute_id].data();
+    if (reverse_permute) {
+      out_tensor = pp[PermuteParam::in_tensor];
+      in_tensor = pp[PermuteParam::out_tensor];
+      out_offset = pp[PermuteParam::in_offset];
+      in_offset = pp[PermuteParam::out_offset];
+    } else {
+      in_tensor = pp[PermuteParam::in_tensor];
+      out_tensor = pp[PermuteParam::out_tensor];
+      in_offset = pp[PermuteParam::in_offset];
+      out_offset = pp[PermuteParam::out_offset];
     }
-    // Use elementwise access for the last incomplete vector.
-    for (auto i = loop_end + worker_id; i < length; i += blockDim.x) {
-      output_ptr[i] = input_ptr[i];
-    }
-  } else { // Fallback if not aligned.
-    for (auto i = worker_id; i < length; i += blockDim.x) {
-      output_ptr[i] = input_ptr[i];
-    }
-  }
-
-  // for reverse_permute (backward) with next
-  while (reverse_permute && next > 0 && next < permute_size) {
-    int32_t* __restrict__ pp = permutes[next].data();
-    in_tensor = pp[PermuteParam::out_tensor];
-    in_offset = pp[PermuteParam::out_offset];
     length = pp[PermuteParam::length];
-    next = -pp[PermuteParam::next];
+    next = pp[PermuteParam::next];
 
+    if (worker_id >= length) {
+      continue;
+    }
+    if (reverse_permute && next < 0) {
+      continue;
+    }
+
+    // locate the batch_id
     const auto in_length = in_lengths[in_tensor];
-    const scalar_t* input_ptr =
+    // Sometimes batch_id * length can go beyond 32-bit int (e.g., 3900 *
+    // 654060) so cast them to int64_t.
+    const scalar_t* __restrict__ input_ptr =
         reinterpret_cast<const scalar_t*>(inputs[in_tensor]) +
         static_cast<int64_t>(batch_id) * static_cast<int64_t>(in_length) +
         in_offset;
 
-    for (auto i = worker_id; i < length; i += blockDim.x) {
-      output_ptr[i] += input_ptr[i];
+    const auto out_length = out_lengths[out_tensor];
+    scalar_t* __restrict__ output_ptr =
+        reinterpret_cast<scalar_t*>(outputs[out_tensor]) +
+        static_cast<int64_t>(batch_id) * static_cast<int64_t>(out_length) +
+        out_offset;
+
+    if (fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(output_ptr) &&
+        fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(input_ptr)) {
+      constexpr int32_t vec_size = 4;
+      const int32_t loop_end = round_down(length, vec_size);
+      for (int32_t i = worker_id * vec_size; i < loop_end;
+           i += blockDim.x * vec_size) {
+        fbgemm_gpu::Vec4T<scalar_t>::copy(&input_ptr[i], &output_ptr[i]);
+      }
+      // Use elementwise access for the last incomplete vector.
+      for (auto i = loop_end + worker_id; i < length; i += blockDim.x) {
+        output_ptr[i] = input_ptr[i];
+      }
+    } else { // Fallback if not aligned.
+      for (auto i = worker_id; i < length; i += blockDim.x) {
+        output_ptr[i] = input_ptr[i];
+      }
+    }
+
+    // for reverse_permute (backward) with next
+    while (reverse_permute && next > 0 && next < permute_size) {
+      int32_t* __restrict__ pp = permutes[next].data();
+      in_tensor = pp[PermuteParam::out_tensor];
+      in_offset = pp[PermuteParam::out_offset];
+      length = pp[PermuteParam::length];
+      next = -pp[PermuteParam::next];
+
+      const auto in_length = in_lengths[in_tensor];
+      const scalar_t* input_ptr =
+          reinterpret_cast<const scalar_t*>(inputs[in_tensor]) +
+          static_cast<int64_t>(batch_id) * static_cast<int64_t>(in_length) +
+          in_offset;
+
+      for (auto i = worker_id; i < length; i += blockDim.x) {
+        output_ptr[i] += input_ptr[i];
+      }
     }
   }
 }
@@ -275,8 +278,16 @@ std::vector<Tensor> permute_multi_embedding_function_gpu(
       fbgemm_gpu::kMaxThreads / fbgemm_gpu::kWarpSizeHost();
   const int32_t max_grid_dim = 32768; // The CUDA maximum is 65535, not 1<<N.
   const dim3 block_dim(fbgemm_gpu::kWarpSizeHost(), warp_per_block);
-  const dim3 grid_dim(
+  // HIP enforces a hard limit of 2^32 total threads per launch.
+  // permute_multi_embs_kernel grid-strides over permute_id, so capping is
+  // correctness-preserving. y/z dims are already bounded by max_grid_dim.
+  // See: https://github.com/ROCm/hip/issues/2253
+  const auto blocks_x = utils::cuda::cap_grid_dim_x(
       fbgemm_gpu::div_round_up(permute_size, warp_per_block),
+      fbgemm_gpu::kMaxThreads,
+      at::cuda::getCurrentCUDAStream());
+  const dim3 grid_dim(
+      blocks_x,
       std::min(static_cast<int32_t>(batch_size), max_grid_dim),
       (batch_size + max_grid_dim - 1) / max_grid_dim);
 

--- a/fbgemm_gpu/test/permute/permute_multi_embedding_ops_test.py
+++ b/fbgemm_gpu/test/permute/permute_multi_embedding_ops_test.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+# pyre-ignore-all-errors[56]
+
+import unittest
+
+import torch
+
+try:
+    # pyre-ignore[21]
+    from fbgemm_gpu import open_source  # noqa: F401
+
+    # pyre-ignore[21]
+    from test_utils import gpu_memory_lt_gb, gpu_unavailable
+except Exception:
+    from fbgemm_gpu.test.test_utils import gpu_memory_lt_gb, gpu_unavailable
+
+    torch.ops.load_library(
+        "//deeplearning/fbgemm/fbgemm_gpu:permute_multi_embedding_ops_gpu"
+    )
+    torch.ops.load_library(
+        "//deeplearning/fbgemm/fbgemm_gpu:permute_multi_embedding_ops_cpu"
+    )
+
+
+# permutes tensor schema (matching PermuteParam enum in
+# permute_multi_embedding_ops.cu): each row is
+#   [in_tensor, out_tensor, in_offset, out_offset, length, next].
+
+PERMUTES_DTYPE: torch.dtype = torch.int32
+SHAPES_DTYPE: torch.dtype = torch.int32
+
+
+class PermuteMultiEmbeddingOpsTest(unittest.TestCase):
+    @unittest.skipIf(*gpu_unavailable)
+    def test_permute_multi_embedding_smoke(self) -> None:
+        """Small-input correctness regression. Gates the kernel-side
+        grid-stride transformation against breakage on small inputs."""
+        device = torch.accelerator.current_accelerator()
+        batch_size = 4
+        in_lengths = [4, 8]
+        out_lengths = [4, 8]
+
+        permutes = torch.tensor(
+            [
+                [0, 0, 0, 0, 4, -1],
+                [1, 1, 0, 0, 8, -1],
+            ],
+            dtype=PERMUTES_DTYPE,
+            device=device,
+        )
+        in_shapes = torch.tensor(in_lengths, dtype=SHAPES_DTYPE, device=device)
+        out_shapes = torch.tensor(out_lengths, dtype=SHAPES_DTYPE, device=device)
+
+        pooled_embs = [
+            torch.arange(batch_size * length, dtype=torch.float32, device=device)
+            .view(batch_size, length)
+            .contiguous()
+            for length in in_lengths
+        ]
+
+        outputs = torch.ops.fbgemm.permute_multi_embedding(
+            pooled_embs,
+            permutes,
+            in_shapes,
+            out_shapes,
+            out_lengths,
+        )
+
+        self.assertEqual(len(outputs), 2)
+        self.assertEqual(outputs[0].shape, (batch_size, out_lengths[0]))
+        self.assertEqual(outputs[1].shape, (batch_size, out_lengths[1]))
+        torch.testing.assert_close(outputs[0], pooled_embs[0])
+        torch.testing.assert_close(outputs[1], pooled_embs[1])
+
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(4))
+    def test_permute_multi_embedding_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in permute_multi_embs_kernel
+        (src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu).
+
+        Block: dim3(kWarpSize=32, kMaxThreads/kWarpSize=32) = 1024 threads.
+        Grid x = div_round_up(permute_size, 32). Grid y = batch_size capped
+        at max_grid_dim=32768. With permute_size = 2**22 + 1 and
+        batch_size = 32, total threads = ceil((2**22+1)/32) * 32 * 1024
+        > 2**32, tripping KernelLauncher::checkThreadCountNotExceeded on
+        ROCm pre-fix.
+
+        Pre-fix: AMD launch fails. Post-fix: passes (kernel grid-strides
+        over permute_id).
+
+        All-zero permutes (length=0, next=-1) make the inner copy work
+        bounded. We still exercise the saturating gridDim.x path.
+        """
+        device = torch.accelerator.current_accelerator()
+        permute_size = (1 << 22) + 1
+        batch_size = 32
+        in_lengths = [1]
+        out_lengths = [1]
+
+        permutes = torch.zeros((permute_size, 6), dtype=PERMUTES_DTYPE, device=device)
+        # next = -1 disables the reverse_permute follow-on chain
+        permutes[:, 5] = -1
+        in_shapes = torch.tensor(in_lengths, dtype=SHAPES_DTYPE, device=device)
+        out_shapes = torch.tensor(out_lengths, dtype=SHAPES_DTYPE, device=device)
+
+        pooled_embs = [
+            torch.zeros(
+                (batch_size, in_lengths[0]),
+                dtype=torch.float32,
+                device=device,
+            )
+        ]
+
+        outputs = torch.ops.fbgemm.permute_multi_embedding(
+            pooled_embs,
+            permutes,
+            in_shapes,
+            out_shapes,
+            out_lengths,
+        )
+
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(outputs[0].shape, (batch_size, out_lengths[0]))
+
+        # Tier-A CPU-oracle correctness check at small scale with
+        # non-trivial permutes (length > 0). The smoke test above covers
+        # identity permutes; this section exercises the full grid-stride
+        # path with non-trivial copy work.
+        small_batch = 4
+        small_in_lengths = [4, 8]
+        small_out_lengths = [4, 8]
+        small_permutes = torch.tensor(
+            [
+                [0, 0, 0, 0, 4, -1],
+                [1, 1, 0, 0, 8, -1],
+            ],
+            dtype=PERMUTES_DTYPE,
+        )
+        small_in_shapes = torch.tensor(small_in_lengths, dtype=SHAPES_DTYPE)
+        small_out_shapes = torch.tensor(small_out_lengths, dtype=SHAPES_DTYPE)
+        small_pooled_cpu = [
+            torch.arange(small_batch * length, dtype=torch.float32)
+            .view(small_batch, length)
+            .contiguous()
+            for length in small_in_lengths
+        ]
+        out_cpu = torch.ops.fbgemm.permute_multi_embedding(
+            small_pooled_cpu,
+            small_permutes,
+            small_in_shapes,
+            small_out_shapes,
+            small_out_lengths,
+        )
+        out_gpu = torch.ops.fbgemm.permute_multi_embedding(
+            [t.to(device) for t in small_pooled_cpu],
+            small_permutes.to(device),
+            small_in_shapes.to(device),
+            small_out_shapes.to(device),
+            small_out_lengths,
+        )
+        self.assertEqual(len(out_gpu), len(out_cpu))
+        for cpu_t, gpu_t in zip(out_cpu, out_gpu):
+            torch.testing.assert_close(gpu_t.cpu(), cpu_t)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2943


The audit at
/home/bensonma415/.llms/plans/permute_metric_layout_etc_rocm_grid_overflow_audit.plan.md
flagged `permute_multi_embs_kernel` (Tier-2): the saturating dimension
is `gridDim.x` (one warp per permute_id), and the kernel uses an early
`if (permute_id >= permute_size) return` bail-out that assumes the full
grid is launched. On ROCm,
`KernelLauncher::checkThreadCountNotExceeded` (under `#ifdef USE_ROCM`
in `FBGEMM_LAUNCH_KERNEL`) fires a `TORCH_CHECK` once total threads
exceed 2^32 (HIP enforces a hard limit; NVIDIA silently wraps).

This diff does the standard Tier-2 pair:

1. Kernel-side
   (`src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu`):
   convert the `permute_id` axis from a single-pass early-return into a
   2D-block grid-stride loop with stride `gridDim.x * blockDim.y` and
   bound `permute_size`. All per-iteration registers are re-derived
   inside the loop body (`in_tensor`, `out_tensor`, `in_offset`,
   `out_offset`, `length`, `next`, `pp`, `in_length`,
   `input_ptr`, `out_length`, `output_ptr`). The early-return on
   `worker_id >= length` and the reverse_permute `next < 0` short-circuit
   become `continue` (skip to next permute_id) instead of `return` so
   subsequent strides are still serviced. The reverse_permute follow-on
   chain (`while (reverse_permute && next > 0 ...)`) is per-permute_id
   private so it is reset on each iteration via re-derivation at the
   loop top. `(blockIdx.y, blockIdx.z)` mapping for `batch_id` is kept
   as-is — the existing manual `max_grid_dim = 32768` host-side cap
   protects y/z. No `__shared__`, `__syncthreads()`, or warp shuffles.
   Reference pattern: `permute_2D_data_kernel` (sparse_permute_2d.cu:36).

2. Host-side: apply the canonical
   `#ifdef USE_ROCM / std::min(blocks_x_uncapped, get_max_thread_blocks(stream))`
   cap to `grid_dim.x` (the `permute_size / warp_per_block` axis)
   only. y/z dims unchanged.

Plus a new test file
`test/permute/permute_multi_embedding_ops_test.py` (didn't exist
before — kernel was previously only exercised via
`bench/jagged_tensor_benchmark.py` and out-of-tree MTIA tests). It
contains a small-input correctness smoke test gating the kernel-side
change, and a large-grid repro test sized so total threads on ROCm
pre-fix would exceed 2^32 and trip
`KernelLauncher::checkThreadCountNotExceeded`. The corresponding BUCK
target is added.

Parent fixes:
- D104903707, D104937969 (sparse_ops Tier-2 cap pattern)
- D105352349 (Tier-2 stack: recat_copy_async_kernel)

Reviewed By: henrylhtsang

Differential Revision: D105353645


