### PR TITLE
Multi-table CPU pooled coverage for dropped output pre-zero (D113243671)

### DIFF
--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -577,6 +577,119 @@ class NBitFowardTest(NBitFowardTestCommon):
             with self.subTest(case=name):
                 self._execute_nan_zero_fill(weights_ty, D, output_dtype, weighted)
 
+    def test_nbit_forward_cpu_multi_table_pooled_no_prezero(self) -> None:
+        """Multi-table CPU SUM-pooled nbit forward writes every output column itself.
+
+        This pins the invariant the pooled-output ``output.fill_(0)`` pre-zero is
+        redundant against: for FP32/FP16/BF16 the per-table ``D_offsets`` fully
+        partition ``[0, total_D)``, so each table overwrites only its own column
+        slice and, together, every column of every row is written -- including
+        empty (L == 0) and fully-pruned bags, which the kernel zeroes itself. Any
+        column a table failed to write would surface as leaked/uninitialized memory,
+        caught here by the exact-value and finite checks.
+
+        Uses distinct per-table D so the column partitioning is non-trivial, and
+        every embedding row set to 1.0 so each output column equals the count of
+        non-pruned indices in that (table, bag).
+        """
+        E = 100
+        Ds = [16, 24, 40]  # distinct per-table widths -> non-trivial D_offsets
+        T = len(Ds)
+        # Ragged per-(table, bag) lengths; include empty bags (L == 0).
+        Ls = [
+            [0, 2, 5, 0, 3, 4],
+            [1, 0, 4, 2, 0, 6],
+            [3, 3, 0, 1, 5, 0],
+        ]
+        B = len(Ls[0])
+        fully_pruned = [4, 2, 3]  # per table: a non-empty bag whose indices are all -1
+
+        for output_dtype in (SparseType.FP32, SparseType.FP16, SparseType.BF16):
+            with self.subTest(output_dtype=output_dtype):
+                op = IntNBitTableBatchedEmbeddingBagsCodegen(
+                    embedding_specs=[
+                        ("", E, Ds[t], SparseType.FP16, EmbeddingLocation.HOST)
+                        for t in range(T)
+                    ],
+                    output_dtype=output_dtype,
+                    pooling_mode=PoolingMode.SUM,
+                    device="cpu",
+                )
+                op.fill_random_weights()
+
+                # Overwrite every row of every table with 1.0 (exact in fp16).
+                for t in range(T):
+                    quant_weights, quant_scale_shift = quantize_embs(
+                        torch.ones(E, Ds[t]), SparseType.FP16
+                    )
+                    weights, scale_shift = op.split_embedding_weights()[t]
+                    weights.copy_(quant_weights)
+                    if quant_scale_shift is not None:
+                        self.assertIsNotNone(scale_shift)
+                        scale_shift.copy_(quant_scale_shift)
+
+                # Build indices/offsets in (table, bag) order, pruning ~1/3 of
+                # indices plus the designated fully-pruned bag per table.
+                all_indices: list[int] = []
+                offsets: list[int] = [0]
+                expected = torch.zeros(B, sum(Ds), dtype=torch.float)
+                d_prefix = np.cumsum([0, *Ds]).tolist()
+                running = 0
+                for t in range(T):
+                    for b in range(B):
+                        kept = 0
+                        for _ in range(Ls[t][b]):
+                            prune = (b == fully_pruned[t]) or (running % 3 == 0)
+                            all_indices.append(-1 if prune else (running % E))
+                            kept += 0 if prune else 1
+                            running += 1
+                        offsets.append(len(all_indices))
+                        expected[b, d_prefix[t] : d_prefix[t + 1]] = float(kept)
+
+                output = op(
+                    indices=torch.tensor(all_indices, dtype=torch.int),
+                    offsets=torch.tensor(offsets, dtype=torch.int),
+                )
+
+                self.assertEqual(tuple(output.shape), (B, sum(Ds)))
+                self.assertTrue(torch.isfinite(output.float()).all().item())
+                torch.testing.assert_close(
+                    output.float().cpu(),
+                    expected,
+                    atol=1.0e-2,
+                    rtol=1.0e-2,
+                    equal_nan=False,  # leaked uninitialized data (NaN) must fail
+                )
+
+    def test_nbit_forward_cpu_multi_table_out_of_bounds_all_tables_defined(
+        self,
+    ) -> None:
+        """An out-of-bounds index in ONE table of a multi-table pooled op is clamped
+        by the CPU bounds check, and every table's output slice stays finite and
+        fully written -- no path leaves the pooled output partially uninitialized,
+        even across the per-table column partition."""
+        E = 100
+        Ds = [16, 32]
+        op = IntNBitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                ("", E, Ds[0], SparseType.INT8, EmbeddingLocation.HOST),
+                ("", E, Ds[1], SparseType.INT8, EmbeddingLocation.HOST),
+            ],
+            output_dtype=SparseType.FP16,
+            pooling_mode=PoolingMode.SUM,
+            device="cpu",
+        )
+        op.fill_random_weights()
+
+        # (table, bag) order: t0b0 in-range, t0b1 empty, t1b0 out-of-range
+        # (clamped to row 0), t1b1 in-range.
+        indices = torch.tensor([0, E + 5, 3], dtype=torch.int)
+        offsets = torch.tensor([0, 1, 1, 2, 3], dtype=torch.int)
+        output = op(indices=indices, offsets=offsets)
+
+        self.assertEqual(tuple(output.shape), (2, sum(Ds)))
+        self.assertTrue(torch.isfinite(output.float()).all().item())
+
     @unittest.skipIf(*gpu_unavailable)
     @given(
         T=st.integers(min_value=1, max_value=10),


### PR DESCRIPTION
Summary:
Adds two CPU unit tests that pin the exact behavior changed in D113243671
("Drop redundant output pre-zero in quantized TBE CPU pooled forward"), which
removes the whole-output output.fill_(0) on the pooled FP32/FP16/BF16 path of
int_nbit_split_embedding_codegen_forward_*_cpu and makes the error path zero only
a table's own column slice.

- test_nbit_forward_cpu_multi_table_pooled_no_prezero: 3-table SUM-pooled op with
  distinct per-table D (16/24/40), every row = 1.0, ragged bags including empty
  (L==0) and fully-pruned bags, across output_dtype in {FP32, FP16, BF16}. Asserts
  each table's output column-slice equals its non-pruned count and empty/pruned
  bags are exactly 0 (equal_nan=False). Pins the invariant the removed pre-zero
  relied on: per-table D_offsets fully partition [0, total_D), so the kernel writes
  every column itself.
- test_nbit_forward_cpu_multi_table_out_of_bounds_all_tables_defined: multi-table
  op with an out-of-bounds (clamped) index in one table; asserts every table's
  output slice stays finite and fully written.

The !success per-table memset hunk is not deterministically reachable from Python
(needs a kernel failure that is not an out-of-bounds index); the out-of-bounds
test covers the reachable robustness of that region.

Reviewed By: cthi

Differential Revision: D113601556


