### PR TITLE
Skip test_l2_norm_pruning_workflow in OSS CI (#6073)

### DIFF
--- a/fbgemm_gpu/experimental/hstu/hstu/cuda_hstu_attention.py
+++ b/fbgemm_gpu/experimental/hstu/hstu/cuda_hstu_attention.py
@@ -563,7 +563,6 @@ class HstuAttnVarlenFunc(torch.autograd.Function):
                 )
                 dout_t = dout_t.transpose(0, 2).contiguous().transpose(0, 2).detach()
             elif quant_mode == 2:
-                dim = q.shape[-1]
                 bm, bn = get_bm_and_bn_block_size_bwd()
                 q, q_descale, cu_seqlens_q_block_descale = quantize_for_block_scale(
                     ctx.q_fp16, cu_seqlens_q, block_size=bm, fp8_type=bwd_fp8_type

--- a/fbgemm_gpu/experimental/hstu/hstu/library.py
+++ b/fbgemm_gpu/experimental/hstu/hstu/library.py
@@ -12,13 +12,13 @@
 import logging
 import os
 
+import torch
+
 no_fbgemm_gpu: bool = False
 try:
     import fbgemm_gpu  # noqa: F401
 except ImportError:
     no_fbgemm_gpu = True
-
-import torch
 
 try:
     # pyre-ignore[21]

--- a/fbgemm_gpu/experimental/hstu/setup.py
+++ b/fbgemm_gpu/experimental/hstu/setup.py
@@ -1,18 +1,13 @@
 # Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 # Copyright (c) 2024, NVIDIA Corporation & AFFILIATES.
 
-import ast
 import copy
 import glob
-import itertools
 import os
 import platform
-import re
 import shutil
 import subprocess
 import sys
-import urllib.error
-import urllib.request
 import warnings
 from pathlib import Path
 
@@ -20,7 +15,6 @@ from packaging.version import parse, Version
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 from src.generate_kernels import generate_kernels_ampere, generate_kernels_hopper
-from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
@@ -123,12 +117,7 @@ if ONLY_COMPILE_SO:
 
 else:
     import torch
-    from torch.utils.cpp_extension import (
-        BuildExtension,
-        CppExtension,
-        CUDA_HOME,
-        CUDAExtension,
-    )
+    from torch.utils.cpp_extension import BuildExtension, CUDA_HOME, CUDAExtension
 
 
 def get_platform():

--- a/fbgemm_gpu/experimental/hstu/test/hstu_test.py
+++ b/fbgemm_gpu/experimental/hstu/test/hstu_test.py
@@ -1515,8 +1515,8 @@ def P_blockwise_Vt_gemm_fp8(
     BM = BN if swapQK else BM
     BN = BM if swapQK else BN
 
-    is_delta_q_m = (swapQK == False) and (start_ids is not None)
-    is_delta_q_n = (swapQK == True) and (start_ids is not None)
+    is_delta_q_m = (not swapQK) and (start_ids is not None)
+    is_delta_q_n = swapQK and (start_ids is not None)
 
     output = torch.zeros(B, H, seq_len_q, dim, dtype=torch.float, device="cuda")
     descale_one = torch.tensor([1.0], dtype=torch.float32, device="cuda")
@@ -1972,7 +1972,6 @@ def _bwd_reference_fp8(
     ori_n_k: int = n_k
     n_q = 16 * math.ceil(seqlen_q / 16)
     n_k = 16 * math.ceil(seqlen_k / 16)
-    L: int = q.size(0)
     dtype_out = q.dtype
     bm, bn = get_bm_and_bn_block_size_bwd()
 
@@ -2665,7 +2664,7 @@ class HSTU8Test(unittest.TestCase):
             )
             return
         if quant_mode > 0 and (
-            total_q % 16 != 0 or total_k % 16 != 0 or full_batch == False
+            total_q % 16 != 0 or total_k % 16 != 0 or not full_batch
         ):
             logger.info(
                 "Skipping test for quant_mode > 0 and (total_q % 16 != 0 or total_k % 16 != 0 or full_batch == False), not supported"

--- a/fbgemm_gpu/test/tbe/inference/inference_converter_test.py
+++ b/fbgemm_gpu/test/tbe/inference/inference_converter_test.py
@@ -42,9 +42,13 @@ from ..common import open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_available, on_arm_platform
+    from test_utils import gpu_available, on_arm_platform, running_on_github
 else:
-    from fbgemm_gpu.test.test_utils import gpu_available, on_arm_platform
+    from fbgemm_gpu.test.test_utils import (
+        gpu_available,
+        on_arm_platform,
+        running_on_github,
+    )
 
 EMB_WEIGHT_UNIFORM_INIT_BOUND = 0.000316
 MAX_EXAMPLES = 40
@@ -239,6 +243,7 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
         )
 
     @unittest.skipIf(*on_arm_platform)
+    @unittest.skipIf(*running_on_github)
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
     #  `hypothesis.strategies.booleans() if test_utils.gpu_available else
     #  hypothesis.strategies.just(True)` to decorator factory `hypothesis.given`.


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2977


- Skip test_l2_norm_pruning_workflow in OSS CI until we can figure out the test failure

Differential Revision: D113665992


