### PR TITLE
Make empty PT2 wrapper TUs byte-distinct per optimizer

### DIFF
--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
@@ -18,6 +18,12 @@
         [PT2 wrapper] --Torch dispatch--> [CPU backend] | <<<
             --Fn call--> [CPU kernel]                   |
 */#}
+{%- if not is_forward %}
+// Per-TU marker for {{ optimizer }}{{ "_ssd" if ssd else "_split" }}. Optimizers
+// without CPU support render this file empty except for this line; it keeps those
+// TUs byte-distinct so a path-insensitive compiler cache cannot dedup them to a
+// single object.
+{%- endif %}
 {%- if has_cpu_support %}
 ////////////////////////////////////////////////////////////////////////////////
 // Required for op registrations and dispatchers

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
@@ -18,6 +18,12 @@
         [PT2 wrapper] --Torch dispatch--> [CUDA backend] | <<<
             --kernel dispatch--> [CUDA kernel]           |
 */#}
+{%- if not is_forward %}
+// Per-TU marker for {{ optimizer }}{{ "_ssd" if ssd else "_split" }}. Deprecated
+// optimizers (has_gpu_support=False) render this file empty except for this line;
+// it keeps those TUs byte-distinct so a path-insensitive compiler cache cannot
+// dedup them to one object (which on HIP yields duplicate __hip_cuid symbols).
+{%- endif %}
 {%- if has_gpu_support %}
 ////////////////////////////////////////////////////////////////////////////////
 // Required for op registrations and dispatchers


### PR DESCRIPTION
This PR tries to address an issue discovered in https://github.com/pytorch/pytorch/pull/190601.

The TBE PT2 CPU/CUDA wrapper templates guard their entire body on `has_cpu_support` / `has_gpu_support`. For the six deprecated optimizers (both flags False) they render to byte-identical, effectively empty translation units that differ only by output filename.

Under a preprocessor-off, path-insensitive compiler cache (e.g. sccache classic mode) the cache key ignores the input/output path, so all six identical sources collapse to a single cached object that is copied to every output. On HIP each copy then carries the same `__hip_cuid` symbol and the link fails with "multiple definition of `__hip_cuid_...`".

Emit a per-TU marker comment (optimizer name plus split/ssd) outside the support-flag guard, so each generated file is byte-distinct even when the body is empty. The cache no longer dedups them and HIP assigns a distinct `__hip_cuid` per object. Non-empty wrappers are unaffected.

Note: this is one of two alternative fixes for the same issue. The other alternative is #6043.

Authored with assistance from Cursor

Made with [Cursor](https://cursor.com)