### PR TITLE
Fix build break when using llvm-21 (#6046)

### DIFF
--- a/src/TransposeUtilsSve.h
+++ b/src/TransposeUtilsSve.h
@@ -97,7 +97,7 @@ static void transpose_kernel_mxn_small_sve(
     int64_t ld_dst) {
   asm volatile(
 
-      "mov x0, %[N]\t\n"
+      "mov w0, %w[N]\t\n"
       "mov x1, %[src]\t\n"
       "mov x2, %[ld_src]\t\n"
       "mov x3, %[dst]\t\n"
@@ -350,7 +350,7 @@ static void transpose_kernel_mxn_large_sve(
     int64_t ld_dst) {
   asm volatile(
 
-      "mov x0, %[N]\t\n"
+      "mov w0, %w[N]\t\n"
       "mov x1, %[src]\t\n"
       "mov x2, %[ld_src]\t\n"
       "mov x3, %[dst]\t\n"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2946


Assigning a 32-bit variable to a 64-bit register generates a warning, which may result into build breaks

Reviewed By: mcfi

Differential Revision: D113269630


