### PR TITLE
Add ROCm cap to count_unique_indices and find_long_segments launches

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -817,7 +817,8 @@ Tensor {{ embedding_cuda_op }}(
                 {{ "int64_t" if nobag else "uint32_t" }},
                 {{ "true" if nobag else "false" }}
                 >),
-            div_round_up(total_unique_indices, kMaxThreads),
+            utils::cuda::cap_grid_dim_x_from_workload(
+                total_unique_indices, kMaxThreads, at::cuda::getCurrentCUDAStream()),
             kMaxThreads,
             0,
             at::cuda::getCurrentCUDAStream(),
@@ -1029,7 +1030,8 @@ Tensor {{ embedding_cuda_op }}(
                 constexpr auto fls_ctx = "find_long_segments";
                 FBGEMM_LAUNCH_KERNEL(
                     split_embedding_backward_codegen_find_long_segments,
-                    div_round_up(total_unique_indices, kMaxThreads),
+                    utils::cuda::cap_grid_dim_x_from_workload(
+                        total_unique_indices, kMaxThreads, at::cuda::getCurrentCUDAStream()),
                     kMaxThreads,
                     0,
                     at::cuda::getCurrentCUDAStream(),


### PR DESCRIPTION
Summary:
split_embedding_backward_count_unique_indices_kernel and
split_embedding_backward_codegen_find_long_segments both launch
grid = div_round_up(total_unique_indices, kMaxThreads) with block = kMaxThreads.
On ROCm total threads ~= total_unique_indices exceeds the HIP 2^32
threads-per-launch limit for very large index counts.

Both kernels already grid-stride over run_id, so this is a cap-only fix: wrap
each grid with utils::cuda::cap_grid_dim_x_from_workload(total_unique_indices,
kMaxThreads, stream) (OverflowOnly). No-op on CUDA; kernels unchanged.

Reviewed By: cthi

Differential Revision: D113351684


