### PR TITLE
Drop redundant uint32_t narrowing at cap_grid_dim_x in repeat_arange/get_source_mask

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/get_source_mask.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/get_source_mask.cu
@@ -86,9 +86,7 @@ Tensor get_source_mask_cuda(
   // correctness-preserving.
   // See: https://github.com/ROCm/hip/issues/2253
   const auto num_blocks = utils::cuda::cap_grid_dim_x(
-      static_cast<uint32_t>(batch_size),
-      kMaxThreads,
-      at::cuda::getCurrentCUDAStream());
+      batch_size, kMaxThreads, at::cuda::getCurrentCUDAStream());
 
   AT_DISPATCH_INDEX_TYPES(
       num_sources.scalar_type(), "get_source_mask_kernel", ([&] {

--- a/fbgemm_gpu/src/jagged_tensor_ops/repeat_arange.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/repeat_arange.cu
@@ -109,9 +109,7 @@ Tensor repeat_arange_cuda(const Tensor& lengths) {
   // correctness-preserving.
   // See: https://github.com/ROCm/hip/issues/2253
   const auto num_blocks = utils::cuda::cap_grid_dim_x(
-      static_cast<uint32_t>(batch_size),
-      kMaxThreads,
-      at::cuda::getCurrentCUDAStream());
+      batch_size, kMaxThreads, at::cuda::getCurrentCUDAStream());
 
   AT_DISPATCH_INDEX_TYPES(
       lengths.scalar_type(), "repeat_arange_kernel", ([&] {


### PR DESCRIPTION
Summary: cap_grid_dim_x takes int64_t; the static_cast<uint32_t>(batch_size) pre-narrowing is redundant. Drops it in repeat_arange and get_source_mask.

Reviewed By: cthi

Differential Revision: D112381247


