### PR TITLE
Add fast-fail TORCH_CHECK for auc_kernel HIP grid overflow

### DIFF
--- a/fbgemm_gpu/src/metric_ops/metric_ops.cu
+++ b/fbgemm_gpu/src/metric_ops/metric_ops.cu
@@ -240,6 +240,29 @@ at::Tensor batch_auc(
 
   const int grid_size = num_blocks * num_tasks;
 
+  // HIP enforces a hard limit of 2^32 total threads per launch. auc_kernel
+  // is a chained block-level prefix-sum that requires every (num_blocks *
+  // num_tasks) CTA to be co-resident concurrently (it spinwaits on
+  // block_flags[num_blocks - 1] published by the last block of each
+  // task), so the standard grid-stride + cap pattern is not safe — capping
+  // the grid would force serial reuse of block_flags / block_sums slots
+  // and corrupt the cumsum (best case wrong output, worst case deadlock).
+  // Until the inter-block scan is restructured (Tier-3 follow-up) we
+  // fast-fail host-side instead of letting HIP fire its runtime error
+  // (or, on NVIDIA, silently wrap and produce wrong AUC values).
+  TORCH_CHECK(
+      static_cast<uint64_t>(num_blocks) * static_cast<uint64_t>(num_tasks) *
+              static_cast<uint64_t>(NUM_THREADS_PER_BLOCK) <
+          (uint64_t(1) << 32),
+      "auc_kernel launch would exceed HIP 2^32 thread-per-launch "
+      "limit (num_blocks=",
+      num_blocks,
+      ", num_tasks=",
+      num_tasks,
+      ", threads_per_block=",
+      NUM_THREADS_PER_BLOCK,
+      ")");
+
   at::Tensor block_flags;
   at::Tensor block_sums;
   if (num_blocks > 1) {

--- a/fbgemm_gpu/test/metric_ops_test.py
+++ b/fbgemm_gpu/test/metric_ops_test.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
+# pyre-ignore-all-errors[56]
 
 import unittest
 
@@ -17,7 +18,11 @@ try:
     # pyre-ignore[21]
     from fbgemm_gpu import open_source  # noqa: F401
 
+    # pyre-ignore[21]
+    from test_utils import gpu_memory_lt_gb, gpu_unavailable
 except Exception:
+    from fbgemm_gpu.test.test_utils import gpu_memory_lt_gb, gpu_unavailable
+
     try:
         torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:metric_ops")
     except Exception:
@@ -59,6 +64,108 @@ class MetricOpsTest(unittest.TestCase):
                 rtol=1e-2 if dtype == torch.half else None,
                 atol=1e-2 if dtype == torch.half else None,
             )
+
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(2))
+    def test_batch_auc_large_grid_torch_check(self) -> None:
+        """
+        Asserts the host-side TORCH_CHECK in batch_auc fires when the
+        auc_kernel launch would exceed the HIP 2^32 thread-per-launch
+        limit.
+
+        auc_kernel cannot be converted to a grid-stride loop without
+        redesigning its inter-block prefix-sum scan (block_flags +
+        spinwait coordination). Tier-3 follow-up.
+
+        Sizing: grid_size = num_blocks * num_tasks. With num_entries = 1,
+        num_blocks = 1, so grid_size = num_tasks. Pick num_tasks =
+        (1 << 24) + 1; total threads = (2**24 + 1) * 256 > 2**32.
+        """
+        num_tasks = (1 << 24) + 1
+        num_entries = 1
+        device = torch.accelerator.current_accelerator()
+        predictions = torch.zeros(
+            (num_tasks, num_entries),
+            dtype=torch.float32,
+            device=device,
+        )
+        labels = torch.zeros(
+            (num_tasks, num_entries),
+            dtype=torch.float32,
+            device=device,
+        )
+        weights = torch.ones(
+            (num_tasks, num_entries),
+            dtype=torch.float32,
+            device=device,
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "auc_kernel launch would exceed HIP 2\\^32 thread-per-launch limit",
+        ):
+            _ = fbgemm_gpu.metrics.auc(num_tasks, predictions, labels, weights)
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_batch_auc_small_scale_correctness(self) -> None:
+        """
+        Tier-B small-scale correctness check for the AUC kernel,
+        complementing the cap-trip Tier-C assertRaisesRegex above. This
+        verifies that the kernel still produces correct AUC values when
+        the cap is not hit.
+
+        Python reference: per-task AUC = U / (P * N) where U is the
+        Mann-Whitney U statistic with weights, computed via a sort-and-
+        count-pairs over (positive, negative) pairs.
+        """
+        device = torch.accelerator.current_accelerator()
+        num_tasks = 2
+        num_entries = 8
+        # Sentinel values: distinct predictions so AUC is well-defined.
+        predictions_cpu = torch.tensor(
+            [
+                [0.1, 0.4, 0.35, 0.8, 0.05, 0.7, 0.2, 0.9],
+                [0.5, 0.6, 0.1, 0.3, 0.9, 0.45, 0.55, 0.25],
+            ],
+            dtype=torch.float32,
+        )
+        labels_cpu = torch.tensor(
+            [
+                [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+                [1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0],
+            ],
+            dtype=torch.float32,
+        )
+        weights_cpu = torch.ones((num_tasks, num_entries), dtype=torch.float32)
+
+        result = fbgemm_gpu.metrics.auc(
+            num_tasks,
+            predictions_cpu.to(device),
+            labels_cpu.to(device),
+            weights_cpu.to(device),
+        )
+
+        # Python reference: per-task AUC via Mann-Whitney U.
+        ref_aucs = []
+        for t in range(num_tasks):
+            preds = predictions_cpu[t]
+            lbls = labels_cpu[t]
+            wts = weights_cpu[t]
+            pos_idx = (lbls > 0).nonzero(as_tuple=True)[0]
+            neg_idx = (lbls == 0).nonzero(as_tuple=True)[0]
+            num = 0.0
+            den = 0.0
+            for p in pos_idx:
+                for n in neg_idx:
+                    w = float(wts[p].item()) * float(wts[n].item())
+                    if preds[p] > preds[n]:
+                        num += w
+                    elif preds[p] == preds[n]:
+                        num += 0.5 * w
+                    den += w
+            ref_aucs.append(num / den if den > 0 else 0.0)
+        ref = torch.tensor(ref_aucs, dtype=torch.float32)
+        torch.testing.assert_close(result.cpu().view(-1), ref, rtol=1e-4, atol=1e-4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
The audit at
/home/bensonma415/.llms/plans/permute_metric_layout_etc_rocm_grid_overflow_audit.plan.md
flagged `auc_kernel` (Tier-2 Special) in
`src/metric_ops/metric_ops.cu`. Unlike the other Tier-2 kernels in
this stack, `auc_kernel` cannot be converted to a grid-stride loop
without redesigning its inter-block coordination.

Why: `auc_kernel` is a chained block-level prefix-sum:
- `block_id = blockIdx.x % num_blocks`,
  `task_id = blockIdx.x / num_blocks` — `gridDim.x = num_blocks * num_tasks`
  exactly, no bail-out.
- Per-block calls `inclusive_sum_scan_kernel`, which publishes its
  block-prefix-sum into `block_sums_*` and bumps
  `block_flags[block_id]`.
- Block `block_id` (except the last) busy-waits on
  `while (atomicAdd(&block_flags[num_blocks - 1], 0) < 2)` for the
  *last* block of its task to publish the grand totals.

This is a decoupled-look-back / chained-scan that requires every
`(num_blocks * num_tasks)` CTA to be **resident concurrently**.
Capping `gridDim.x` would force serial reuse of `block_flags` /
`block_sums_*` slots → corrupts the cumsum (best case wrong output,
worst case deadlock on the spinwait). Algorithmic restructure (e.g.,
replace `inclusive_sum_scan_kernel` with `cub::DeviceScan::InclusiveSum`,
chunk per-task host-side, or split into a 2-pass scan) is **out of
scope** for Tier-2 — Tier-3 follow-up.

This diff lands a fast-fail `TORCH_CHECK` host-side guard in
`batch_auc` (placed once per dispatch, hoisted out of the
`LAUNCH_AUC_KERNEL` macro that fans into 4+ template instantiations)
that fires when the launch would exceed the HIP `2^32`
thread-per-launch limit:

    TORCH_CHECK(
        static_cast<uint64_t>(num_blocks) *
                static_cast<uint64_t>(num_tasks) *
                static_cast<uint64_t>(NUM_THREADS_PER_BLOCK) <
            (uint64_t(1) << 32),
        "auc_kernel launch would exceed HIP 2^32 thread-per-launch "
        "limit (num_blocks=", num_blocks,
        ", num_tasks=", num_tasks,
        ", threads_per_block=", NUM_THREADS_PER_BLOCK, ")");

This converts the silent HIP runtime error (or worse, the silent
NVIDIA wraparound producing wrong AUC values) into a clean Python
`RuntimeError` with a documented message until the cross-block
prefix-sum can be redesigned.

Parent fixes:
- D104903707, D104937969 (sparse_ops Tier-2 cap pattern)
- D105352349 (Tier-2 stack: recat_copy_async_kernel)
- D105353645 (Tier-2 stack: permute_multi_embs_kernel)
- D105354406 (Tier-2 stack: permute_pooled_embs_kernel)
- D105355306 (Tier-2 stack: permute_pooled_embs_split host cap)

Reviewed By: cthi

Differential Revision: D105355961


