### PR TITLE
Add ROCm cap to permute_pooled_embs_split host launch

### DIFF
--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split.cu
@@ -15,6 +15,7 @@
 
 #include "fbgemm_gpu/layout_transform_ops.cuh"
 #include "fbgemm_gpu/permute_pooled_embedding_ops_split.h"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 #include "fbgemm_gpu/utils/dispatch_macros.h"
 #include "fbgemm_gpu/utils/kernel_launcher.cuh"
 #include "fbgemm_gpu/utils/tensor_utils.h"
@@ -110,8 +111,17 @@ Tensor permute_pooled_embs_split_gpu_impl(
   const int32_t max_grid_dim_y =
       32768; // The CUDA maximum is 65535, not a power of 2.
   const dim3 threads(fbgemm_gpu::kMaxThreads);
-  const dim3 blocks(
+  // HIP enforces a hard limit of 2^32 total threads per launch.
+  // permute_pooled_embs_kernel grid-strides over t (kernel-side change
+  // landed in the previous diff in this stack), so capping is
+  // correctness-preserving. y/z dims are already bounded by max_grid_dim_y.
+  // See: https://github.com/ROCm/hip/issues/2253
+  const auto blocks_x = utils::cuda::cap_grid_dim_x(
       fbgemm_gpu::div_round_up(T, warp_per_block),
+      fbgemm_gpu::kMaxThreads,
+      at::cuda::getCurrentCUDAStream());
+  const dim3 blocks(
+      blocks_x,
       std::min(static_cast<int32_t>(B), max_grid_dim_y),
       (B + max_grid_dim_y - 1) / max_grid_dim_y);
 

--- a/fbgemm_gpu/test/permute/permute_pooled_embedding_test.py
+++ b/fbgemm_gpu/test/permute/permute_pooled_embedding_test.py
@@ -11,6 +11,13 @@ import inspect
 import sys
 import unittest
 
+# Import for its side effect of registering the Python abstract (fake-tensor)
+# impls for the split permute ops (e.g. fbgemm::permute_pooled_embs_split).
+# Without this, generate_opcheck_tests' faketensor / aot_dispatch variants of
+# test_permute_pooled_embedding_split_large_grid fail with "could not find the
+# abstract impl". The non-split ops register their meta impl in C++, so they do
+# not need this.
+import fbgemm_gpu.sparse_ops  # noqa: F401
 import hypothesis.strategies as st
 import torch
 import torch.nn as nn
@@ -211,6 +218,48 @@ class PooledEmbeddingModulesTest(unittest.TestCase):
         small_ref = torch.cat([small_segments[p] for p in small_permute], dim=1)
 
         torch.testing.assert_close(small_result.cpu(), small_ref)
+
+    @unittest.skipIf(*typed_gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(8))
+    def test_permute_pooled_embedding_split_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in the split frontend of
+        permute_pooled_embs_kernel
+        (src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split.cu).
+
+        Same kernel as test_permute_pooled_embedding_large_grid, exercised
+        through torch.ops.fbgemm.permute_pooled_embs_auto_grad_split.
+        """
+        T = (1 << 22) + 1
+        B = 32
+        embs_dims = [1] * T
+        permute = list(range(T))
+        inv_permute = list(range(T))
+
+        offsets = torch.zeros(T + 1, dtype=torch.int64, device=self.device)
+        offsets[1:] = torch.cumsum(
+            torch.tensor(embs_dims, dtype=torch.int64, device=self.device),
+            dim=0,
+        )
+        permute_t = torch.tensor(permute, dtype=torch.int64, device=self.device)
+        inv_permute_t = torch.tensor(inv_permute, dtype=torch.int64, device=self.device)
+
+        pooled_embs = torch.zeros(
+            B,
+            int(offsets[-1].item()),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        result = torch.ops.fbgemm.permute_pooled_embs_auto_grad_split(
+            pooled_embs,
+            offsets,
+            permute_t,
+            offsets,
+            inv_permute_t,
+        )
+
+        self.assertEqual(result.shape, pooled_embs.shape)
+        self.assertTrue(torch.all(result == 0).item())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
The audit at
/home/bensonma415/.llms/plans/permute_metric_layout_etc_rocm_grid_overflow_audit.plan.md
flagged the split frontend in
`src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split.cu`
as the second host-side caller of the shared
`permute_pooled_embs_kernel` template. The kernel-side grid-stride
change landed in the previous diff in this stack
(`include/fbgemm_gpu/layout_transform_ops.cuh`); this diff is a
host-side-only follow-up that picks up the kernel change automatically
and applies the verbatim `#ifdef USE_ROCM` cap pattern to the split
frontend's `blocks.x` (the `div_round_up(T, warp_per_block)` axis).

Plus a new
`test_permute_pooled_embedding_split_large_grid` test that exercises
the same kernel through
`torch.ops.fbgemm.permute_pooled_embs_auto_grad_split`.

Parent fixes:
- D104903707, D104937969 (sparse_ops Tier-2 cap pattern)
- D105352349 (Tier-2 stack: recat_copy_async_kernel)
- D105353645 (Tier-2 stack: permute_multi_embs_kernel)
- D105354406 (Tier-2 stack: permute_pooled_embs_kernel — kernel-side
  change shared with this diff)

Reviewed By: henrylhtsang

Differential Revision: D105355306


