### PR TITLE
Add grid-stride + ROCm cap to grad_indice_weights kernel

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_indice_weights_template.cu
@@ -18,6 +18,7 @@
 // Required for op registrations
 ////////////////////////////////////////////////////////////////////////////////
 #include "fbgemm_gpu/embedding_forward_template_helpers.cuh"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 #include "fbgemm_gpu/utils/ops_utils.h"
 #include "fbgemm_gpu/utils/tensor_utils.h"
 #include "fbgemm_gpu/utils/assert_macros.h"
@@ -106,10 +107,19 @@ __global__ __launch_bounds__(kForwardMaxThreads) void
     [[maybe_unused]] int64_t error_value = 0;
 
     int32_t T = D_offsets.size(0) - 1;
+    // On ROCm the launch caps the grid to stay within the HIP 2^32
+    // threads-per-launch limit, so we grid-stride to cover the full workload.
+    // On CUDA the grid is not capped and the loop body runs once per warp.
+#ifdef USE_ROCM
+    for (auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
+         b_t < offsets.size(0) - 1;
+         b_t += blockDim.y * gridDim.x) {
+#else
     auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
     if (b_t >= offsets.size(0) - 1) {
         return;
     }
+#endif
 
     int32_t t;
     [[maybe_unused]] int32_t b;
@@ -141,7 +151,12 @@ __global__ __launch_bounds__(kForwardMaxThreads) void
                 grad_indice_weights[indices_start + l] = 0.0;
             }
         }
+        // This b_t has no gradient to compute; move on to the next strided warp.
+#ifdef USE_ROCM
+        continue;
+#else
         return;
+#endif
     }
 
     emb_t* __restrict__ weights;
@@ -426,6 +441,9 @@ kernel_error_handler:
         weights_numel
     )
 {%- endif %}
+#ifdef USE_ROCM
+    } // for b_t (grid-stride loop, ROCm only)
+#endif
 }
 {%- endfor %} {# /* for use_vec_blocking */ #}
 
@@ -548,7 +566,10 @@ Tensor {{ mdesc }}_embedding_codegen_grad_indice_weights{{ vdesc }}_cuda(
                         cache_t,
                         index_t,
                         kFixedMaxVecsPerThread>),
-                    div_round_up(total_B, kForwardMaxThreads / kWarpSize),
+                    utils::cuda::cap_grid_dim_x(
+                        div_round_up(total_B, kForwardMaxThreads / kWarpSize),
+                        kForwardMaxThreads,
+                        at::cuda::getCurrentCUDAStream()),
                     dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
                     0,
                     at::cuda::getCurrentCUDAStream(),

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_nobag_small_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_nobag_small_template.cu
@@ -68,11 +68,22 @@ batch_index_select_dim0_codegen_forward_small_kernel(
     pta::PackedTensorAccessor64<output_t, {{ "1" if is_index_select else "2" }}, at::RestrictPtrTraits> output
     ) {
     int32_t T = weights_offsets.size(0);
-    auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
     {%- if not is_index_select %}
+    // On ROCm the launch caps the grid to stay within the HIP 2^32
+    // threads-per-launch limit, so we grid-stride to cover the full workload.
+    // On CUDA the grid is not capped and the loop body runs once per warp.
+#ifdef USE_ROCM
+    for (auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
+         b_t < offsets.size(0) - 1;
+         b_t += blockDim.y * gridDim.x) {
+#else
+    auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
     if (b_t >= offsets.size(0) - 1) {
         return;
     }
+#endif
+    {%- else %}
+    auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
     {%- endif %}
     int32_t t;
     int32_t b;
@@ -190,6 +201,11 @@ batch_index_select_dim0_codegen_forward_small_kernel(
             }
         }
     }
+    {%- if not is_index_select %}
+#ifdef USE_ROCM
+    } // for b_t (grid-stride loop, ROCm only)
+#endif
+    {%- endif %}
 }
 
 /*

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
@@ -633,7 +633,14 @@ batch_index_select_dim0_codegen_forward_cuda(
               output_t,
               index_t,
               kEmbeddingSize / 4>),
+            {%- if is_index_select %}
             div_round_up(total_B, kForwardMaxThreads / kWarpSize),
+            {%- else %}
+            utils::cuda::cap_grid_dim_x(
+                div_round_up(total_B, kForwardMaxThreads / kWarpSize),
+                kForwardMaxThreads,
+                at::cuda::getCurrentCUDAStream()),
+            {%- endif %}
             dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
             0,
             at::cuda::getCurrentCUDAStream(),
@@ -683,7 +690,14 @@ batch_index_select_dim0_codegen_forward_cuda(
               <emb_t, cache_t, output_t, use_cache_t, index_t>
               {%- endif %}
             ),
+            {%- if is_index_select %}
             div_round_up(total_B, kForwardMaxThreads / kWarpSize),
+            {%- else %}
+            utils::cuda::cap_grid_dim_x(
+                div_round_up(total_B, kForwardMaxThreads / kWarpSize),
+                kForwardMaxThreads,
+                at::cuda::getCurrentCUDAStream()),
+            {%- endif %}
             dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
             0,
             at::cuda::getCurrentCUDAStream(),

--- a/fbgemm_gpu/test/tbe/training/forward_backward_int32_overflow_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_backward_int32_overflow_test.py
@@ -14,7 +14,10 @@ from typing import Any
 import hypothesis.strategies as st
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import EmbeddingLocation
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+    EmbeddingLocation,
+    PoolingMode,
+)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     SplitTableBatchedEmbeddingBagsCodegen,
@@ -115,6 +118,76 @@ class ForwardBackwardInt32OverflowTest(unittest.TestCase):
 
         # Delete the op to save space
         del op
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_forward_nobag_large_grid(self) -> None:
+        """
+        Repro for the HIP 2**32 threads-per-launch overflow in the sequence
+        (nobag) TBE forward kernel.
+
+        The nobag forward launches
+        grid = div_round_up(total_B, kForwardMaxThreads / kWarpSize) with
+        block = dim3(kWarpSize, kForwardMaxThreads / kWarpSize), so the total
+        thread count is ~= total_B * kWarpSize. On ROCm (kWarpSize = 64),
+        total_B > 2**32 / 64 (~67.1M) exceeds the HIP limit. total_B = B * T;
+        we drive it with a large B and a tiny 1-row table (D = 4) so tensors
+        stay small -- the overflow is grid-driven, not memory-driven.
+
+        Pre-fix on ROCm, FBGEMM_LAUNCH_KERNEL ->
+        KernelLauncher::checkThreadCountNotExceeded TORCH_CHECK-fails. The fix
+        caps the grid on ROCm and grid-strides the small nobag kernel to cover
+        the full workload; the tail sentinel below fails if any strided bag is
+        dropped.
+
+        On CUDA (kWarpSize = 32) total threads stay under 2**32, so this is a
+        ROCm-specific repro.
+        """
+        if torch.version.hip is None:
+            self.skipTest("2**32 grid-overflow repro is ROCm-specific")
+
+        device = torch.cuda.current_device()
+        warp = 64
+        D = 4
+        E = 1
+        # total_B = B (T = 1). Require total_B * warp > 2**32.
+        B = (2**32) // warp + 2
+        self.assertGreater(B * warp, 2**32)
+
+        # offsets (B+1) i32 + indices B i32 + output B*D f32, with headroom.
+        needed_bytes = ((B + 1) * 4 + B * 4 + B * D * 4) * 6 // 5
+        total_memory = torch.cuda.get_device_properties().total_memory
+        free_memory = total_memory - torch.cuda.memory_reserved()
+        if free_memory < needed_bytes:
+            self.skipTest(
+                f"Skip test_forward_nobag_large_grid: free memory "
+                f"({free_memory}) < needed ({needed_bytes})"
+            )
+
+        op = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[(E, D, EmbeddingLocation.DEVICE, ComputeDevice.CUDA)],
+            output_dtype=SparseType.FP32,
+            pooling_mode=PoolingMode.NONE,
+            device=device,
+        )
+
+        # Row 0 of the (single) table = a known sentinel; every bag selects it.
+        sentinel = torch.tensor([1.0, 2.0, 3.0, 4.0], device=device)
+        with torch.no_grad():
+            op.split_embedding_weights()[0].copy_(sentinel.view(E, D))
+
+        indices = torch.zeros(B, dtype=torch.int, device=device)
+        offsets = torch.arange(0, B + 1, dtype=torch.int, device=device)
+
+        out = op(indices=indices, offsets=offsets)
+        torch.cuda.synchronize()
+
+        self.assertEqual(out.shape[0], B)
+        # Head / middle / tail bags must all be produced; the tail only appears
+        # if the ROCm grid-stride loop covers the whole (capped) workload.
+        torch.testing.assert_close(out[0].cpu(), sentinel.cpu())
+        torch.testing.assert_close(out[B // 2].cpu(), sentinel.cpu())
+        torch.testing.assert_close(out[-1].cpu(), sentinel.cpu())
+        del op, indices, offsets, out
 
     @unittest.skipIf(*gpu_unavailable)
     @given(**common_st)


### PR DESCRIPTION
Summary:
The TBE grad_indice_weights backward launches
grid = div_round_up(total_B, kForwardMaxThreads / kWarpSize) with
block = dim3(kWarpSize, kForwardMaxThreads / kWarpSize) (total_B = B * T), so
total threads ~= total_B * kWarpSize exceeds the HIP 2^32 threads-per-launch
limit on ROCm for large total_B.

Cap the launch with utils::cuda::cap_grid_dim_x(..., OverflowOnly) and add a
ROCm grid-stride loop to the kernel. The feature-does-not-require-grad early
exit becomes `continue` under ROCm so remaining strided warps are not dropped.
OverflowOnly is a no-op on CUDA, so CUDA codegen is unchanged.

Reviewed By: henrylhtsang

Differential Revision: D113351695


