### PR TITLE
Drop redundant uint32_t narrowing at cap_grid_dim_x in jagged softmax/batched_dense_vec

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_backward.cu
@@ -125,7 +125,7 @@ std::tuple<Tensor, Tensor> batched_dense_vec_jagged_2d_mul_backward(
                 // is correctness-preserving.
                 // See: https://github.com/ROCm/hip/issues/2253
                 const auto blocks_x_t = utils::cuda::cap_grid_dim_x(
-                    static_cast<uint32_t>(div_round_up(B * H, block_dim_y)),
+                    div_round_up(B * H, block_dim_y),
                     kMaxThreads,
                     at::cuda::getCurrentCUDAStream());
 
@@ -152,8 +152,7 @@ std::tuple<Tensor, Tensor> batched_dense_vec_jagged_2d_mul_backward(
                 // correctness-preserving.
                 // See: https://github.com/ROCm/hip/issues/2253
                 const auto blocks_x_o = utils::cuda::cap_grid_dim_x(
-                    static_cast<uint32_t>(
-                        div_round_up(B * H * max_L, block_dim_y)),
+                    div_round_up(B * H * max_L, block_dim_y),
                     kMaxThreads,
                     at::cuda::getCurrentCUDAStream());
 

--- a/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_forward.cu
@@ -81,7 +81,7 @@ Tensor batched_dense_vec_jagged_2d_mul_forward(
     // correctness-preserving.
     // See: https://github.com/ROCm/hip/issues/2253
     const auto blocks_x = utils::cuda::cap_grid_dim_x(
-        static_cast<uint32_t>(div_round_up(B * H, block_dim_y)),
+        div_round_up(B * H, block_dim_y),
         kMaxThreads,
         at::cuda::getCurrentCUDAStream());
 

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_backward.cu
@@ -118,7 +118,7 @@ Tensor jagged_softmax_backward_cuda(
     const auto blocks_y = static_cast<int32_t>(
         std::min<int64_t>(B, static_cast<int64_t>(kMaxBlockYDim)));
     const auto blocks_x = utils::cuda::cap_grid_dim_x(
-        static_cast<uint32_t>(D),
+        D,
         static_cast<int64_t>(THREADS_PER_BLOCK) * blocks_y,
         at::cuda::getCurrentCUDAStream());
     const dim3 grid(blocks_x, blocks_y, 1);

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_forward.cu
@@ -141,7 +141,7 @@ Tensor jagged_softmax_forward_cuda(
     const auto blocks_y = static_cast<int32_t>(
         std::min<int64_t>(B, static_cast<int64_t>(kMaxBlockYDim)));
     const auto blocks_x = utils::cuda::cap_grid_dim_x(
-        static_cast<uint32_t>(D),
+        D,
         static_cast<int64_t>(THREADS_PER_BLOCK) * blocks_y,
         at::cuda::getCurrentCUDAStream());
     const dim3 grid(blocks_x, blocks_y, 1);


### PR DESCRIPTION
Summary: cap_grid_dim_x now takes an int64_t block count and clamps internally (landed in D105204171), so the static_cast<uint32_t> pre-narrowing at these already-landed call sites is redundant and counterproductive against the overflow guard. Drops it in jagged_softmax_forward/backward and batched_dense_vec_jagged_2d_mul_forward/backward.

Reviewed By: henrylhtsang

Differential Revision: D112381255


