### PR TITLE
Drop redundant casts at cap_grid_dim_x in segment_sum/lru_cache/reorder_batched_ad (#6067)

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_reorder_batched_ad.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_reorder_batched_ad.cu
@@ -88,7 +88,7 @@ DLL_PUBLIC Tensor reorder_batched_ad_lengths_gpu(
   const dim3 blocks(
       utils::cuda::cap_grid_dim_x(
           grid_size_uncapped,
-          static_cast<int64_t>(threads.x) * static_cast<int64_t>(threads.y),
+          static_cast<int64_t>(threads.x) * threads.y,
           at::cuda::getCurrentCUDAStream()));
 
   FBGEMM_DISPATCH_ALL_TYPES(
@@ -493,8 +493,7 @@ DLL_PUBLIC Tensor reorder_batched_ad_indices_gpu(
               const dim3 blocks(
                   utils::cuda::cap_grid_dim_x(
                       cuda_calc_xblock_count(B * T, NUM_WARPS),
-                      static_cast<int64_t>(threads.x) *
-                          static_cast<int64_t>(threads.y),
+                      static_cast<int64_t>(threads.x) * threads.y,
                       at::cuda::getCurrentCUDAStream()));
               FBGEMM_LAUNCH_KERNEL(
                   (reorder_batched_ad_indices_kernel_name),
@@ -601,7 +600,7 @@ DLL_PUBLIC Tensor reorder_batched_sequence_embeddings_gpu(
   const dim3 blocks(
       utils::cuda::cap_grid_dim_x(
           grid_size_uncapped,
-          static_cast<int64_t>(threads.x) * static_cast<int64_t>(threads.y),
+          static_cast<int64_t>(threads.x) * threads.y,
           at::cuda::getCurrentCUDAStream()));
 
   FBGEMM_DISPATCH_FLOATING_TYPES_AND(

--- a/fbgemm_gpu/src/sparse_ops/sparse_segment_sum_csr.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_segment_sum_csr.cu
@@ -94,9 +94,7 @@ DLL_PUBLIC Tensor segment_sum_csr_cuda(
   // segments, so capping the launch grid is correctness-preserving.
   // See: https://github.com/ROCm/hip/issues/2253
   const uint32_t num_blocks = utils::cuda::cap_grid_dim_x(
-      static_cast<uint32_t>(num_segments),
-      threads_per_block,
-      at::cuda::getCurrentCUDAStream());
+      num_segments, threads_per_block, at::cuda::getCurrentCUDAStream());
 
   FBGEMM_DISPATCH_ALL_TYPES(
       values.scalar_type(), "_segment_sum_csr_cuda_1", [&] {

--- a/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate.cu
@@ -233,9 +233,7 @@ void lru_cache_insert_cuda(
         // SM-bounded by div_round_up(SM_cnt, 8), so this cap is a no-op for it.
         // See: https://github.com/ROCm/hip/issues/2253
         const auto grid_size = utils::cuda::cap_grid_dim_x(
-            static_cast<uint32_t>(grid_size_uncapped),
-            kMaxThreads,
-            at::cuda::getCurrentCUDAStream());
+            grid_size_uncapped, kMaxThreads, at::cuda::getCurrentCUDAStream());
 
         FBGEMM_LAUNCH_KERNEL(
             (lru_cache_insert_kernel<emb_t, cache_t>),


### PR DESCRIPTION
Summary:

cap_grid_dim_x takes int64_t, so static_cast<uint32_t> narrowing is redundant in _segment_sum_csr and lru_cache_insert; also collapse the static_cast<int64_t> threads product to a single leading cast in reorder_batched_ad (3 launch sites).

Reviewed By: henrylhtsang

Differential Revision: D112381256


