### PR TITLE
Skip codegen of empty PT2 wrappers for optimizers without backend support

### DIFF
--- a/fbgemm_gpu/cmake/tbe_sources.py
+++ b/fbgemm_gpu/cmake/tbe_sources.py
@@ -355,13 +355,13 @@ gen_cpu_files_training_pt2 = (
     ]
     + [
         "gen_embedding_backward_split_{}_pt2_cpu_wrapper.cpp".format(optimizer)
-        for optimizer in ALL_OPTIMIZERS
+        for optimizer in CPU_OPTIMIZERS
     ]
 )
 
 gen_gpu_files_training_pt2 = [
     "gen_embedding_backward_split_{}_pt2_cuda_wrapper.cpp".format(optimizer)
-    for optimizer in ALL_OPTIMIZERS
+    for optimizer in GPU_OPTIMIZERS
 ] + [
     "gen_embedding_backward_ssd_{}_pt2_cuda_wrapper.cpp".format(optimizer)
     for optimizer in SSD_OPTIMIZERS

--- a/fbgemm_gpu/codegen/genscript/generate_backward_split.py
+++ b/fbgemm_gpu/codegen/genscript/generate_backward_split.py
@@ -183,17 +183,25 @@ class BackwardSplitGenerator:
                     filename, is_forward=False, ssd=ssd, **kwargs
                 )
 
-                # Generate PT2 unified autograd, and PT2 backward wrapper for all optimizers
-                for template_filepath, filename in [
+                # PT2 unified autograd is generated for every optimizer to preserve
+                # backward compatibility (deprecated optimizers emit a throwing stub).
+                # The CUDA wrapper only has content when has_gpu_support is True; for
+                # deprecated optimizers it would render to a byte-identical empty TU,
+                # so skip it to avoid emitting redundant sources.
+                pt2_templates = [
                     (
                         "training/pt2/embedding_split_host_pt2_autograd_template.cpp",
                         f"gen_embedding_{desc}_{optimizer}_pt2_autograd.cpp",
                     ),
-                    (
-                        "training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp",
-                        f"gen_embedding_backward_{desc}_{optimizer}_pt2_cuda_wrapper.cpp",
-                    ),
-                ]:
+                ]
+                if kwargs.get("has_gpu_support"):
+                    pt2_templates.append(
+                        (
+                            "training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp",
+                            f"gen_embedding_backward_{desc}_{optimizer}_pt2_cuda_wrapper.cpp",
+                        )
+                    )
+                for template_filepath, filename in pt2_templates:
                     CodeTemplate.load(template_filepath).write(
                         filename,
                         is_forward=False,
@@ -247,16 +255,25 @@ class BackwardSplitGenerator:
 
         # Generate the backward splits (non-dense)
         if not kwargs.get("dense"):
-            for template_filepath, filename in [
+            # The host CPU source is generated for every optimizer to preserve
+            # backward compatibility (deprecated optimizers emit a throwing stub).
+            # The PT2 CPU wrapper only has content when has_cpu_support is True; for
+            # unsupported optimizers it would render to a byte-identical empty TU,
+            # so skip it to avoid emitting redundant sources.
+            cpu_templates = [
                 (
                     "training/backward/embedding_backward_split_host_cpu_template.cpp",
                     f"gen_embedding_backward_split_{optimizer}_cpu.cpp",
                 ),
-                (
-                    "training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp",
-                    f"gen_embedding_backward_split_{optimizer}_pt2_cpu_wrapper.cpp",
-                ),
-            ]:
+            ]
+            if kwargs.get("has_cpu_support"):
+                cpu_templates.append(
+                    (
+                        "training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp",
+                        f"gen_embedding_backward_split_{optimizer}_pt2_cpu_wrapper.cpp",
+                    )
+                )
+            for template_filepath, filename in cpu_templates:
                 CodeTemplate.load(template_filepath).write(
                     filename,
                     is_forward=False,


### PR DESCRIPTION
This PR tries to address an issue discovered in https://github.com/pytorch/pytorch/pull/190601.

TBE PT2 codegen emitted a CPU and CUDA backend wrapper TU for every entry in `ALL_OPTIMIZERS`, including the six deprecated optimizers (`approx_sgd`, `approx_rowwise_adagrad`, `approx_rowwise_adagrad_with_counter`, `approx_rowwise_adagrad_with_weight_decay`, `rowwise_adagrad_with_weight_decay`, `rowwise_weighted_adagrad`), whose `has_cpu_support` and `has_gpu_support` are both False. The wrapper templates guard their entire body on those flags, so for these optimizers they render to byte-identical, effectively empty translation units that only differ by filename.

Besides being wasted compilation, the six identical CUDA wrappers are a liability under a preprocessor-off, path-insensitive compiler cache (e.g. sccache classic mode): the cache key ignores the input/output path, so all six collapse to one cached object that is copied to every output. On HIP each copy then carries the same `__hip_cuid` symbol and the link fails with "multiple definition of `__hip_cuid_...`".

Gate wrapper generation on the corresponding support flag (autograd, which carries the deprecation stub needed for backward compatibility, is still generated for every optimizer), and build the CMake wrapper source lists from `CPU_OPTIMIZERS` / `GPU_OPTIMIZERS` instead of `ALL_OPTIMIZERS`. At current head those groups exactly equal the sets with `has_cpu_support` / `has_gpu_support` True, so the generated file set matches the listed sources.

Note: this is one of two alternative fixes for the same issue. The other alternative is #6044 

Authored with assistance from Cursor

Made with [Cursor](https://cursor.com)