### PR TITLE
Migrate TBE benchmark type imports to fbgemm_gpu.tbe.* leaves (Phase 3.7)

### DIFF
--- a/fbgemm_gpu/bench/merge_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/merge_embeddings_benchmark.py
@@ -18,13 +18,10 @@ import numpy as np
 import tabulate
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BoundsCheckMode,
-    EmbeddingLocation,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.config.embedding_config import BoundsCheckMode, EmbeddingLocation
 from torch import Tensor
 
 # pyre-fixme[21]: Could not find name `ProfilerActivity` in `torch.profiler`.

--- a/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
@@ -19,12 +19,6 @@ import click
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BoundsCheckMode,
-    CacheAlgorithm,
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     DenseTableBatchedEmbeddingBagsCodegen,
@@ -41,6 +35,12 @@ from fbgemm_gpu.tbe.bench import (
     TbeBenchClickInterface,
     TBEBenchmarkingConfig,
     TBEBenchmarkingConfigLoader,
+)
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config.embedding_config import (
+    BoundsCheckMode,
+    EmbeddingLocation,
+    PoolingMode,
 )
 from fbgemm_gpu.tbe.ssd import SSDTableBatchedEmbeddingBags
 from fbgemm_gpu.tbe.utils import generate_requests, get_device, round_up, TBERequest

--- a/fbgemm_gpu/bench/tbe/tbe_cache_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_cache_benchmark.py
@@ -13,13 +13,11 @@ import click
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    CacheAlgorithm,
-    EmbeddingLocation,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation
 from fbgemm_gpu.utils.loader import load_torch_module
 from torch import nn, Tensor
 

--- a/fbgemm_gpu/bench/tbe/tbe_inference_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_inference_benchmark.py
@@ -23,13 +23,6 @@ import click
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BoundsCheckMode,
-    CacheAlgorithm,
-    EmbeddingLocation,
-    PoolingMode,
-    RecordCacheMetrics,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
@@ -41,6 +34,13 @@ from fbgemm_gpu.tbe.bench import (
     benchmark_requests_refer,
     BenchmarkReporter,
     fill_random_scale_bias,
+)
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config.embedding_config import (
+    BoundsCheckMode,
+    EmbeddingLocation,
+    PoolingMode,
+    RecordCacheMetrics,
 )
 from fbgemm_gpu.tbe.utils import generate_requests, round_up, TBERequest
 from torch.profiler import profile

--- a/fbgemm_gpu/bench/tbe/tbe_kv_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_kv_benchmark.py
@@ -15,12 +15,12 @@ import click
 import numpy as np
 import psutil
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import EmbeddingLocation
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
 from fbgemm_gpu.tbe.bench import benchmark_requests
 from fbgemm_gpu.tbe.cache.kv_embedding_ops_inference import KVEmbeddingInference
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation
 from fbgemm_gpu.tbe.utils import generate_requests, round_up, TBERequest
 
 OptionCommandType = Callable[..., Callable[..., None]]

--- a/fbgemm_gpu/bench/tbe/tbe_ssd_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_ssd_benchmark.py
@@ -19,11 +19,6 @@ import click
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    CacheAlgorithm,
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
@@ -32,6 +27,8 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     SplitTableBatchedEmbeddingBagsCodegen,
 )
 from fbgemm_gpu.tbe.bench import benchmark_requests
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
 from fbgemm_gpu.tbe.ssd import (
     SSDIntNBitTableBatchedEmbeddingBags,
     SSDTableBatchedEmbeddingBags,

--- a/fbgemm_gpu/bench/tbe/tbe_training_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_training_benchmark.py
@@ -30,10 +30,6 @@ from fbgemm_gpu.split_embedding_configs import (
     EmbOptimType as OptimType,
     SparseType,
 )
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    CacheAlgorithm,
-    EmbeddingLocation,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     DenseTableBatchedEmbeddingBagsCodegen,
@@ -54,6 +50,8 @@ from fbgemm_gpu.tbe.bench.tbe_data_config_bench_helper import (
     generate_requests,
     generate_requests_with_Llist,
 )
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation
 from fbgemm_gpu.tbe.ssd import SSDTableBatchedEmbeddingBags
 from fbgemm_gpu.tbe.utils import get_device
 from torch.profiler import profile

--- a/fbgemm_gpu/bench/tbe/tbe_utils_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_utils_benchmark.py
@@ -20,11 +20,6 @@ import fbgemm_gpu
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BoundsCheckMode,
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
     rounded_row_size_in_bytes,
@@ -37,6 +32,11 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training_common import (
     generate_vbe_metadata,
 )
 from fbgemm_gpu.tbe.bench import benchmark_eval_compression, benchmark_requests
+from fbgemm_gpu.tbe.config.embedding_config import (
+    BoundsCheckMode,
+    EmbeddingLocation,
+    PoolingMode,
+)
 from fbgemm_gpu.tbe.utils import generate_requests, get_device, round_up, TBERequest
 from torch.profiler import profile
 


### PR DESCRIPTION
Summary:
Continues the Chunk H consumer migration: point the fbgemm_gpu benchmark
scripts at the canonical fbgemm_gpu.tbe.* leaf modules instead of the legacy
split_table_batched_embeddings_ops_common re-export shim.

Identity-preserving: split_table_batched_embeddings_ops_common already
re-exports these exact symbols from the same leaves, so importing directly
yields the same objects.

Files (10):
- bench/merge_embeddings_benchmark.py
- bench/tbe/{split_table_batched_embeddings,tbe_cache,tbe_inference,tbe_kv,tbe_ssd,tbe_training,tbe_utils}_benchmark.py
- fb/bench/split_table_batched_embeddings_benchmark_fb.py
- fb/triton/bench/triton_table_batched_embeddings_bench.py

Note: tbe_utils_benchmark.py keeps its generate_vbe_metadata import from
split_table_batched_embeddings_ops_training_common (that leaf, tbe/operators/vbe.py,
is a later chunk).

Reviewed By: henrylhtsang

Differential Revision: D112765163


