### PR TITLE
Fix HIP 2^32 grid-overflow in batch_index_select_dim0 forward kernels (#6053)

### DIFF
--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_nobag_small_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_nobag_small_template.cu
@@ -68,8 +68,19 @@ batch_index_select_dim0_codegen_forward_small_kernel(
     pta::PackedTensorAccessor64<output_t, {{ "1" if is_index_select else "2" }}, at::RestrictPtrTraits> output
     ) {
     int32_t T = weights_offsets.size(0);
+    {%- if is_index_select %}
+    // On ROCm the launch caps the grid to stay within the HIP 2^32
+    // threads-per-launch limit, so we grid-stride to cover the full workload.
+    // On CUDA the grid is not capped and the loop body runs exactly once per warp.
+#ifdef USE_ROCM
+    for (auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
+         ;
+         b_t += blockDim.y * gridDim.x) {
+#else
     auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
-    {%- if not is_index_select %}
+#endif
+    {%- else %}
+    auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
     if (b_t >= offsets.size(0) - 1) {
         return;
     }
@@ -84,13 +95,23 @@ batch_index_select_dim0_codegen_forward_small_kernel(
     int32_t L;
     int32_t L_start;
     if (t >= T) {
+        // t is monotonically increasing in b_t, so no further warp has work.
+#ifdef USE_ROCM
+        break;
+#else
         return;
+#endif
     }
     const auto total_L_start = total_L_offsets[t];
     const auto total_L = total_L_offsets[t + 1] - total_L_start;
     L_start = b * fixed_L_per_warp;
     if (L_start >= total_L) {
+        // This warp has no rows to gather; move on to the next strided warp.
+#ifdef USE_ROCM
+        continue;
+#else
         return;
+#endif
     }
     indices_start = total_L_start + L_start;
     L = (total_L - L_start >= fixed_L_per_warp) ? fixed_L_per_warp : (total_L - L_start);
@@ -190,6 +211,11 @@ batch_index_select_dim0_codegen_forward_small_kernel(
             }
         }
     }
+    {%- if is_index_select %}
+#ifdef USE_ROCM
+    } // for b_t (grid-stride loop, ROCm only)
+#endif
+    {%- endif %}
 }
 
 /*

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
@@ -637,7 +637,16 @@ batch_index_select_dim0_codegen_forward_kernel(
 
     // Determine the linearized warp ID, and exit early if needed
     {%- if is_index_select %}
+    // On ROCm the launch caps the grid to stay within the HIP 2^32
+    // threads-per-launch limit, so we grid-stride to cover the full workload.
+    // On CUDA the grid is not capped and the loop body runs exactly once per warp.
+#ifdef USE_ROCM
+    for (auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
+         ;
+         b_t += blockDim.y * gridDim.x) {
+#else
     auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
+#endif
     {%- else %}
     const auto total_B = offsets.size(0) - 1;
     // Since we place a limit on the grid size, we need to perform grid-striding
@@ -663,13 +672,23 @@ batch_index_select_dim0_codegen_forward_kernel(
     int32_t L;
     overflow_safe_int_t L_start;
     if (t >= T) {
+        // t is monotonically increasing in b_t, so no further warp has work.
+#ifdef USE_ROCM
+        break;
+#else
         return;
+#endif
     }
     const auto total_L_start = total_L_offsets[t];
     const auto total_L = total_L_offsets[t + 1] - total_L_start;
     L_start = static_cast<overflow_safe_int_t>(b) * fixed_L_per_warp;
     if (L_start >= total_L) {
+        // This warp has no rows to gather; move on to the next strided warp.
+#ifdef USE_ROCM
+        continue;
+#else
         return;
+#endif
     }
     indices_start = total_L_start + L_start;
     L = (total_L - L_start >= fixed_L_per_warp) ? fixed_L_per_warp : (total_L - L_start);
@@ -821,7 +840,11 @@ batch_index_select_dim0_codegen_forward_kernel(
     }
     {%- endif %}
 
-    {%- if not is_index_select %}
+    {%- if is_index_select %}
+#ifdef USE_ROCM
+    } // for b_t (grid-stride loop, ROCm only)
+#endif
+    {%- else %}
     } // for b_t
     {%- endif %}
 }

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
@@ -633,7 +633,18 @@ batch_index_select_dim0_codegen_forward_cuda(
               output_t,
               index_t,
               kEmbeddingSize / 4>),
+            {%- if is_index_select %}
+            // Cap the grid on ROCm to stay within the HIP 2^32 threads-per-launch
+            // limit; the kernel grid-strides to cover the full workload. This is a
+            // no-op on CUDA (OverflowOnly).
+            utils::cuda::cap_grid_dim_x(
+                div_round_up(total_B, kForwardMaxThreads / kWarpSize),
+                kForwardMaxThreads,
+                at::cuda::getCurrentCUDAStream(),
+                utils::cuda::BlockCapPolicy::OverflowOnly),
+            {%- else %}
             div_round_up(total_B, kForwardMaxThreads / kWarpSize),
+            {%- endif %}
             dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
             0,
             at::cuda::getCurrentCUDAStream(),
@@ -683,7 +694,18 @@ batch_index_select_dim0_codegen_forward_cuda(
               <emb_t, cache_t, output_t, use_cache_t, index_t>
               {%- endif %}
             ),
+            {%- if is_index_select %}
+            // Cap the grid on ROCm to stay within the HIP 2^32 threads-per-launch
+            // limit; the kernel grid-strides to cover the full workload. This is a
+            // no-op on CUDA (OverflowOnly).
+            utils::cuda::cap_grid_dim_x(
+                div_round_up(total_B, kForwardMaxThreads / kWarpSize),
+                kForwardMaxThreads,
+                at::cuda::getCurrentCUDAStream(),
+                utils::cuda::BlockCapPolicy::OverflowOnly),
+            {%- else %}
             div_round_up(total_B, kForwardMaxThreads / kWarpSize),
+            {%- endif %}
             dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
             0,
             at::cuda::getCurrentCUDAStream(),

--- a/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
@@ -278,18 +278,21 @@ std::vector<Tensor> permute_multi_embedding_function_gpu(
       fbgemm_gpu::kMaxThreads / fbgemm_gpu::kWarpSizeHost();
   const int32_t max_grid_dim = 32768; // The CUDA maximum is 65535, not 1<<N.
   const dim3 block_dim(fbgemm_gpu::kWarpSizeHost(), warp_per_block);
+  const int32_t grid_dim_y = std::min(batch_size, max_grid_dim);
+  const int32_t grid_dim_z = (batch_size + max_grid_dim - 1) / max_grid_dim;
   // HIP enforces a hard limit of 2^32 total threads per launch.
-  // permute_multi_embs_kernel grid-strides over permute_id, so capping is
-  // correctness-preserving. y/z dims are already bounded by max_grid_dim.
-  // See: https://github.com/ROCm/hip/issues/2253
+  // permute_multi_embs_kernel grid-strides over permute_id (the gridDim.x
+  // axis), so capping gridDim.x is correctness-preserving. The batch_id axis
+  // (gridDim.y * gridDim.z) is NOT grid-strided, so fold it into the per-grid-x
+  // thread count passed to the cap, keeping the accounting consistent with the
+  // launcher's total-thread check (grid.x * grid.y * grid.z * block_size).
+  // Bounding y/z to max_grid_dim alone does not prevent the product from
+  // exceeding 2^32. See: https://github.com/ROCm/hip/issues/2253
   const auto blocks_x = utils::cuda::cap_grid_dim_x(
       fbgemm_gpu::div_round_up(permute_size, warp_per_block),
-      fbgemm_gpu::kMaxThreads,
+      static_cast<int64_t>(fbgemm_gpu::kMaxThreads) * grid_dim_y * grid_dim_z,
       at::cuda::getCurrentCUDAStream());
-  const dim3 grid_dim(
-      blocks_x,
-      std::min(static_cast<int32_t>(batch_size), max_grid_dim),
-      (batch_size + max_grid_dim - 1) / max_grid_dim);
+  const dim3 grid_dim(blocks_x, grid_dim_y, grid_dim_z);
 
   FBGEMM_DISPATCH_FLOATING_TYPES(
       pooled_embs[0].scalar_type(), "permute_multi_embedding", [&] {

--- a/fbgemm_gpu/test/sparse/index_select_test.py
+++ b/fbgemm_gpu/test/sparse/index_select_test.py
@@ -775,6 +775,128 @@ class IndexSelectTest(unittest.TestCase):
             small_input_gpu.grad.cpu(), small_input_cpu_clone.grad
         )
 
+    @optests.dontGenerateOpCheckTests(
+        "GPU-only large-scale repro; opcheck/faketensor variants add no op "
+        "coverage and are impractical at 2**32-thread scale (T191384137)"
+    )
+    @unittest.skipIf(*gpu_unavailable)
+    # This test exercises the HIP launch-side limit on the
+    # batch_index_select_dim0 forward path
+    # (batch_index_select_dim0_codegen_forward_kernel). The forward tensors
+    # here stay small (~1.5 GiB), so most large-HBM GPUs run it; the overflow
+    # is triggered by the grid size, not tensor size.
+    @unittest.skipIf(*gpu_memory_lt_gb(8))
+    def test_batch_index_select_dim0_forward_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in the
+        batch_index_select_dim0 forward kernel and verifies output
+        correctness via head/middle/tail sentinels plus a small-scale
+        CPU oracle (forward + backward).
+
+        The forward launch computes
+        total_B = num_warps_per_feature * T = max(input_num_indices) * num_inputs
+        (fixed_L_per_warp = ROWS_PER_WARP = 1), and launches
+        grid = div_round_up(total_B, kForwardMaxThreads / kWarpSize) with
+        block = dim3(kWarpSize, kForwardMaxThreads / kWarpSize). On ROCm
+        (kWarpSize = 64, kForwardMaxThreads = 512) the total thread count
+        is ~= total_B * 64. With num_inputs = 1024 and
+        input_num_indices = 80000, total_B = 81_920_000 and total threads
+        ~= 5.24e9 > 2**32. Pre-fix on ROCm, FBGEMM_LAUNCH_KERNEL ->
+        KernelLauncher::checkThreadCountNotExceeded TORCH_CHECK-fails.
+        The fix caps the grid on ROCm and grid-strides the kernel to
+        cover the full workload; the tail sentinel check below fails if
+        any strided work item is dropped.
+
+        Unlike index_select_dim0, memory here stays modest because the
+        overflow is driven by the number of (input, selected-row) work
+        items rather than the tensor sizes, so full-scale forward +
+        backward-free correctness checks are cheap.
+        """
+
+        num_inputs = 1024
+        num_indices = 80000
+        input_rows = 4
+        cols = 4  # must be a multiple of 4
+
+        total_b = num_indices * num_inputs
+        self.assertGreater(total_b * 64, 2**32)
+
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+
+        # ---- Full-scale forward: launch survival + head/middle/tail sentinels. ----
+        # Build the concatenated op inputs directly on device. Wrap in
+        # no_grad to avoid autograd graph creation.
+        with torch.no_grad():
+            concat_inputs = torch.zeros(
+                num_inputs * input_rows * cols, dtype=torch.float16, device=device
+            )
+            mid = num_inputs // 2
+            # Sentinels (exactly representable in fp16) at the first input's
+            # row 0, a middle input's row 1, and the last input's last row.
+            concat_inputs[0] = 1.0
+            concat_inputs[mid * input_rows * cols + 1 * cols + 0] = 2.0
+            concat_inputs[
+                (num_inputs - 1) * input_rows * cols
+                + (input_rows - 1) * cols
+                + (cols - 1)
+            ] = 3.0
+
+            # Per-input selection pattern: index k selects row (k % input_rows).
+            per_input_indices = (
+                torch.arange(num_indices, dtype=torch.long, device=device) % input_rows
+            )
+            concat_indices = per_input_indices.repeat(num_inputs)
+
+            output = torch.ops.fbgemm.batch_index_select_dim0(
+                concat_inputs,
+                concat_indices,
+                [num_indices] * num_inputs,  # input_num_indices
+                [input_rows] * num_inputs,  # input_rows
+                [cols] * num_inputs,  # input_columns
+                False,  # permute_output_dim_0_1
+            )
+
+            self.assertEqual(output.numel(), num_inputs * num_indices * cols)
+            # output[i, k, c] is flattened at i*(num_indices*cols) + k*cols + c,
+            # and equals concat input i's row (k % input_rows), column c.
+            # Head: input 0, k=0 -> row 0, col 0.
+            self.assertEqual(output[0].item(), 1.0)
+            # Middle: input mid, k=1 -> row 1, col 0.
+            self.assertEqual(output[mid * num_indices * cols + cols].item(), 2.0)
+            # Tail: last input, k=num_indices-1 -> row input_rows-1, col cols-1.
+            # This is the final work item; it is only produced if the ROCm
+            # grid-stride loop covers the whole (capped) workload.
+            self.assertEqual(output[-1].item(), 3.0)
+            del concat_inputs, concat_indices, per_input_indices, output
+
+        # Release the caching allocator pool before the small-scale step.
+        torch.cuda.empty_cache()
+
+        # ---- Small-scale correctness (forward + backward) vs CPU dispatch. ----
+        small_input_rows = [4, 5, 6]
+        small_cols = [4, 8, 4]
+        small_num_indices = [7, 3, 5]
+        inputs = [
+            torch.rand(rows, c, dtype=torch.float, device=device)
+            for rows, c in zip(small_input_rows, small_cols)
+        ]
+        indices = [
+            torch.randint(0, rows, (n,), dtype=torch.long, device=device)
+            for n, rows in zip(small_num_indices, small_input_rows)
+        ]
+        self.execute_batch_index_select_dim0(
+            num_inputs=len(small_input_rows),
+            inputs=inputs,
+            indices=indices,
+            input_rows=small_input_rows,
+            input_columns=small_cols,
+            input_num_indices=small_num_indices,
+            permute_output_dim_0_1=False,
+            dtype=torch.float,
+            device=device,
+            op=torch.ops.fbgemm.batch_index_select_dim0,
+        )
+
 
 # e.g. "test_faketensor__test_cumsum": [unittest.expectedFailure]
 # Please avoid putting tests here, you should put operator-specific


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2953

The batch_index_select_dim0 forward kernel crashes on AMD/ROCm for large workloads. MAST job fire-changbin-train-UFM-10EBF_full_length-4d036 failed with:
[batch_index_select_dim0_codegen_forward_kernel] [grid dim 10773753 x 1 x 1] [block dim 64 x 8 x 1]:
Total number of threads 5516161536 is greater than the HIP limit of 2^32

Mirror the D94944619 cap-plus-grid-stride pattern for the index-select forward:
1. Launch sites (embedding_forward_split_template.cu): wrap both the small- and main-kernel grids in utils::cuda::cap_grid_dim_x(..., BlockCapPolicy::OverflowOnly), gated on is_index_select.
2. Kernels (embedding_forward_split_kernel_template.cu, ..._nobag_small_template.cu): add an #ifdef USE_ROCM grid-stride loop for the is_index_select path; convert t >= T -> break (t is monotonic in b_t) and L_start >= total_L -> continue.

Also complete the grid-x cap for permute_multi_embs_kernel (permute_multi_embedding_ops.cu), which shares this ROCm CI test suite. The prior cap (PR #6040) passed only kMaxThreads as the per-grid-x thread count, ignoring the non-grid-strided batch_id axis (gridDim.y * gridDim.z). For large permute_size with batch_size > 1 the launch still exceeded 2^32 (test_permute_multi_embedding_large_grid: grid 262145 x 32 x 1, block 64 x 16 x 1 -> 8.59e9 threads). Fold grid_dim_y * grid_dim_z into the cap's per-grid-x thread count, matching the sparse_index_add.cu / jagged_softmax precedent. This unblocks the ROCm CI test suite.

Reviewed By: q10

Differential Revision: D113306267


