### PR TITLE
Add int32 overflow guards to CUDA sparse permute ops

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_1d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_1d.cu
@@ -232,6 +232,13 @@ permute_1D_sparse_data_cuda(
   Tensor permuted_lengths;
   Tensor permuted_indices;
   Tensor permuted_weights;
+  TORCH_CHECK(
+      permuted_lengths_size >= 0 &&
+          permuted_lengths_size <= std::numeric_limits<int32_t>::max(),
+      "permuted_lengths_size must be >= 0 and within int32. permute.numel() = ",
+      permuted_lengths_size,
+      ", lengths.numel() = ",
+      lengths_size);
   permuted_lengths = at::empty({permuted_lengths_size}, lengths.options());
 
   constexpr int32_t threads_1 = kMaxThreads;
@@ -270,6 +277,12 @@ permute_1D_sparse_data_cuda(
   } else {
     permuted_indices_size = output_offsets[-1].item<int64_t>();
   }
+  TORCH_CHECK(
+      permuted_indices_size >= 0 &&
+          permuted_indices_size <= std::numeric_limits<int32_t>::max(),
+      "permuted_indices_size must be >= 0 and within int32. "
+      "permuted_indices_size = ",
+      permuted_indices_size);
 
   constexpr int32_t BT_blocks = 16;
   dim3 threads_2(64, BT_blocks);
@@ -306,6 +319,13 @@ permute_1D_sparse_data_cuda(
                           weights_value.contiguous();
                       int32_t weights_columns = 1;
                       if (weights_value.dense_dim() > 1) {
+                        TORCH_CHECK(
+                            weights_value.size(1) >= 0 &&
+                                weights_value.size(1) <=
+                                    std::numeric_limits<int32_t>::max(),
+                            "weights_columns must be >= 0 and within int32. "
+                            "weights.size(1) = ",
+                            weights_value.size(1));
                         weights_columns = weights_value.size(1);
                         permuted_weights = at::empty(
                             {permuted_indices_size, weights_columns},

--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
@@ -248,6 +248,16 @@ permute_2D_sparse_preallocated_out_cuda(
     };
   }
 
+  // T and B are narrowed to int32_t at the kernel boundary, and the data
+  // kernels grid-stride over b_t < B * T (also int32_t). Guard the product so
+  // neither the narrowing nor the loop bound silently overflows.
+  TORCH_CHECK(
+      B * T <= std::numeric_limits<int32_t>::max(),
+      "B * T must be within int32. B = ",
+      B,
+      ", T = ",
+      T);
+
   Tensor permuted_lengths;
   Tensor permuted_indices;
   Tensor permuted_weights;
@@ -315,6 +325,13 @@ permute_2D_sparse_preallocated_out_cuda(
                 const auto weights_value_contig = weights_value.contiguous();
                 int32_t weights_columns = 1;
                 if (weights_value.dense_dim() > 1) {
+                  TORCH_CHECK(
+                      weights_value.size(1) >= 0 &&
+                          weights_value.size(1) <=
+                              std::numeric_limits<int32_t>::max(),
+                      "weights_columns must be >= 0 and within int32. "
+                      "weights.size(1) = ",
+                      weights_value.size(1));
                   weights_columns = weights_value.size(1);
                   permuted_weights = permuted_weights_out.has_value()
                       ? permuted_weights_out.value()
@@ -482,6 +499,22 @@ permute_sparse_features_cuda(
   const auto num_output_features = permute.numel();
   const auto num_features = lengths.size(0);
   const auto B = lengths.size(1);
+
+  // num_output_features and B are each narrowed to int32_t at the kernel
+  // boundary, and permute_indices_weights_kernel grid-strides over
+  // b_t < B * num_output_features (also int32_t). Unlike
+  // permute_2D_sparse_preallocated_out_cuda there is no early return for a zero
+  // dimension here, so guard each value in addition to the product: the product
+  // check alone would miss a degenerate case such as num_output_features == 0
+  // with B > INT32_MAX, where B still truncates.
+  TORCH_CHECK(
+      B <= std::numeric_limits<int32_t>::max() &&
+          num_output_features <= std::numeric_limits<int32_t>::max() &&
+          B * num_output_features <= std::numeric_limits<int32_t>::max(),
+      "B, num_output_features, and their product must be within int32. B = ",
+      B,
+      ", num_output_features = ",
+      num_output_features);
 
   Tensor permuted_lengths;
   Tensor permuted_indices;


### PR DESCRIPTION
Summary:
The CUDA `permute_1D_sparse_data`, `permute_2D_sparse_data` /
`permute_2D_sparse_preallocated_out`, and `permute_sparse_features`
kernels receive several size arguments as `int32_t` parameters
(`permuted_lengths_size`, `permuted_indices_size`, `T`, `B`,
`weights_columns`), while the host derives them as `int64_t` from
`numel()` / `size()`. When a host value -- or the `B * T` product that
the kernels use as the grid-stride loop bound -- exceeds `INT32_MAX`, it
silently truncates (and, for the product, overflows in 32-bit signed
arithmetic, which is UB) at the kernel boundary. The result is either a
wrong permutation or a non-deterministic CUDA illegal memory access with
no actionable error.

Add host-side `TORCH_CHECK` guards that fail fast with a descriptive
message (echoing the offending value) before launch. The checks are
purely additive; no existing narrowing or arithmetic is changed, so
valid in-range inputs are unaffected.

- `sparse_permute_1d.cu`: guard `permuted_lengths_size`,
  `permuted_indices_size`, and `weights.size(1)` against `INT32_MAX`.
- `sparse_permute_2d.cu`: guard `B * T` (in
  `permute_2D_sparse_preallocated_out_cuda`), `weights.size(1)`, and
  `B * num_output_features` (in `permute_sparse_features_cuda`). The
  products are evaluated in int64 (both operands are `int64_t` on the
  host), matching how the kernels later recompute them in int32.

Note: the 2D kernels take `permuted_indices_size` as `int64_t len`, so
unlike the 1D kernels it needs no guard.

Reviewed By: q10

Differential Revision: D113808890


