### PR TITLE
Add grid-stride + ROCm cap to permute_pooled_embs_kernel

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/layout_transform_ops.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/layout_transform_ops.cuh
@@ -72,46 +72,54 @@ __global__ void permute_pooled_embs_kernel(
     const int64_t B,
     const int64_t T,
     const int64_t dim_sum) {
-  const auto t = blockIdx.x * (blockDim.x / warpSize) + threadIdx.x / warpSize;
+  const auto t_start =
+      blockIdx.x * (blockDim.x / warpSize) + threadIdx.x / warpSize;
+  const auto t_stride = gridDim.x * (blockDim.x / warpSize);
   const auto b = blockIdx.y + gridDim.y * blockIdx.z;
   const auto idx = threadIdx.x % warpSize;
   const int32_t blk = warpSize;
   if (b >= B) {
     return;
   }
-  if (t >= T) {
-    return;
-  }
-  const int64_t permute_idx = permute_list[t];
-  const int64_t input_dim_start = offset_dim_list[permute_idx];
-  const int64_t input_dim_end = offset_dim_list[permute_idx + 1];
-  const int64_t cur_dim = input_dim_end - input_dim_start;
-  if (idx >= cur_dim) {
-    return;
-  }
-  // Apply the offsets on B dimension.
-  go += b * dim_sum;
-  // Last index in inv_offset_dim_list will contain output size. Use
-  // offset_dim_list in the case of backward()
-  sgo += b * max(inv_offset_dim_list[T], offset_dim_list[T]);
-  const int64_t sgo_offset = inv_offset_dim_list[t];
-  // Need to check alignment before using vector code path.
-  if (fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(&sgo[sgo_offset]) &&
-      fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(
-          &go[input_dim_start])) {
-    const int32_t vec_size = 4;
-    const int32_t loop_end = cur_dim / (vec_size) * (vec_size);
-    for (int32_t i = idx * vec_size; i < loop_end; i += blk * vec_size) {
-      fbgemm_gpu::Vec4T<scalar_t>::copy(
-          &go[input_dim_start + i], &sgo[sgo_offset + i]);
+  // Grid-stride loop over t so the kernel remains correct when the host caps
+  // gridDim.x to satisfy the HIP 2^32 thread-per-launch limit.
+  for (int64_t t = t_start; t < T; t += t_stride) {
+    const int64_t permute_idx = permute_list[t];
+    const int64_t input_dim_start = offset_dim_list[permute_idx];
+    const int64_t input_dim_end = offset_dim_list[permute_idx + 1];
+    const int64_t cur_dim = input_dim_end - input_dim_start;
+    if (idx >= cur_dim) {
+      continue;
     }
-    // Use elementwise access for the last incomplete vector.
-    for (int32_t i = loop_end + idx; i < cur_dim; i += blk) {
-      sgo[sgo_offset + i] = go[input_dim_start + i];
-    }
-  } else { // Fallback if not aligned.
-    for (int32_t i = idx; i < cur_dim; i += blk) {
-      sgo[sgo_offset + i] = go[input_dim_start + i];
+    // Apply the offsets on B dimension. Use per-iteration locals so each
+    // outer t iteration starts from the correct base pointers (the prior
+    // implementation mutated `go`/`sgo` in place, which is unsafe under a
+    // grid-stride loop).
+    const scalar_t* __restrict__ go_iter = go + b * dim_sum;
+    // Last index in inv_offset_dim_list will contain output size. Use
+    // offset_dim_list in the case of backward()
+    scalar_t* __restrict__ sgo_iter =
+        sgo + b * max(inv_offset_dim_list[T], offset_dim_list[T]);
+    const int64_t sgo_offset = inv_offset_dim_list[t];
+    // Need to check alignment before using vector code path.
+    if (fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(
+            &sgo_iter[sgo_offset]) &&
+        fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(
+            &go_iter[input_dim_start])) {
+      const int32_t vec_size = 4;
+      const int32_t loop_end = cur_dim / (vec_size) * (vec_size);
+      for (int32_t i = idx * vec_size; i < loop_end; i += blk * vec_size) {
+        fbgemm_gpu::Vec4T<scalar_t>::copy(
+            &go_iter[input_dim_start + i], &sgo_iter[sgo_offset + i]);
+      }
+      // Use elementwise access for the last incomplete vector.
+      for (int32_t i = loop_end + idx; i < cur_dim; i += blk) {
+        sgo_iter[sgo_offset + i] = go_iter[input_dim_start + i];
+      }
+    } else { // Fallback if not aligned.
+      for (int32_t i = idx; i < cur_dim; i += blk) {
+        sgo_iter[sgo_offset + i] = go_iter[input_dim_start + i];
+      }
     }
   }
 }

--- a/fbgemm_gpu/include/fbgemm_gpu/layout_transform_ops.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/layout_transform_ops.cuh
@@ -24,37 +24,38 @@ __global__ void recat_copy_async_kernel(
     const int64_t T,
     const int64_t B,
     const int64_t dim_sum) {
-  const auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
-  const auto b = b_t % B;
-  const auto t = b_t / B;
+  const auto b_t_start = blockIdx.x * blockDim.y + threadIdx.y;
+  const auto stride = gridDim.x * blockDim.y;
+  // Grid-stride loop over (b, t) pairs so the kernel remains correct when the
+  // host caps gridDim.x to satisfy the HIP 2^32 thread-per-launch limit.
+  for (int64_t b_t = b_t_start; b_t < B * T; b_t += stride) {
+    const auto b = b_t % B;
+    const auto t = b_t / B;
+    const auto dim_current = dim_sum_per_rank[t];
+    const auto tgt_base_addr = B * cum_dim_sum_per_rank[t];
+    const auto src_base_addr = cum_dim_sum_per_rank[t];
 
-  if (b_t >= B * T) {
-    return;
-  }
-  const auto dim_current = dim_sum_per_rank[t];
-  const auto tgt_base_addr = B * cum_dim_sum_per_rank[t];
-  const auto src_base_addr = cum_dim_sum_per_rank[t];
-
-  if (fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(
-          &sgo[tgt_base_addr + b * dim_current]) &&
-      fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(
-          &go[src_base_addr + b * dim_sum])) {
-    int32_t d_base = dim_current / 4 * 4;
-    for (int32_t d = threadIdx.x * 4; d < d_base; d += blockDim.x * 4) {
-      fbgemm_gpu::Vec4T<scalar_t>::copy(
-          &go[src_base_addr + b * dim_sum + d],
-          &sgo[tgt_base_addr + b * dim_current + d]);
-    }
-    // Use elementwise access for the last incomplete vector.
-    for (int32_t d_left = threadIdx.x; d_base + d_left < dim_current;
-         d_left += blockDim.x) {
-      sgo[tgt_base_addr + b * dim_current + d_base + d_left] =
-          go[src_base_addr + b * dim_sum + d_base + d_left];
-    }
-  } else {
-    for (int32_t d = threadIdx.x; d < dim_current; d += blockDim.x) {
-      sgo[tgt_base_addr + b * dim_current + d] =
-          go[src_base_addr + b * dim_sum + d];
+    if (fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(
+            &sgo[tgt_base_addr + b * dim_current]) &&
+        fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(
+            &go[src_base_addr + b * dim_sum])) {
+      int32_t d_base = dim_current / 4 * 4;
+      for (auto d = threadIdx.x * 4; d < d_base; d += blockDim.x * 4) {
+        fbgemm_gpu::Vec4T<scalar_t>::copy(
+            &go[src_base_addr + b * dim_sum + d],
+            &sgo[tgt_base_addr + b * dim_current + d]);
+      }
+      // Use elementwise access for the last incomplete vector.
+      for (auto d_left = threadIdx.x; d_base + d_left < dim_current;
+           d_left += blockDim.x) {
+        sgo[tgt_base_addr + b * dim_current + d_base + d_left] =
+            go[src_base_addr + b * dim_sum + d_base + d_left];
+      }
+    } else {
+      for (auto d = threadIdx.x; d < dim_current; d += blockDim.x) {
+        sgo[tgt_base_addr + b * dim_current + d] =
+            go[src_base_addr + b * dim_sum + d];
+      }
     }
   }
 }
@@ -71,10 +72,9 @@ __global__ void permute_pooled_embs_kernel(
     const int64_t B,
     const int64_t T,
     const int64_t dim_sum) {
-  const int32_t t =
-      blockIdx.x * (blockDim.x / warpSize) + threadIdx.x / warpSize;
-  const int32_t b = blockIdx.y + gridDim.y * blockIdx.z;
-  const int32_t idx = threadIdx.x % warpSize;
+  const auto t = blockIdx.x * (blockDim.x / warpSize) + threadIdx.x / warpSize;
+  const auto b = blockIdx.y + gridDim.y * blockIdx.z;
+  const auto idx = threadIdx.x % warpSize;
   const int32_t blk = warpSize;
   if (b >= B) {
     return;

--- a/fbgemm_gpu/src/layout_transform_ops/layout_transform_ops.cu
+++ b/fbgemm_gpu/src/layout_transform_ops/layout_transform_ops.cu
@@ -21,6 +21,7 @@
 #include <torch/library.h>
 #include "fbgemm_gpu/layout_transform_ops.cuh"
 #include "fbgemm_gpu/sparse_ops.h"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 #include "fbgemm_gpu/utils/dispatch_macros.h"
 #include "fbgemm_gpu/utils/kernel_launcher.cuh"
 #include "fbgemm_gpu/utils/ops_utils.h"
@@ -140,10 +141,16 @@ Tensor recat_embedding_grad_output_mixed_D_batch_cuda(
   const dim3 threads(
       fbgemm_gpu::kWarpSizeHost(),
       fbgemm_gpu::kMaxThreads / fbgemm_gpu::kWarpSizeHost());
-  const dim3 blocks(
+  // HIP enforces a hard limit of 2^32 total threads per launch.
+  // recat_copy_async_kernel grid-strides over (b, t), so capping is
+  // correctness-preserving.
+  // See: https://github.com/ROCm/hip/issues/2253
+  const auto blocks_x = utils::cuda::cap_grid_dim_x(
       fbgemm_gpu::div_round_up(
-          (B_local * dim_num),
-          fbgemm_gpu::kMaxThreads / fbgemm_gpu::kWarpSizeHost()));
+          (B_local * dim_num), fbgemm_gpu::kMaxThreads / fbgemm_gpu::kWarpSizeHost()),
+      fbgemm_gpu::kMaxThreads,
+      at::cuda::getCurrentCUDAStream());
+  const dim3 blocks(blocks_x);
 
   FBGEMM_DISPATCH_FLOAT_AND_HALF(
       grad_output.scalar_type(), "recat_embedding_gradients", [&] {

--- a/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
@@ -17,6 +17,7 @@
 
 #include "fbgemm_gpu/permute_multi_embedding_function.h"
 #include "fbgemm_gpu/utils/cuda_prelude.cuh"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 #include "fbgemm_gpu/utils/kernel_launcher.cuh"
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
 #include "fbgemm_gpu/utils/vec4.cuh"
@@ -41,88 +42,90 @@ __global__ void permute_multi_embs_kernel(
     const int32_t permute_size) {
   // workers in a warp handle exact one permute (of a feature/key)
   const auto worker_id = threadIdx.x;
-  const auto permute_id = threadIdx.y + blockIdx.x * blockDim.y;
+  const auto permute_id_start = threadIdx.y + blockIdx.x * blockDim.y;
+  const auto permute_stride = gridDim.x * blockDim.y;
   const auto batch_id = blockIdx.y + gridDim.y * blockIdx.z;
   if (batch_id >= batch_size) {
     return;
   }
-  if (permute_id >= permute_size) {
-    return;
-  }
-
-  // parse permutes
-  int32_t in_tensor, out_tensor, in_offset, out_offset, length, next;
-  int32_t* __restrict__ pp = permutes[permute_id].data();
-  if (reverse_permute) {
-    out_tensor = pp[PermuteParam::in_tensor];
-    in_tensor = pp[PermuteParam::out_tensor];
-    out_offset = pp[PermuteParam::in_offset];
-    in_offset = pp[PermuteParam::out_offset];
-  } else {
-    in_tensor = pp[PermuteParam::in_tensor];
-    out_tensor = pp[PermuteParam::out_tensor];
-    in_offset = pp[PermuteParam::in_offset];
-    out_offset = pp[PermuteParam::out_offset];
-  }
-  length = pp[PermuteParam::length];
-  next = pp[PermuteParam::next];
-
-  if (worker_id >= length) {
-    return;
-  }
-  if (reverse_permute && next < 0) {
-    return;
-  }
-
-  // locate the batch_id
-  const auto in_length = in_lengths[in_tensor];
-  // Sometimes batch_id * length can go beyond 32-bit int (e.g., 3900 * 654060)
-  // so cast them to int64_t.
-  const scalar_t* __restrict__ input_ptr =
-      reinterpret_cast<const scalar_t*>(inputs[in_tensor]) +
-      static_cast<int64_t>(batch_id) * static_cast<int64_t>(in_length) +
-      in_offset;
-
-  const auto out_length = out_lengths[out_tensor];
-  scalar_t* __restrict__ output_ptr =
-      reinterpret_cast<scalar_t*>(outputs[out_tensor]) +
-      static_cast<int64_t>(batch_id) * static_cast<int64_t>(out_length) +
-      out_offset;
-
-  if (fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(output_ptr) &&
-      fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(input_ptr)) {
-    constexpr int32_t vec_size = 4;
-    const int32_t loop_end = round_down(length, vec_size);
-    for (int32_t i = worker_id * vec_size; i < loop_end;
-         i += blockDim.x * vec_size) {
-      fbgemm_gpu::Vec4T<scalar_t>::copy(&input_ptr[i], &output_ptr[i]);
+  // Grid-stride loop over permute_id so the kernel remains correct when the
+  // host caps gridDim.x to satisfy the HIP 2^32 thread-per-launch limit.
+  for (int32_t permute_id = permute_id_start; permute_id < permute_size;
+       permute_id += permute_stride) {
+    // parse permutes
+    int32_t in_tensor, out_tensor, in_offset, out_offset, length, next;
+    int32_t* __restrict__ pp = permutes[permute_id].data();
+    if (reverse_permute) {
+      out_tensor = pp[PermuteParam::in_tensor];
+      in_tensor = pp[PermuteParam::out_tensor];
+      out_offset = pp[PermuteParam::in_offset];
+      in_offset = pp[PermuteParam::out_offset];
+    } else {
+      in_tensor = pp[PermuteParam::in_tensor];
+      out_tensor = pp[PermuteParam::out_tensor];
+      in_offset = pp[PermuteParam::in_offset];
+      out_offset = pp[PermuteParam::out_offset];
     }
-    // Use elementwise access for the last incomplete vector.
-    for (auto i = loop_end + worker_id; i < length; i += blockDim.x) {
-      output_ptr[i] = input_ptr[i];
-    }
-  } else { // Fallback if not aligned.
-    for (auto i = worker_id; i < length; i += blockDim.x) {
-      output_ptr[i] = input_ptr[i];
-    }
-  }
-
-  // for reverse_permute (backward) with next
-  while (reverse_permute && next > 0 && next < permute_size) {
-    int32_t* __restrict__ pp = permutes[next].data();
-    in_tensor = pp[PermuteParam::out_tensor];
-    in_offset = pp[PermuteParam::out_offset];
     length = pp[PermuteParam::length];
-    next = -pp[PermuteParam::next];
+    next = pp[PermuteParam::next];
 
+    if (worker_id >= length) {
+      continue;
+    }
+    if (reverse_permute && next < 0) {
+      continue;
+    }
+
+    // locate the batch_id
     const auto in_length = in_lengths[in_tensor];
-    const scalar_t* input_ptr =
+    // Sometimes batch_id * length can go beyond 32-bit int (e.g., 3900 *
+    // 654060) so cast them to int64_t.
+    const scalar_t* __restrict__ input_ptr =
         reinterpret_cast<const scalar_t*>(inputs[in_tensor]) +
         static_cast<int64_t>(batch_id) * static_cast<int64_t>(in_length) +
         in_offset;
 
-    for (auto i = worker_id; i < length; i += blockDim.x) {
-      output_ptr[i] += input_ptr[i];
+    const auto out_length = out_lengths[out_tensor];
+    scalar_t* __restrict__ output_ptr =
+        reinterpret_cast<scalar_t*>(outputs[out_tensor]) +
+        static_cast<int64_t>(batch_id) * static_cast<int64_t>(out_length) +
+        out_offset;
+
+    if (fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(output_ptr) &&
+        fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(input_ptr)) {
+      constexpr int32_t vec_size = 4;
+      const int32_t loop_end = round_down(length, vec_size);
+      for (int32_t i = worker_id * vec_size; i < loop_end;
+           i += blockDim.x * vec_size) {
+        fbgemm_gpu::Vec4T<scalar_t>::copy(&input_ptr[i], &output_ptr[i]);
+      }
+      // Use elementwise access for the last incomplete vector.
+      for (auto i = loop_end + worker_id; i < length; i += blockDim.x) {
+        output_ptr[i] = input_ptr[i];
+      }
+    } else { // Fallback if not aligned.
+      for (auto i = worker_id; i < length; i += blockDim.x) {
+        output_ptr[i] = input_ptr[i];
+      }
+    }
+
+    // for reverse_permute (backward) with next
+    while (reverse_permute && next > 0 && next < permute_size) {
+      int32_t* __restrict__ pp = permutes[next].data();
+      in_tensor = pp[PermuteParam::out_tensor];
+      in_offset = pp[PermuteParam::out_offset];
+      length = pp[PermuteParam::length];
+      next = -pp[PermuteParam::next];
+
+      const auto in_length = in_lengths[in_tensor];
+      const scalar_t* input_ptr =
+          reinterpret_cast<const scalar_t*>(inputs[in_tensor]) +
+          static_cast<int64_t>(batch_id) * static_cast<int64_t>(in_length) +
+          in_offset;
+
+      for (auto i = worker_id; i < length; i += blockDim.x) {
+        output_ptr[i] += input_ptr[i];
+      }
     }
   }
 }
@@ -275,8 +278,16 @@ std::vector<Tensor> permute_multi_embedding_function_gpu(
       fbgemm_gpu::kMaxThreads / fbgemm_gpu::kWarpSizeHost();
   const int32_t max_grid_dim = 32768; // The CUDA maximum is 65535, not 1<<N.
   const dim3 block_dim(fbgemm_gpu::kWarpSizeHost(), warp_per_block);
-  const dim3 grid_dim(
+  // HIP enforces a hard limit of 2^32 total threads per launch.
+  // permute_multi_embs_kernel grid-strides over permute_id, so capping is
+  // correctness-preserving. y/z dims are already bounded by max_grid_dim.
+  // See: https://github.com/ROCm/hip/issues/2253
+  const auto blocks_x = utils::cuda::cap_grid_dim_x(
       fbgemm_gpu::div_round_up(permute_size, warp_per_block),
+      fbgemm_gpu::kMaxThreads,
+      at::cuda::getCurrentCUDAStream());
+  const dim3 grid_dim(
+      blocks_x,
       std::min(static_cast<int32_t>(batch_size), max_grid_dim),
       (batch_size + max_grid_dim - 1) / max_grid_dim);
 

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops.cu
@@ -16,6 +16,7 @@
 
 #include "fbgemm_gpu/layout_transform_ops.cuh"
 #include "fbgemm_gpu/permute_pooled_embedding_ops.h"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 #include "fbgemm_gpu/utils/dispatch_macros.h"
 #include "fbgemm_gpu/utils/kernel_launcher.cuh"
 
@@ -110,8 +111,16 @@ Tensor permute_pooled_embs_gpu_impl(
   const int32_t max_grid_dim_y =
       32768; // The CUDA maximum is 65535, not a power of 2.
   const dim3 threads(fbgemm_gpu::kMaxThreads);
-  const dim3 blocks(
+  // HIP enforces a hard limit of 2^32 total threads per launch.
+  // permute_pooled_embs_kernel grid-strides over t, so capping is
+  // correctness-preserving. y/z dims are already bounded by max_grid_dim_y.
+  // See: https://github.com/ROCm/hip/issues/2253
+  const auto blocks_x = utils::cuda::cap_grid_dim_x(
       fbgemm_gpu::div_round_up(T, warp_per_block),
+      fbgemm_gpu::kMaxThreads,
+      at::cuda::getCurrentCUDAStream());
+  const dim3 blocks(
+      blocks_x,
       std::min(static_cast<int32_t>(B), max_grid_dim_y),
       (B + max_grid_dim_y - 1) / max_grid_dim_y);
 

--- a/fbgemm_gpu/test/layout_transform_ops_test.py
+++ b/fbgemm_gpu/test/layout_transform_ops_test.py
@@ -19,10 +19,10 @@ try:
     from fbgemm_gpu import open_source  # noqa: F401
 
     # pyre-ignore[21]
-    from test_utils import gpu_unavailable
+    from test_utils import gpu_memory_lt_gb, gpu_unavailable
 
 except Exception:
-    from fbgemm_gpu.test.test_utils import gpu_unavailable
+    from fbgemm_gpu.test.test_utils import gpu_memory_lt_gb, gpu_unavailable
 
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
 
@@ -187,6 +187,80 @@ class LayoutTransformOpsTest(unittest.TestCase):
         torch.testing.assert_close(
             sharded_grad_output_impl.cpu(), sharded_grad_output.cpu()
         )
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-ignore[56]: Pyre cannot infer the type of `gpu_memory_lt_gb`
+    # through the open-source / non-open-source import branch above.
+    @unittest.skipIf(*gpu_memory_lt_gb(8))
+    def test_recat_embedding_grad_output_mixed_D_batch_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in recat_copy_async_kernel
+        (include/fbgemm_gpu/layout_transform_ops.cuh).
+
+        Block: dim3(kWarpSize=32, kMaxThreads/kWarpSize=32) = 1024 threads.
+        Grid: div_round_up(B_local * dim_num, 32). Total threads ~=
+        B_local * dim_num * kWarpSize. For B_local * dim_num > 2**27,
+        total threads exceed the HIP 2**32 limit, tripping
+        KernelLauncher::checkThreadCountNotExceeded on ROCm.
+
+        Pre-fix: AMD launch fails. Post-fix: passes (kernel grid-strides).
+        """
+        B_local = 8
+        dim_num = (1 << 24) + 1  # B_local * dim_num = 2**27 + 8 > 2**27
+        # All-zero dim_sum_per_rank means each rank contributes 0 elements,
+        # so per-tile copy work inside the kernel is empty. grad_output
+        # therefore has width 0 and the output tensor is also empty.
+        dim_sum_per_rank_tensor = torch.zeros(
+            dim_num, dtype=torch.int64, device=torch.accelerator.current_accelerator()
+        )
+        cumsum_dim_sum_per_rank_tensor = torch.zeros(
+            dim_num, dtype=torch.int64, device=torch.accelerator.current_accelerator()
+        )
+        grad_output = torch.zeros(
+            (B_local, 0),
+            dtype=torch.float32,
+            device=torch.accelerator.current_accelerator(),
+        )
+        sharded_grad_output = (
+            torch.ops.fbgemm.recat_embedding_grad_output_mixed_D_batch(
+                grad_output,
+                dim_sum_per_rank_tensor,
+                cumsum_dim_sum_per_rank_tensor,
+            )
+        )
+        self.assertEqual(sharded_grad_output.numel(), grad_output.numel())
+
+        # Tier-B Python-reference correctness check at small scale.
+        # Sentinel non-zero values force the kernel to do non-trivial copies.
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        small_B = 4
+        small_dim_sum_per_rank = [3, 5, 2]  # W = 3 ranks
+        small_total_D = sum(small_dim_sum_per_rank)
+        small_grad_output = torch.arange(
+            small_B * small_total_D, dtype=torch.float32, device=device
+        ).reshape(small_B, small_total_D)
+        small_dim_sum_tensor = torch.tensor(
+            small_dim_sum_per_rank, dtype=torch.int64, device=device
+        )
+        small_cumsum_tensor = torch.tensor(
+            [0] + list(np.cumsum(small_dim_sum_per_rank)[:-1]),
+            dtype=torch.int64,
+            device=device,
+        )
+
+        # Python reference: split grad_output column-wise per rank, then
+        # concatenate the per-rank flattened views.
+        ref_outputs_by_rank = small_grad_output.split(small_dim_sum_per_rank, dim=1)
+        ref_sharded = torch.cat(
+            [g.contiguous().view(-1) for g in ref_outputs_by_rank], dim=0
+        )
+
+        small_sharded = torch.ops.fbgemm.recat_embedding_grad_output_mixed_D_batch(
+            small_grad_output,
+            small_dim_sum_tensor,
+            small_cumsum_tensor,
+        )
+        torch.testing.assert_close(small_sharded, ref_sharded)
 
 
 if __name__ == "__main__":

--- a/fbgemm_gpu/test/permute/common.py
+++ b/fbgemm_gpu/test/permute/common.py
@@ -20,7 +20,11 @@ open_source: bool = getattr(fbgemm_gpu, "open_source", False)
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_unavailable, on_arm_platform
+    from test_utils import (  # noqa: F401
+        gpu_memory_lt_gb,
+        gpu_unavailable,
+        on_arm_platform,
+    )
 else:
     torch.ops.load_library(
         "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_split_gpu"
@@ -28,7 +32,11 @@ else:
     torch.ops.load_library(
         "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_split_cpu"
     )
-    from fbgemm_gpu.test.test_utils import gpu_unavailable, on_arm_platform
+    from fbgemm_gpu.test.test_utils import (  # noqa: F401
+        gpu_memory_lt_gb,
+        gpu_unavailable,
+        on_arm_platform,
+    )
 
 typed_gpu_unavailable: tuple[bool, str] = gpu_unavailable
 typed_on_arm_platform: tuple[bool, str] = on_arm_platform

--- a/fbgemm_gpu/test/permute/permute_multi_embedding_ops_test.py
+++ b/fbgemm_gpu/test/permute/permute_multi_embedding_ops_test.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+# pyre-ignore-all-errors[56]
+
+import unittest
+
+import torch
+
+try:
+    # pyre-ignore[21]
+    from fbgemm_gpu import open_source  # noqa: F401
+
+    # pyre-ignore[21]
+    from test_utils import gpu_memory_lt_gb, gpu_unavailable
+except Exception:
+    from fbgemm_gpu.test.test_utils import gpu_memory_lt_gb, gpu_unavailable
+
+    torch.ops.load_library(
+        "//deeplearning/fbgemm/fbgemm_gpu:permute_multi_embedding_ops_gpu"
+    )
+    torch.ops.load_library(
+        "//deeplearning/fbgemm/fbgemm_gpu:permute_multi_embedding_ops_cpu"
+    )
+
+
+# permutes tensor schema (matching PermuteParam enum in
+# permute_multi_embedding_ops.cu): each row is
+#   [in_tensor, out_tensor, in_offset, out_offset, length, next].
+
+PERMUTES_DTYPE = torch.int32
+SHAPES_DTYPE = torch.int32
+
+
+class PermuteMultiEmbeddingOpsTest(unittest.TestCase):
+    @unittest.skipIf(*gpu_unavailable)
+    def test_permute_multi_embedding_smoke(self) -> None:
+        """Small-input correctness regression. Gates the kernel-side
+        grid-stride transformation against breakage on small inputs."""
+        device = torch.accelerator.current_accelerator("cuda")
+        batch_size = 4
+        in_lengths = [4, 8]
+        out_lengths = [4, 8]
+
+        permutes = torch.tensor(
+            [
+                [0, 0, 0, 0, 4, -1],
+                [1, 1, 0, 0, 8, -1],
+            ],
+            dtype=PERMUTES_DTYPE,
+            device=device,
+        )
+        in_shapes = torch.tensor(in_lengths, dtype=SHAPES_DTYPE, device=device)
+        out_shapes = torch.tensor(out_lengths, dtype=SHAPES_DTYPE, device=device)
+
+        pooled_embs = [
+            torch.arange(batch_size * length, dtype=torch.float32, device=device)
+            .view(batch_size, length)
+            .contiguous()
+            for length in in_lengths
+        ]
+
+        outputs = torch.ops.fbgemm.permute_multi_embedding(
+            pooled_embs,
+            permutes,
+            in_shapes,
+            out_shapes,
+            out_lengths,
+        )
+
+        self.assertEqual(len(outputs), 2)
+        self.assertEqual(outputs[0].shape, (batch_size, out_lengths[0]))
+        self.assertEqual(outputs[1].shape, (batch_size, out_lengths[1]))
+        torch.testing.assert_close(outputs[0], pooled_embs[0])
+        torch.testing.assert_close(outputs[1], pooled_embs[1])
+
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(4))
+    def test_permute_multi_embedding_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in permute_multi_embs_kernel
+        (src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu).
+
+        Block: dim3(kWarpSize=32, kMaxThreads/kWarpSize=32) = 1024 threads.
+        Grid x = div_round_up(permute_size, 32). Grid y = batch_size capped
+        at max_grid_dim=32768. With permute_size = 2**22 + 1 and
+        batch_size = 32, total threads = ceil((2**22+1)/32) * 32 * 1024
+        > 2**32, tripping KernelLauncher::checkThreadCountNotExceeded on
+        ROCm pre-fix.
+
+        Pre-fix: AMD launch fails. Post-fix: passes (kernel grid-strides
+        over permute_id).
+
+        All-zero permutes (length=0, next=-1) make the inner copy work
+        bounded. We still exercise the saturating gridDim.x path.
+        """
+        device = torch.accelerator.current_accelerator("cuda")
+        permute_size = (1 << 22) + 1
+        batch_size = 32
+        in_lengths = [1]
+        out_lengths = [1]
+
+        permutes = torch.zeros((permute_size, 6), dtype=PERMUTES_DTYPE, device=device)
+        # next = -1 disables the reverse_permute follow-on chain
+        permutes[:, 5] = -1
+        in_shapes = torch.tensor(in_lengths, dtype=SHAPES_DTYPE, device=device)
+        out_shapes = torch.tensor(out_lengths, dtype=SHAPES_DTYPE, device=device)
+
+        pooled_embs = [
+            torch.zeros(
+                (batch_size, in_lengths[0]),
+                dtype=torch.float32,
+                device=device,
+            )
+        ]
+
+        outputs = torch.ops.fbgemm.permute_multi_embedding(
+            pooled_embs,
+            permutes,
+            in_shapes,
+            out_shapes,
+            out_lengths,
+        )
+
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(outputs[0].shape, (batch_size, out_lengths[0]))
+
+        # Tier-A CPU-oracle correctness check at small scale with
+        # non-trivial permutes (length > 0). The smoke test above covers
+        # identity permutes; this section exercises the full grid-stride
+        # path with non-trivial copy work.
+        small_batch = 4
+        small_in_lengths = [4, 8]
+        small_out_lengths = [4, 8]
+        small_permutes = torch.tensor(
+            [
+                [0, 0, 0, 0, 4, -1],
+                [1, 1, 0, 0, 8, -1],
+            ],
+            dtype=PERMUTES_DTYPE,
+        )
+        small_in_shapes = torch.tensor(small_in_lengths, dtype=SHAPES_DTYPE)
+        small_out_shapes = torch.tensor(small_out_lengths, dtype=SHAPES_DTYPE)
+        small_pooled_cpu = [
+            torch.arange(small_batch * length, dtype=torch.float32)
+            .view(small_batch, length)
+            .contiguous()
+            for length in small_in_lengths
+        ]
+        out_cpu = torch.ops.fbgemm.permute_multi_embedding(
+            small_pooled_cpu,
+            small_permutes,
+            small_in_shapes,
+            small_out_shapes,
+            small_out_lengths,
+        )
+        out_gpu = torch.ops.fbgemm.permute_multi_embedding(
+            [t.to(device) for t in small_pooled_cpu],
+            small_permutes.to(device),
+            small_in_shapes.to(device),
+            small_out_shapes.to(device),
+            small_out_lengths,
+        )
+        self.assertEqual(len(out_gpu), len(out_cpu))
+        for cpu_t, gpu_t in zip(out_cpu, out_gpu):
+            torch.testing.assert_close(gpu_t.cpu(), cpu_t)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/fbgemm_gpu/test/permute/permute_pooled_embedding_test.py
+++ b/fbgemm_gpu/test/permute/permute_pooled_embedding_test.py
@@ -17,7 +17,7 @@ import torch.nn as nn
 from fbgemm_gpu.permute_pooled_embedding_modules import PermutePooledEmbeddings
 from hypothesis import given, settings
 
-from .common import Net, open_source
+from .common import gpu_memory_lt_gb, Net, open_source, typed_gpu_unavailable
 
 if open_source:
     # pyre-ignore[21]
@@ -158,6 +158,59 @@ class PooledEmbeddingModulesTest(unittest.TestCase):
 
         assert output_meta.shape == output_cpu.shape
         assert input.shape == output_meta.shape
+
+    @unittest.skipIf(*typed_gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(8))
+    def test_permute_pooled_embedding_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in permute_pooled_embs_kernel
+        (include/fbgemm_gpu/layout_transform_ops.cuh:64-117).
+
+        Block: dim3(kMaxThreads=1024). Grid x = div_round_up(T, 32). For
+        T = 2**22 + 1 and B = 32, total threads = ceil(T/32) * 32 * 1024
+        > 2**32, tripping KernelLauncher::checkThreadCountNotExceeded on
+        ROCm pre-fix.
+
+        Pre-fix: AMD launch fails. Post-fix: passes (kernel grid-strides
+        over t).
+        """
+        T = (1 << 22) + 1
+        B = 32
+        embs_dims = [1] * T
+        permute = list(range(T))
+
+        pooled_embs = torch.zeros(
+            B, sum(embs_dims), dtype=torch.float32, device=self.device
+        )
+        module = PermutePooledEmbeddings(embs_dims, permute, device=self.device)
+        result = module(pooled_embs)
+
+        self.assertEqual(result.shape, pooled_embs.shape)
+        self.assertTrue(torch.all(result == 0).item())
+
+        # Tier-A correctness check at small scale with non-trivial permute
+        # and non-zero values. Pure Python reference: per-feature gather.
+        small_embs_dims = [3, 5, 2, 4]
+        small_T = len(small_embs_dims)
+        # Reverse permute: [3, 2, 1, 0].
+        small_permute = list(range(small_T))[::-1]
+        small_B = 4
+        small_total_D = sum(small_embs_dims)
+        # Distinct values across rows.
+        small_pooled_cpu = torch.arange(
+            small_B * small_total_D, dtype=torch.float32
+        ).view(small_B, small_total_D)
+
+        small_module = PermutePooledEmbeddings(
+            small_embs_dims, small_permute, device=self.device
+        )
+        small_result = small_module(small_pooled_cpu.to(self.device))
+
+        # Python reference: split per-feature, gather by permute.
+        small_segments = list(small_pooled_cpu.split(small_embs_dims, dim=1))
+        small_ref = torch.cat([small_segments[p] for p in small_permute], dim=1)
+
+        torch.testing.assert_close(small_result.cpu(), small_ref)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
The audit at
/home/bensonma415/.llms/plans/permute_metric_layout_etc_rocm_grid_overflow_audit.plan.md
flagged `permute_pooled_embs_kernel` (Tier-2): the saturating dimension
is `gridDim.x` (one warp per t = feature index), and the kernel uses an
early `if (t >= T) return` bail-out that assumes the full grid is
launched. On ROCm, `KernelLauncher::checkThreadCountNotExceeded` (under
`#ifdef USE_ROCM` in `FBGEMM_LAUNCH_KERNEL`) fires a `TORCH_CHECK` once
total threads exceed 2^32 (HIP enforces a hard limit; NVIDIA silently
wraps).

This diff does the standard Tier-2 pair:

1. Kernel-side
   (`include/fbgemm_gpu/layout_transform_ops.cuh`, shared by both the
   non-split and split frontends): convert the `t` axis from a
   single-pass early-return into a 2D-block grid-stride loop with stride
   `gridDim.x * (blockDim.x / warpSize)` and bound `T`. All
   per-iteration registers are re-derived inside the loop body
   (`permute_idx`, `input_dim_start`, `input_dim_end`, `cur_dim`,
   `sgo_offset`). The previous in-place pointer mutations (`go +=
   b * dim_sum` and `sgo += b * max(...)`) would corrupt subsequent
   iterations, so they are rewritten to per-iteration locals
   (`go_iter`, `sgo_iter`) so each outer `t` iteration starts from the
   correct base. The early-return on `idx >= cur_dim` becomes
   `continue` so subsequent strides are still serviced.
   `(blockIdx.y, blockIdx.z)` mapping for `b = batch_id` is kept as-is
   — the existing manual `max_grid_dim_y = 32768` host-side cap
   protects y/z. No `__shared__`, `__syncthreads()`, or warp shuffles.
   Reference pattern: `permute_2D_data_kernel` (sparse_permute_2d.cu:36).

2. Host-side
   (`src/permute_pooled_embedding_ops/permute_pooled_embedding_ops.cu`):
   apply the canonical
   `#ifdef USE_ROCM / std::min(blocks_x_uncapped, get_max_thread_blocks(stream))`
   cap to `blocks.x` (the `div_round_up(T, warp_per_block)` axis).
   y/z dims unchanged.

`test/permute/common.py` is extended to re-export `gpu_memory_lt_gb` so
the new test in `permute_pooled_embedding_test.py` can import it via
the shared helper module.

The split frontend
(`permute_pooled_embedding_ops_split.cu`) calls the same kernel
template; its host-side cap will land in the next diff in this stack.

Parent fixes:
- D104903707, D104937969 (sparse_ops Tier-2 cap pattern)
- D105352349 (Tier-2 stack: recat_copy_async_kernel)
- D105353645 (Tier-2 stack: permute_multi_embs_kernel)

Differential Revision: D105354406


