### PR TITLE
Drop redundant casts at cap_grid_dim_x in jagged elementwise dispatch

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_backward.cu
@@ -125,7 +125,7 @@ std::tuple<Tensor, Tensor> batched_dense_vec_jagged_2d_mul_backward(
                 // is correctness-preserving.
                 // See: https://github.com/ROCm/hip/issues/2253
                 const auto blocks_x_t = utils::cuda::cap_grid_dim_x(
-                    static_cast<uint32_t>(div_round_up(B * H, block_dim_y)),
+                    div_round_up(B * H, block_dim_y),
                     kMaxThreads,
                     at::cuda::getCurrentCUDAStream());
 
@@ -152,8 +152,7 @@ std::tuple<Tensor, Tensor> batched_dense_vec_jagged_2d_mul_backward(
                 // correctness-preserving.
                 // See: https://github.com/ROCm/hip/issues/2253
                 const auto blocks_x_o = utils::cuda::cap_grid_dim_x(
-                    static_cast<uint32_t>(
-                        div_round_up(B * H * max_L, block_dim_y)),
+                    div_round_up(B * H * max_L, block_dim_y),
                     kMaxThreads,
                     at::cuda::getCurrentCUDAStream());
 

--- a/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_forward.cu
@@ -81,7 +81,7 @@ Tensor batched_dense_vec_jagged_2d_mul_forward(
     // correctness-preserving.
     // See: https://github.com/ROCm/hip/issues/2253
     const auto blocks_x = utils::cuda::cap_grid_dim_x(
-        static_cast<uint32_t>(div_round_up(B * H, block_dim_y)),
+        div_round_up(B * H, block_dim_y),
         kMaxThreads,
         at::cuda::getCurrentCUDAStream());
 

--- a/fbgemm_gpu/src/jagged_tensor_ops/common.cuh
+++ b/fbgemm_gpu/src/jagged_tensor_ops/common.cuh
@@ -779,54 +779,53 @@ inline bool jagged_dense_dense_elementwise_jagged_output_matches_opt(
 // `offset` at line 327 of common.cuh
 // (`for (offset = offset_begin; offset < nnz; offset += offset_stride)`),
 // so capping is correctness-preserving.
-#define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)                              \
-  {                                                                         \
-    dim3 threads, blocks;                                                   \
-    StackArray<int64_t> jagged_dims_tensor;                                 \
-    std::tie(threads, blocks, jagged_dims_tensor) =                         \
-        check_shape_and_partition_(x_values, x_offsets, y);                 \
-    blocks.x = div_round_up(x_values.size(0), threads.y);                   \
-    blocks.x = utils::cuda::cap_grid_dim_x(                                 \
-        static_cast<uint32_t>(blocks.x),                                    \
-        static_cast<int64_t>(threads.x) * static_cast<int64_t>(threads.y) * \
-            static_cast<int64_t>(threads.z),                                \
-        at::cuda::getCurrentCUDAStream());                                  \
-    std::vector<Tensor> x_offsets_contig;                                   \
-    x_offsets_contig.resize(num_jagged_dim);                                \
-    StackArray<index_t*> x_offset_ptrs;                                     \
-    x_offset_ptrs.ndim = num_jagged_dim;                                    \
-    StackArray<int64_t> x_offset_sizes;                                     \
-    x_offset_sizes.ndim = num_jagged_dim;                                   \
-    for (int d = 0; d < num_jagged_dim; ++d) {                              \
-      x_offsets_contig[d] = x_offsets[d].contiguous();                      \
-      x_offset_ptrs.vals[d] =                                               \
-          x_offsets_contig[d].template data_ptr<index_t>();                 \
-      x_offset_sizes.vals[d] = x_offsets[d].numel();                        \
-    }                                                                       \
-    const auto ff =                                                         \
-        ([f] __device__(                                                    \
-             scalar_t x, scalar_t y, scalar_t /*unused*/) -> scalar_t {     \
-          return f(x, y);                                                   \
-        });                                                                 \
-                                                                            \
-    FBGEMM_LAUNCH_KERNEL(                                                   \
-        (jagged_dense_dense_elementwise_jagged_output_kernel_<              \
-            NUM_JAGGED_DIM,                                                 \
-            index_t,                                                        \
-            scalar_t,                                                       \
-            decltype(ff)>),                                                 \
-        blocks,                                                             \
-        threads,                                                            \
-        0,                                                                  \
-        at::cuda::getCurrentCUDAStream(),                                   \
-        PTA_B(x_values, scalar_t, 2, 32),                                   \
-        x_offset_ptrs,                                                      \
-        x_offset_sizes,                                                     \
-        PTA_B(y_reshaped, scalar_t, 3, 32),                                 \
-        PTA_B(y_reshaped, scalar_t, 3, 32),                                 \
-        PTA_B(output_values, scalar_t, 2, 32),                              \
-        jagged_dims_tensor,                                                 \
-        ff);                                                                \
+#define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)                          \
+  {                                                                     \
+    dim3 threads, blocks;                                               \
+    StackArray<int64_t> jagged_dims_tensor;                             \
+    std::tie(threads, blocks, jagged_dims_tensor) =                     \
+        check_shape_and_partition_(x_values, x_offsets, y);             \
+    blocks.x = div_round_up(x_values.size(0), threads.y);               \
+    blocks.x = utils::cuda::cap_grid_dim_x(                             \
+        blocks.x,                                                       \
+        static_cast<int64_t>(threads.x) * threads.y * threads.z,        \
+        at::cuda::getCurrentCUDAStream());                              \
+    std::vector<Tensor> x_offsets_contig;                               \
+    x_offsets_contig.resize(num_jagged_dim);                            \
+    StackArray<index_t*> x_offset_ptrs;                                 \
+    x_offset_ptrs.ndim = num_jagged_dim;                                \
+    StackArray<int64_t> x_offset_sizes;                                 \
+    x_offset_sizes.ndim = num_jagged_dim;                               \
+    for (int d = 0; d < num_jagged_dim; ++d) {                          \
+      x_offsets_contig[d] = x_offsets[d].contiguous();                  \
+      x_offset_ptrs.vals[d] =                                           \
+          x_offsets_contig[d].template data_ptr<index_t>();             \
+      x_offset_sizes.vals[d] = x_offsets[d].numel();                    \
+    }                                                                   \
+    const auto ff =                                                     \
+        ([f] __device__(                                                \
+             scalar_t x, scalar_t y, scalar_t /*unused*/) -> scalar_t { \
+          return f(x, y);                                               \
+        });                                                             \
+                                                                        \
+    FBGEMM_LAUNCH_KERNEL(                                               \
+        (jagged_dense_dense_elementwise_jagged_output_kernel_<          \
+            NUM_JAGGED_DIM,                                             \
+            index_t,                                                    \
+            scalar_t,                                                   \
+            decltype(ff)>),                                             \
+        blocks,                                                         \
+        threads,                                                        \
+        0,                                                              \
+        at::cuda::getCurrentCUDAStream(),                               \
+        PTA_B(x_values, scalar_t, 2, 32),                               \
+        x_offset_ptrs,                                                  \
+        x_offset_sizes,                                                 \
+        PTA_B(y_reshaped, scalar_t, 3, 32),                             \
+        PTA_B(y_reshaped, scalar_t, 3, 32),                             \
+        PTA_B(output_values, scalar_t, 2, 32),                          \
+        jagged_dims_tensor,                                             \
+        ff);                                                            \
   }
 #else
 #define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)                          \

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_elementwise_mul_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_elementwise_mul_backward.cu
@@ -97,9 +97,8 @@ void jagged_jagged_elementwise_dense_output_(
   // correctness-preserving.
   // See: https://github.com/ROCm/hip/issues/2253
   blocks.x = utils::cuda::cap_grid_dim_x(
-      static_cast<uint32_t>(blocks.x),
-      static_cast<int64_t>(threads.x) * static_cast<int64_t>(threads.y) *
-          static_cast<int64_t>(threads.z),
+      blocks.x,
+      static_cast<int64_t>(threads.x) * threads.y * threads.z,
       at::cuda::getCurrentCUDAStream());
 
   // Canonicalize output to 3D, collapsing jagged dimensions.

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_backward.cu
@@ -118,7 +118,7 @@ Tensor jagged_softmax_backward_cuda(
     const auto blocks_y = static_cast<int32_t>(
         std::min<int64_t>(B, static_cast<int64_t>(kMaxBlockYDim)));
     const auto blocks_x = utils::cuda::cap_grid_dim_x(
-        static_cast<uint32_t>(D),
+        D,
         static_cast<int64_t>(THREADS_PER_BLOCK) * blocks_y,
         at::cuda::getCurrentCUDAStream());
     const dim3 grid(blocks_x, blocks_y, 1);

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_forward.cu
@@ -141,7 +141,7 @@ Tensor jagged_softmax_forward_cuda(
     const auto blocks_y = static_cast<int32_t>(
         std::min<int64_t>(B, static_cast<int64_t>(kMaxBlockYDim)));
     const auto blocks_x = utils::cuda::cap_grid_dim_x(
-        static_cast<uint32_t>(D),
+        D,
         static_cast<int64_t>(THREADS_PER_BLOCK) * blocks_y,
         at::cuda::getCurrentCUDAStream());
     const dim3 grid(blocks_x, blocks_y, 1);


### PR DESCRIPTION
Summary: cap_grid_dim_x takes int64_t, so the static_cast<uint32_t>(blocks.x) narrowing is redundant; also collapse the static_cast<int64_t> product to a single leading cast (the rest promote). Covers jagged_dense_elementwise_mul_backward and the shared JAGGED dispatch macro in common.cuh.

Reviewed By: henrylhtsang

Differential Revision: D112381248


