### PR TITLE
[ROCm] Make FP8 (fnuz vs OCP) selection architecture-aware

### DIFF
--- a/fbgemm_gpu/codegen/genscript/jinja_environment.py
+++ b/fbgemm_gpu/codegen/genscript/jinja_environment.py
@@ -74,6 +74,20 @@ env.globals["fixed_max_vecs_per_thread"] = {"backward": 2, "backward_indice_weig
 env.globals["dense"] = False
 env.globals["is_rocm"] = args.is_rocm
 
+# FP8 embedding weight types to instantiate kernels for.
+#
+# FP8 e4m3 has two encodings: the OCP "fn" variant (CUDA, and AMD gfx950) and
+# the "fnuz" variant (AMD gfx942 / gfx90a). A single ROCm build can be a fat
+# binary spanning both arch families, so on ROCm we instantiate BOTH kernel
+# variants and let the runtime dispatch (keyed on the tensor's scalar type,
+# which is chosen per-device by getNFP8ScalarType()) select the correct one.
+# CUDA only needs the OCP "fn" variant.
+env.globals["emb_fp8_types"] = (
+    ["at::Float8_e4m3fnuz", "at::Float8_e4m3fn"]
+    if args.is_rocm
+    else ["at::Float8_e4m3fn"]
+)
+
 
 ################################################################################
 # Helper functions in Jinja Environment

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
@@ -548,7 +548,7 @@ batch_index_select_dim0_codegen_backward_kernel_cta_per_row
 
 {%- macro bulk_template_instantiations(kFixedMaxVecsPerThread, kThreadGroupSize, kUseVecBlocking) %}
     {%- for grad_type in ['float', 'at::Half', 'at::BFloat16'] %}
-    {%- for emb_type in (['float', 'at::Half'] + (['at::Float8_e4m3fnuz'] if is_rocm else ['at::Float8_e4m3fn'])) %}
+    {%- for emb_type in (['float', 'at::Half'] + emb_fp8_types) %}
     {%- for cache_type in ['float', 'at::Half'] %}
     {%- for index_type in ['int32_t', 'int64_t'] %}
     {%- for ph_type_combo in args.placeholder_type_combos %}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -459,7 +459,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row
 
 {%- macro bulk_template_instantiations(kFixedMaxVecsPerThread, kThreadGroupSize, kUseVecBlocking) %}
     {%- for grad_type in ['float', 'at::Half', 'at::BFloat16'] %}
-    {%- for emb_type in (['float', 'at::Half'] + (['at::Float8_e4m3fnuz'] if is_rocm else ['at::Float8_e4m3fn'])) %}
+    {%- for emb_type in (['float', 'at::Half'] + emb_fp8_types) %}
     {%- for cache_type in ['float', 'at::Half'] %}
     {%- for index_type in ['int32_t', 'int64_t'] %}
     {%- for ph_type_combo in args.placeholder_type_combos %}
@@ -767,7 +767,7 @@ hip_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vd
 
 {%- macro hip_bulk_template_instantiations(kFixedMaxVecsPerThread, kThreadGroupSize, kUseVecBlocking) %}
     {%- for grad_type in ['float', 'at::Half', 'at::BFloat16'] %}
-    {%- for emb_type in (['float', 'at::Half'] + (['at::Float8_e4m3fnuz'] if is_rocm else ['at::Float8_e4m3fn'])) %}
+    {%- for emb_type in (['float', 'at::Half'] + emb_fp8_types) %}
     {%- for cache_type in ['float', 'at::Half'] %}
     {%- for index_type in ['int32_t', 'int64_t'] %}
     {%- for kEmbeddingDim in [64, 128, 160, 192, 256, 320] %}

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_nobag_small_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_nobag_small_template.cu
@@ -199,7 +199,7 @@ batch_index_select_dim0_codegen_forward_small_kernel(
 */
 
 {%- for output_type in ['float', 'at::Half', 'at::BFloat16'] %}
-{%- for emb_type in (['float', 'at::Half'] + (['at::Float8_e4m3fnuz'] if is_rocm else ['at::Float8_e4m3fn'])) %}
+{%- for emb_type in (['float', 'at::Half'] + emb_fp8_types) %}
 {%- for cache_type in ['float', 'at::Half'] %}
 {%- for kEmbeddingSize in [4, 8, 16, 32] %}
 {%- for index_type in ['int32_t', 'int64_t'] %}

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
@@ -918,7 +918,7 @@ batch_index_select_dim0_codegen_forward_kernel
 
 {%- macro bulk_template_instantiations(use_cache, kMaxVecsPerThread, kThreadGroupSize) %}
     {%- set max_vecs_per_thread = kMaxVecsPerThread %}
-    {%- for emb_type in (['float', 'at::Half'] + (['at::Float8_e4m3fnuz'] if is_rocm else ['at::Float8_e4m3fn'])) %}
+    {%- for emb_type in (['float', 'at::Half'] + emb_fp8_types) %}
     {%- for cache_type in ['float', 'at::Half'] %}
     {%- for output_type in ['float', 'at::Half', 'at::BFloat16'] %}
     {%- for index_type in ['int32_t', 'int64_t'] %}

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
@@ -109,12 +109,11 @@ template <>
 struct Vec4Type<at::Float8_e4m3fnuz> {
   using type = c10::Float8_e4m3fnuz;
 };
-{%- else %}
+{%- endif %}
 template <>
 struct Vec4Type<at::Float8_e4m3fn> {
   using type = c10::Float8_e4m3fn;
 };
-{%- endif %}
 
 template <typename T>
 using vec4_type = typename Vec4Type<T>::type;
@@ -1039,7 +1038,7 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
 
 {%- for output_type in ['float', 'at::Half', 'at::BFloat16'] %}
 {%- for index_type in ['int32_t', 'int64_t'] %}
-{%- for emb_type in (['float', 'at::Half'] + (['at::Float8_e4m3fnuz'] if is_rocm else ['at::Float8_e4m3fn'])) %}
+{%- for emb_type in (['float', 'at::Half'] + emb_fp8_types) %}
 {%- for cache_type in ['float', 'at::Half'] %}
 {%- for use_cache in ['true', 'false'] %}
 

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
@@ -105,7 +105,7 @@ void split_{{ optimizer }}_update_kernel(
 
 {{ "#ifdef FBGEMM_USE_SUBWARP_SHUFFLE" if use_subwarp else "#else" }}
 
-{%- for emb_type in (['uint8_t', 'float', 'at::Half'] + (['at::Float8_e4m3fnuz'] if is_rocm else ['at::Float8_e4m3fn'])) %}
+{%- for emb_type in (['uint8_t', 'float', 'at::Half'] + emb_fp8_types) %}
 {%- for cache_type in ['float', 'at::Half'] %}
 {%- for ph_type_combo in args.placeholder_type_combos %}
 

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -20,6 +20,37 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
 )
 
 
+@torch.jit.ignore
+def _nfp8_is_fnuz() -> bool:
+    """
+    Whether the current runtime device uses the FP8 "fnuz" e4m3 encoding.
+
+    The FP8 e4m3 encoding is hardware specific on AMD GPUs: gfx942 (MI300) and
+    gfx90a use the "fnuz" encoding, while gfx950 and CUDA use the OCP "fn"
+    encoding. A single ROCm build can be a fat binary spanning multiple archs,
+    so this must be resolved at runtime from the actual device in use, mirroring
+    the C++ getNFP8ScalarType() helper in embedding_common.h. Keep the arch to
+    encoding mapping identical between the two.
+
+    Marked @torch.jit.ignore because the arch query is not TorchScript-able;
+    scripted callers get the eager result at runtime.
+    """
+    if torch.version.hip is not None and torch.cuda.is_available():
+        arch = torch.cuda.get_device_properties(torch.cuda.current_device()).gcnArchName
+        # fnuz archs: gfx942 and gfx90a.
+        if "gfx94" in arch or "gfx90a" in arch:
+            return True
+    return False
+
+
+def nfp8_dtype() -> torch.dtype:
+    """
+    Return the native FP8 (e4m3) torch dtype for the current runtime device.
+    See _nfp8_is_fnuz() for the arch to encoding mapping.
+    """
+    return torch.float8_e4m3fnuz if _nfp8_is_fnuz() else torch.float8_e4m3fn
+
+
 def pad4(value: int) -> int:
     """
     Compute the smallest multiple of 4 that is greater than or equal to the given value.
@@ -361,11 +392,7 @@ def sparse_type_int_to_dtype(ty: int) -> torch.dtype:
     elif ty == 7:  # mx4
         return torch.uint8
     elif ty == 9:
-        return (
-            torch.float8_e4m3fnuz
-            if torch.version.hip is not None
-            else torch.float8_e4m3fn
-        )
+        return torch.float8_e4m3fnuz if _nfp8_is_fnuz() else torch.float8_e4m3fn
     else:  # Invalid is 7 or non enumerated.
         raise ValueError(f"Unsupported sparse type: {ty}")
 
@@ -446,11 +473,7 @@ class SparseType(enum.Enum):
             SparseType.INT2.value: torch.quint2x4,
             SparseType.BF16.value: torch.bfloat16,
             SparseType.MX4.value: torch.uint8,
-            SparseType.NFP8.value: (
-                torch.float8_e4m3fnuz
-                if torch.version.hip is not None
-                else torch.float8_e4m3fn
-            ),
+            SparseType.NFP8.value: nfp8_dtype(),
         }[self.value]
 
     def bit_rate(self) -> int:

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -28,7 +28,11 @@ from torch.autograd.profiler import record_function  # usort:skip
 # @manual=//deeplearning/fbgemm/fbgemm_gpu/codegen:split_embedding_codegen_lookup_invokers
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers as invokers
 from fbgemm_gpu.config import FeatureGate, FeatureGateName
-from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
+from fbgemm_gpu.split_embedding_configs import (
+    EmbOptimType as OptimType,
+    nfp8_dtype,
+    SparseType,
+)
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     BoundsCheckMode,
     CacheAlgorithm,
@@ -3273,11 +3277,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             for param in splits:
                 tmp_param = torch.zeros(param.shape, device=self.current_device)
                 # Create initialized weights and cast to fp8.
-                fp8_dtype = (
-                    torch.float8_e4m3fnuz
-                    if torch.version.hip is not None
-                    else torch.float8_e4m3fn
-                )
+                fp8_dtype = nfp8_dtype()
                 tmp_param.uniform_(min_val, max_val).to(fp8_dtype)
                 param.data.copy_(tmp_param)
         else:

--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_common.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_common.h
@@ -10,6 +10,11 @@
 #include <ATen/ATen.h>
 #include <c10/macros/Macros.h>
 #include <cstdint>
+#ifdef USE_ROCM
+#include <string_view>
+
+#include <ATen/cuda/CUDAContext.h>
+#endif
 
 namespace fbgemm_gpu {
 
@@ -44,6 +49,29 @@ enum class BoundsCheckMode : uint8_t {
   IGNORE = 2,
 };
 
+// Resolves the native FP8 (e4m3) scalar type for the current runtime device.
+//
+// The FP8 encoding is hardware-specific: gfx942 (MI300) and gfx90a use the
+// "fnuz" encoding, while gfx950 and CUDA use the OCP "fn" encoding. Because a
+// ROCm build can be a fat binary spanning multiple archs, this cannot be a
+// compile-time decision on the host: it must query the device actually in use
+// at runtime so the host-allocated tensor dtype matches what device kernels
+// (whose format is selected per-arch at device-compile time) read and write.
+inline at::ScalarType getNFP8ScalarType() {
+#ifdef USE_ROCM
+  if (at::cuda::is_available()) {
+    const std::string_view arch{
+        at::cuda::getCurrentDeviceProperties()->gcnArchName};
+    // fnuz archs: gfx942 and gfx90a.
+    if (arch.find("gfx94") != std::string_view::npos ||
+        arch.find("gfx90a") != std::string_view::npos) {
+      return at::kFloat8_e4m3fnuz;
+    }
+  }
+#endif
+  return at::kFloat8_e4m3fn;
+}
+
 inline at::ScalarType getScalarType(SparseType dtype) {
   switch (dtype) {
     case SparseType::FP32:
@@ -59,11 +87,7 @@ inline at::ScalarType getScalarType(SparseType dtype) {
     case SparseType::INT2:
       return at::kQUInt2x4;
     case SparseType::NFP8:
-#if (defined(USE_ROCM) && !HIP_FP8_TYPE_OCP)
-      return at::kFloat8_e4m3fnuz;
-#else
-      return at::kFloat8_e4m3fn;
-#endif
+      return getNFP8ScalarType();
     default:
       return at::ScalarType::Undefined;
   }

--- a/fbgemm_gpu/include/fbgemm_gpu/rocm/split_embeddings_common.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/rocm/split_embeddings_common.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <c10/util/BFloat16.h>
+#include <c10/util/Float8_e4m3fn.h>
 #include <c10/util/Float8_e4m3fnuz.h>
 #include <c10/util/Half.h>
 
@@ -151,7 +152,8 @@ struct load_row_per_warp {
     // unsupported type is guarded on host side
     if constexpr (
         std::is_same_v<emb_t, c10::BFloat16> ||
-        std::is_same_v<emb_t, c10::Float8_e4m3fnuz>) {
+        std::is_same_v<emb_t, c10::Float8_e4m3fnuz> ||
+        std::is_same_v<emb_t, c10::Float8_e4m3fn>) {
       __builtin_trap();
     } else {
       static_assert(
@@ -399,7 +401,8 @@ struct store_row_per_warp {
     // unsupported type is guarded on host function
     if constexpr (
         std::is_same_v<emb_t, c10::BFloat16> ||
-        std::is_same_v<emb_t, c10::Float8_e4m3fnuz>) {
+        std::is_same_v<emb_t, c10::Float8_e4m3fnuz> ||
+        std::is_same_v<emb_t, c10::Float8_e4m3fn>) {
       __builtin_trap();
     } else {
       static_assert(

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/dispatch_macros.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/dispatch_macros.h
@@ -48,6 +48,12 @@
         at::Float8_e4m3fnuz,                                                 \
         NAME,                                                                \
         __VA_ARGS__)                                                         \
+    PRIVATE_CASE_TYPE_EMB(                                                   \
+        at::ScalarType::Float8_e4m3fn,                                       \
+        _cache_t,                                                            \
+        at::Float8_e4m3fn,                                                   \
+        NAME,                                                                \
+        __VA_ARGS__)                                                         \
     default:                                                                 \
       TORCH_CHECK(                                                           \
           false,                                                             \
@@ -209,6 +215,12 @@
           at::Float8_e4m3fnuz,                                         \
           NAME,                                                        \
           __VA_ARGS__)                                                 \
+      PRIVATE_CASE_TYPE_EMB(                                           \
+          at::ScalarType::Float8_e4m3fn,                               \
+          _cache_t,                                                    \
+          at::Float8_e4m3fn,                                           \
+          NAME,                                                        \
+          __VA_ARGS__)                                                 \
       default:                                                         \
         TORCH_CHECK(                                                   \
             false,                                                     \
@@ -296,10 +308,11 @@
 
 #if defined(USE_ROCM)
 
-#define FBGEMM_DISPATCH_FLOAT_HALF_AND_FP8_CASE(...)   \
-  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__) \
-  AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)  \
-  AT_DISPATCH_CASE(at::ScalarType::Float8_e4m3fnuz, __VA_ARGS__)
+#define FBGEMM_DISPATCH_FLOAT_HALF_AND_FP8_CASE(...)          \
+  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__)        \
+  AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)         \
+  AT_DISPATCH_CASE(at::ScalarType::Float8_e4m3fnuz, __VA_ARGS__) \
+  AT_DISPATCH_CASE(at::ScalarType::Float8_e4m3fn, __VA_ARGS__)
 
 #else
 

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
@@ -12,7 +12,11 @@ from typing import Any
 import hypothesis.strategies as st
 import numpy as np
 import torch
-from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
+from fbgemm_gpu.split_embedding_configs import (
+    EmbOptimType as OptimType,
+    nfp8_dtype,
+    SparseType,
+)
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     CacheAlgorithm,
     EmbeddingLocation,
@@ -97,9 +101,7 @@ common_settings: dict[str, Any] = {
     "deadline": None,
 }
 
-fp8_dtype: torch.dtype = (
-    torch.float8_e4m3fnuz if torch.version.hip is not None else torch.float8_e4m3fn
-)
+fp8_dtype: torch.dtype = nfp8_dtype()
 
 
 def execute_backward_adagrad(  # noqa C901

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_test.py
@@ -81,8 +81,7 @@ class BackwardAdagradTest(unittest.TestCase):
     ) -> None:
         kwargs = adjust_mixed_B_st(kwargs)
         # Skip for use_cpu=True, as FP8 is not supported on CPU.
-        # Also disable on AMD for now.
-        if kwargs["use_cpu"] or torch.version.hip:
+        if kwargs["use_cpu"]:
             return
         execute_backward_adagrad(
             weights_precision=SparseType.NFP8,

--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -17,7 +17,11 @@ from unittest.mock import MagicMock, patch
 import hypothesis.strategies as st
 import numpy as np
 import torch
-from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
+from fbgemm_gpu.split_embedding_configs import (
+    EmbOptimType as OptimType,
+    nfp8_dtype,
+    SparseType,
+)
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     CacheAlgorithm,
     EmbeddingLocation,
@@ -53,7 +57,6 @@ if open_source:
     from test_utils import (
         additional_decorators,
         gpu_unavailable,
-        is_nvidia_device,
         optests,
         running_in_oss,
         TEST_WITH_ROCM,
@@ -62,7 +65,6 @@ else:
     from fbgemm_gpu.test.test_utils import (
         additional_decorators,
         gpu_unavailable,
-        is_nvidia_device,
         optests,
         running_in_oss,
         TEST_WITH_ROCM,
@@ -70,9 +72,7 @@ else:
 
 VERBOSITY: Verbosity = Verbosity.verbose
 
-fp8_dtype: torch.dtype = (
-    torch.float8_e4m3fnuz if torch.version.hip is not None else torch.float8_e4m3fn
-)
+fp8_dtype: torch.dtype = nfp8_dtype()
 
 # pyre-ignore
 additional_decorators.update(
@@ -827,10 +827,6 @@ class ForwardTest(unittest.TestCase):
         self,
         use_experimental_tbe: bool = False,  # TODO This does not yet work when True.
     ) -> None:
-        # Skip on rocm as fp8 is not supported for all versions.
-        if not is_nvidia_device:
-            return
-
         weights_precision = SparseType.NFP8
         use_cpu = False
         T = random.randint(1, 10)
@@ -1023,10 +1019,6 @@ class ForwardTest(unittest.TestCase):
         self,
         cache_algorithm: CacheAlgorithm,
     ) -> None:
-        # Skip tests on rocm since it does not work for all versions.
-        if not is_nvidia_device:
-            return
-
         weights_precision = SparseType.NFP8
         use_cpu = False
         T = random.randint(1, 10)


### PR DESCRIPTION
## Summary

FP8 e4m3 has two encodings on AMD GPUs: gfx942 (MI300 family) and gfx90a use the "fnuz" encoding, while gfx950 and CUDA use the OCP "fn" encoding. FBGEMM previously assumed that any ROCm build uses fnuz, which is wrong on gfx950 and silently produced incorrect FP8 semantics there. This change makes the FP8 encoding selection architecture-aware across every layer that referenced it: the host scalar type helper, the device kernel instantiation, the runtime dispatch macros, and the Python dtype selection. NFP8 embedding training and inference now work correctly on gfx950, and remain correct on gfx942, including in a single fat binary that spans both.

## Background

The FP8 encoding selection appeared in four independent layers, all keyed on "is this a ROCm build" rather than "which arch is the device". First, getScalarType(SparseType::NFP8) in embedding_common.h selected the encoding with the compile-time macro HIP_FP8_TYPE_OCP, but the header did not include hip/hip_fp8.h, so the macro was undefined at the point of use and silently evaluated to 0, forcing fnuz on every ROCm arch. Second, the codegen templates instantiated FP8 embedding kernels only for at::Float8_e4m3fnuz on ROCm. Third, the dispatch macros registered only the fnuz case under USE_ROCM. Fourth, the Python dtype selection chose fnuz whenever torch.version.hip was set. Layers two through four were internally consistent with each other (all fnuz), so upstream did not crash on gfx950; it silently used fnuz semantics on OCP hardware.

A key property established during this work is that the physical FP8 encoding in device code is already correct per architecture: all FP8 device load and store paths reinterpret through the __nv_fp8_e4m3 alias in utils/float.cuh, which resolves to the OCP or fnuz HIP type per device-compile pass. The at::Float8_e4m3fn versus fnuz C++ type is therefore only a dispatch and tensor-dtype label, not the physical encoding. The label must still match the encoding, because PyTorch-native consumers of the tensor (casting, printing, serialization, copying) interpret the raw bytes according to the tensor dtype.

## Changes

Host scalar type. embedding_common.h now includes ATen/cuda/CUDAContext.h and adds getNFP8ScalarType(), which queries the runtime device via at::cuda::getCurrentDeviceProperties()->gcnArchName and returns kFloat8_e4m3fnuz for gfx94x and gfx90a, otherwise kFloat8_e4m3fn. The query is guarded by at::cuda::is_available() so the CPU and meta backends fall back to fn when no device is present. getScalarType(SparseType::NFP8) delegates to this helper. This replaces the broken compile-time macro branch and is correct for multi-arch fat binaries because it is resolved at runtime.

Device kernel instantiation. The codegen now emits both the fnuz and fn FP8 kernel variants on ROCm (CUDA still emits only fn). The repeated per-template type list is centralized as a single emb_fp8_types global in codegen/genscript/jinja_environment.py, and the seven instantiation loop sites plus the Vec4Type specialization in the forward v2 template reference it. The runtime dispatch then selects whichever variant matches the host-allocated tensor dtype; the unused variant is simply never dispatched on a given device.

Runtime dispatch macros. dispatch_macros.h adds a Float8_e4m3fn case alongside the existing Float8_e4m3fnuz case in all three USE_ROCM blocks (_DISPATCH_EMB_CACHE_TYPES, PRIVATE_CASE_TYPE_CACHE_EMB, and FBGEMM_DISPATCH_FLOAT_HALF_AND_FP8_CASE), so runtime dispatch can route either encoding.

ROCm warp helpers. The optimized warp load and store fallbacks in rocm/split_embeddings_common.h previously listed only fnuz in their unsupported-type __builtin_trap guard; the fn instantiation would otherwise hit static_assert(false) at compile time. Float8_e4m3fn is added to both guards, and the c10 Float8_e4m3fn header is included. These paths are guarded on the host side and are never reached at runtime for FP8, matching the existing fnuz behavior.

Python dtype selection. split_embedding_configs.py adds a runtime helper (nfp8_dtype, backed by an arch query marked torch.jit.ignore so scripted callers still compile) that mirrors the C++ arch-to-encoding mapping. The three fnuz-on-any-hip selection sites (sparse_type_int_to_dtype, SparseType.as_dtype, and the NFP8 weight init in split_table_batched_embeddings_ops_training.py) now use it. SparseType.from_dtype already accepted both encodings and is unchanged.

Tests. The NFP8 TBE training tests were previously skipped or disabled on ROCm. forward_test.py test_forward_gpu_no_cache_fp8 and test_forward_gpu_uvm_cache_fp8 no longer early-return on ROCm, backward_adagrad_test.py test_backward_adagrad_fp8_pmSUM no longer disables on ROCm (it still skips CPU), and the shared fp8_dtype in the forward and backward test harnesses uses the arch-aware helper.

## Consistency invariant

The Python nfp8_dtype and the C++ getNFP8ScalarType must use the same arch-to-encoding mapping (gfx94x and gfx90a map to fnuz, everything else to fn). Both use the identical gfx substring checks; keep them in sync if either is changed.
