### PR TITLE
Migrate test/tbe/** TBE type imports to fbgemm_gpu.tbe.* leaves (Phase 3.9) (#6066)

### DIFF
--- a/fbgemm_gpu/test/tbe/cache/cache_common.py
+++ b/fbgemm_gpu/test/tbe/cache/cache_common.py
@@ -14,15 +14,13 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    CacheAlgorithm,
-    EmbeddingLocation,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     MultiPassPrefetchConfig,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation
 from fbgemm_gpu.tbe.monitoring import TBEStatsReporter, TBEStatsReporterConfig
 from fbgemm_gpu.tbe.utils import round_up
 from hypothesis import Verbosity

--- a/fbgemm_gpu/test/tbe/cache/cache_test.py
+++ b/fbgemm_gpu/test/tbe/cache/cache_test.py
@@ -17,17 +17,14 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    CacheAlgorithm,
-    EmbeddingLocation,
-    RecordCacheMetrics,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     DEFAULT_ASSOC,
     MultiPassPrefetchConfig,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, RecordCacheMetrics
 from fbgemm_gpu.tbe.utils import (
     generate_requests,
     get_table_batched_offsets_from_dense,

--- a/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
+++ b/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
@@ -16,8 +16,8 @@ from itertools import accumulate
 import hypothesis.strategies as st
 import numpy as np
 import torch
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import CacheAlgorithm
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import DEFAULT_ASSOC
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
 from fbgemm_gpu.tbe.utils import generate_requests, TBERequest, to_device
 from hypothesis import given, settings, Verbosity
 from torch import Tensor

--- a/fbgemm_gpu/test/tbe/common.py
+++ b/fbgemm_gpu/test/tbe/common.py
@@ -14,10 +14,6 @@ import fbgemm_gpu
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     CacheAlgorithm,
     ComputeDevice,
@@ -25,6 +21,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     is_torchdynamo_compiling,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
 from hypothesis import HealthCheck, settings, Verbosity
 
 # pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.

--- a/fbgemm_gpu/test/tbe/inference/common.py
+++ b/fbgemm_gpu/test/tbe/inference/common.py
@@ -15,14 +15,11 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import FP8QuantizationConfig, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    CacheAlgorithm,
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
 from fbgemm_gpu.tbe.utils import (
     b_indices,
     fake_quantize_embs,

--- a/fbgemm_gpu/test/tbe/inference/inference_converter_test.py
+++ b/fbgemm_gpu/test/tbe/inference/inference_converter_test.py
@@ -23,10 +23,6 @@ from fbgemm_gpu.split_embedding_configs import (
     SparseType,
 )
 from fbgemm_gpu.split_embedding_inference_converter import SplitEmbInferenceConverter
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
@@ -34,6 +30,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
 from hypothesis import given, settings, Verbosity
 from torch import nn
 

--- a/fbgemm_gpu/test/tbe/inference/kv_embedding_test.py
+++ b/fbgemm_gpu/test/tbe/inference/kv_embedding_test.py
@@ -11,12 +11,12 @@ from unittest import skipIf, TestCase
 import fbgemm_gpu
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import EmbeddingLocation
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
     random_quant_scaled_tensor,
 )
 from fbgemm_gpu.tbe.cache.kv_embedding_ops_inference import KVEmbeddingInference
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation
 from fbgemm_gpu.tbe.utils import generate_requests
 
 # pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.

--- a/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
@@ -17,15 +17,16 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
+    IntNBitTableBatchedEmbeddingBagsCodegen,
+)
+from fbgemm_gpu.split_table_batched_embeddings_ops_training import DEFAULT_ASSOC
+from fbgemm_gpu.tbe.config.embedding_config import (
     EmbeddingLocation,
     EmbeddingSpecInfo,
     get_new_embedding_location,
     RecordCacheMetrics,
     tensor_to_device,
-)
-from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
-    IntNBitTableBatchedEmbeddingBagsCodegen,
 )
 from fbgemm_gpu.tbe.utils import get_table_batched_offsets_from_dense
 from hypothesis import given, settings, Verbosity

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_autovec_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_autovec_test.py
@@ -15,10 +15,8 @@ import unittest
 import hypothesis.strategies as st
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    CacheAlgorithm,
-    PoolingMode,
-)
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config.embedding_config import PoolingMode
 from hypothesis import given, settings, Verbosity
 
 from ..common import MAX_EXAMPLES, TEST_WITH_ROCM

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -18,11 +18,6 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    CacheAlgorithm,
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
@@ -31,6 +26,8 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     DEFAULT_ASSOC,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
 from fbgemm_gpu.tbe.utils import (
     b_indices,
     dequantize_embs,

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_threading_worker.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_threading_worker.py
@@ -15,13 +15,10 @@ import sys
 
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
 
 
 def main() -> None:

--- a/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
@@ -18,13 +18,11 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    CacheAlgorithm,
-    EmbeddingLocation,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation
 from fbgemm_gpu.tbe.utils import generate_requests, round_up
 from hypothesis import assume, given, settings, Verbosity
 

--- a/fbgemm_gpu/test/tbe/ssd/kv_backend_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/kv_backend_test.py
@@ -20,9 +20,9 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import EvictionPolicy
 from fbgemm_gpu.tbe.ssd import SSDTableBatchedEmbeddingBags
 from fbgemm_gpu.tbe.ssd.common import pad4
+from fbgemm_gpu.tbe.ssd.ssd_config import EvictionPolicy
 from fbgemm_gpu.tbe.ssd.training import BackendType, KVZCHParams
 from fbgemm_gpu.tbe.utils import round_up
 from hypothesis import given, settings, Verbosity

--- a/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
@@ -16,7 +16,7 @@ import fbgemm_gpu  # noqa E402
 import torch
 import torch.testing
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import BackendType
+from fbgemm_gpu.tbe.ssd.ssd_config import BackendType
 from fbgemm_gpu.utils.loader import load_torch_module
 from hypothesis import given, settings, strategies as st, Verbosity
 

--- a/fbgemm_gpu/test/tbe/ssd/ssd_rwlock_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_rwlock_test.py
@@ -28,10 +28,10 @@ import unittest
 
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import PoolingMode
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     rounded_row_size_in_bytes,
 )
+from fbgemm_gpu.tbe.config.embedding_config import PoolingMode
 from fbgemm_gpu.tbe.ssd import SSDIntNBitTableBatchedEmbeddingBags
 from fbgemm_gpu.tbe.ssd.inference import _RWLock
 from fbgemm_gpu.tbe.utils import get_table_batched_offsets_from_dense

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
@@ -16,13 +16,13 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     rounded_row_size_in_bytes,
     unpadded_row_size_in_bytes,
+)
+from fbgemm_gpu.tbe.config.embedding_config import (
+    DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
+    PoolingMode,
 )
 from fbgemm_gpu.tbe.ssd import SSDIntNBitTableBatchedEmbeddingBags
 from fbgemm_gpu.tbe.ssd.common import ASSOC

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
@@ -15,12 +15,9 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BackendType,
-    BoundsCheckMode,
-    PoolingMode,
-)
+from fbgemm_gpu.tbe.config.embedding_config import BoundsCheckMode, PoolingMode
 from fbgemm_gpu.tbe.ssd import SSDTableBatchedEmbeddingBags
+from fbgemm_gpu.tbe.ssd.ssd_config import BackendType
 from hypothesis import assume, given, settings, Verbosity
 
 from .. import common  # noqa E402

--- a/fbgemm_gpu/test/tbe/ssd/ssd_tbe_training_adam_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_tbe_training_adam_test.py
@@ -13,10 +13,8 @@ from typing import Any
 import hypothesis.strategies as st
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BackendType,
-    PoolingMode,
-)
+from fbgemm_gpu.tbe.config.embedding_config import PoolingMode
+from fbgemm_gpu.tbe.ssd.ssd_config import BackendType
 from hypothesis import assume, given, settings, Verbosity
 
 from .. import common  # noqa E402

--- a/fbgemm_gpu/test/tbe/ssd/ssd_tbe_training_partial_rowwise_adam_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_tbe_training_partial_rowwise_adam_test.py
@@ -13,11 +13,9 @@ from typing import Any
 import hypothesis.strategies as st
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BackendType,
-    PoolingMode,
-)
+from fbgemm_gpu.tbe.config.embedding_config import PoolingMode
 from fbgemm_gpu.tbe.ssd import SSDTableBatchedEmbeddingBags
+from fbgemm_gpu.tbe.ssd.ssd_config import BackendType
 from hypothesis import assume, given, settings, Verbosity
 
 from .. import common  # noqa E402

--- a/fbgemm_gpu/test/tbe/ssd/ssd_tbe_training_rowwise_adagrad_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_tbe_training_rowwise_adagrad_test.py
@@ -13,11 +13,9 @@ import unittest
 import hypothesis.strategies as st
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BackendType,
-    PoolingMode,
-)
+from fbgemm_gpu.tbe.config.embedding_config import PoolingMode
 from fbgemm_gpu.tbe.ssd import SSDTableBatchedEmbeddingBags
+from fbgemm_gpu.tbe.ssd.ssd_config import BackendType
 from hypothesis import assume, given, settings, Verbosity
 
 from .. import common  # noqa E402

--- a/fbgemm_gpu/test/tbe/ssd/training_common.py
+++ b/fbgemm_gpu/test/tbe/ssd/training_common.py
@@ -16,15 +16,10 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BackendType,
-    BoundsCheckMode,
-    EvictionPolicy,
-    KVZCHParams,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import RESParams
+from fbgemm_gpu.tbe.config.embedding_config import BoundsCheckMode, PoolingMode
 from fbgemm_gpu.tbe.ssd import SSDTableBatchedEmbeddingBags
+from fbgemm_gpu.tbe.ssd.ssd_config import BackendType, EvictionPolicy, KVZCHParams
 from fbgemm_gpu.tbe.utils import b_indices, get_table_batched_offsets_from_dense
 from torch import distributed as dist
 

--- a/fbgemm_gpu/test/tbe/stats/tbe_bench_params_reporter_test.py
+++ b/fbgemm_gpu/test/tbe/stats/tbe_bench_params_reporter_test.py
@@ -15,10 +15,6 @@ import hypothesis.strategies as st
 import torch
 from fbgemm_gpu.config import FeatureGateName
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    ComputeDevice,
-    EmbeddingLocation,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
@@ -35,6 +31,7 @@ from fbgemm_gpu.tbe.bench.tbe_data_config_bench_helper import (
     generate_embedding_dims,
     generate_requests,
 )
+from fbgemm_gpu.tbe.config.embedding_config import ComputeDevice, EmbeddingLocation
 from fbgemm_gpu.tbe.monitoring.bench_params_reporter import TBEBenchmarkParamsReporter
 from fbgemm_gpu.tbe.utils import get_device
 from hypothesis import given, settings

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
@@ -17,16 +17,13 @@ from fbgemm_gpu.split_embedding_configs import (
     nfp8_dtype,
     SparseType,
 )
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    CacheAlgorithm,
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     SplitTableBatchedEmbeddingBagsCodegen,
     WeightDecayMode,
 )
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
 from fbgemm_gpu.tbe.utils import (
     b_indices,
     get_table_batched_offsets_from_dense,

--- a/fbgemm_gpu/test/tbe/training/backward_dense_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_dense_test.py
@@ -15,10 +15,10 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import PoolingMode
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     DenseTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.config.embedding_config import PoolingMode
 from fbgemm_gpu.tbe.utils import (
     b_indices,
     get_table_batched_offsets_from_dense,

--- a/fbgemm_gpu/test/tbe/training/backward_determinism_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_determinism_test.py
@@ -26,15 +26,12 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     DenseTableBatchedEmbeddingBagsCodegen,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
 from fbgemm_gpu.tbe.utils import (
     get_table_batched_offsets_from_dense,
     round_up,

--- a/fbgemm_gpu/test/tbe/training/backward_none_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_none_test.py
@@ -22,14 +22,11 @@ from fbgemm_gpu.split_embedding_optimizer_ops import (
     SplitEmbeddingOptimizerParams,
     SplitEmbeddingRowwiseAdagrad,
 )
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
 from fbgemm_gpu.tbe.utils import (
     b_indices,
     get_table_batched_offsets_from_dense,

--- a/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
@@ -17,10 +17,6 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     CounterBasedRegularizationDefinition,
@@ -36,6 +32,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     UserEnabledConfigDefinition,
     WeightDecayMode,
 )
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
 from fbgemm_gpu.tbe.utils import (
     b_indices,
     get_table_batched_offsets_from_dense,

--- a/fbgemm_gpu/test/tbe/training/backward_sgd_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_sgd_test.py
@@ -15,16 +15,13 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    CacheAlgorithm,
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     SplitTableBatchedEmbeddingBagsCodegen,
     UserEnabledConfigDefinition,
 )
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
 from fbgemm_gpu.tbe.utils import (
     b_indices,
     get_table_batched_offsets_from_dense,

--- a/fbgemm_gpu/test/tbe/training/forward_backward_int32_overflow_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_backward_int32_overflow_test.py
@@ -14,14 +14,11 @@ from typing import Any
 import hypothesis.strategies as st
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
 from hypothesis import given, settings, Verbosity
 
 from ..common import gpu_unavailable

--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -22,16 +22,13 @@ from fbgemm_gpu.split_embedding_configs import (
     nfp8_dtype,
     SparseType,
 )
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    CacheAlgorithm,
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     RESParams,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
 from fbgemm_gpu.tbe.utils import (
     b_indices,
     generate_requests,

--- a/fbgemm_gpu/test/tbe/training/store_prefetched_tensors_test.py
+++ b/fbgemm_gpu/test/tbe/training/store_prefetched_tensors_test.py
@@ -11,14 +11,11 @@ import unittest
 from unittest.mock import patch
 
 import torch
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    ComputeDevice,
-    EmbeddingLocation,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     RESParams,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.config.embedding_config import ComputeDevice, EmbeddingLocation
 
 from ..common import open_source
 

--- a/fbgemm_gpu/test/tbe/utils/generate_vbe_metadata_test.py
+++ b/fbgemm_gpu/test/tbe/utils/generate_vbe_metadata_test.py
@@ -11,10 +11,10 @@ import unittest
 from itertools import accumulate
 
 import torch
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import PoolingMode
 from fbgemm_gpu.split_table_batched_embeddings_ops_training_common import (
     generate_vbe_metadata,
 )
+from fbgemm_gpu.tbe.config.embedding_config import PoolingMode
 
 from ..common import open_source
 

--- a/fbgemm_gpu/test/tbe/utils/split_embeddings_test.py
+++ b/fbgemm_gpu/test/tbe/utils/split_embeddings_test.py
@@ -18,7 +18,6 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import EmbeddingLocation
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
     rounded_row_size_in_bytes,
@@ -30,6 +29,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     INT8_EMB_ROW_DIM_OFFSET,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation
 from fbgemm_gpu.tbe.utils import (
     get_table_batched_offsets_from_dense,
     round_up,

--- a/fbgemm_gpu/test/tbe/utils/split_embeddings_utils_test.py
+++ b/fbgemm_gpu/test/tbe/utils/split_embeddings_utils_test.py
@@ -20,10 +20,7 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu import sparse_ops  # noqa: F401
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BoundsCheckMode,
-    PoolingMode,
-)
+from fbgemm_gpu.tbe.config.embedding_config import BoundsCheckMode, PoolingMode
 from hypothesis import assume, given, settings, Verbosity
 
 from .. import common  # noqa E402


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2966


Continues the Chunk H consumer migration: point the fbgemm_gpu test suite at
the canonical fbgemm_gpu.tbe.* leaf modules instead of the legacy
split_table_batched_embeddings_ops_common re-export shim.

Identity-preserving: ops_common already re-exports these exact symbols from
the same leaves (tbe/config/embedding_config.py, tbe/cache/cache_config.py,
tbe/ssd/ssd_config.py), so importing directly yields the same objects.
AUTODEPS updated test/tbe/BUCK (added :tbe_config, dropped an ops_common dep).

Scope: 34 test files across cache/, inference/, ssd/, stats/, training/, utils/
and test/tbe/common.py.

Intentionally NOT migrated (they assert the legacy path keeps working):
- test/tbe/cache/cache_config_test.py (test_matches_legacy_construct_cache_state)
- test/tbe/ssd/ssd_config_test.py (test_ops_common_lazy_ssd_reexports_resolve)

Also left as-is: training_common imports (generate_vbe_metadata) in the utils
tests -- that leaf (tbe/operators/vbe.py) is a later chunk.

Reviewed By: r-barnes

Differential Revision: D112848118
