### PR TITLE
Fold grid.y/z into permute cap_grid_dim_x to fix HIP 2^32 overflow

### DIFF
--- a/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
@@ -278,18 +278,23 @@ std::vector<Tensor> permute_multi_embedding_function_gpu(
       fbgemm_gpu::kMaxThreads / fbgemm_gpu::kWarpSizeHost();
   const int32_t max_grid_dim = 32768; // The CUDA maximum is 65535, not 1<<N.
   const dim3 block_dim(fbgemm_gpu::kWarpSizeHost(), warp_per_block);
+  // The y/z dims carry batch_size (y is capped at max_grid_dim; z holds the
+  // overflow when batch_size > max_grid_dim).
+  const int32_t grid_dim_y =
+      std::min(static_cast<int32_t>(batch_size), max_grid_dim);
+  const int32_t grid_dim_z = (batch_size + max_grid_dim - 1) / max_grid_dim;
   // HIP enforces a hard limit of 2^32 total threads per launch.
-  // permute_multi_embs_kernel grid-strides over permute_id, so capping is
-  // correctness-preserving. y/z dims are already bounded by max_grid_dim.
+  // permute_multi_embs_kernel grid-strides over permute_id, so capping grid.x
+  // is correctness-preserving. cap_grid_dim_x bounds the *total* launch, so we
+  // must fold every other launch dimension (block threads and the y/z batch
+  // dims) into its per-column thread count -- otherwise a large batch_size
+  // multiplies past 2^32 even though grid.x alone fits.
   // See: https://github.com/ROCm/hip/issues/2253
   const auto blocks_x = utils::cuda::cap_grid_dim_x(
       fbgemm_gpu::div_round_up(permute_size, warp_per_block),
-      fbgemm_gpu::kMaxThreads,
+      static_cast<int64_t>(block_dim.x) * block_dim.y * grid_dim_y * grid_dim_z,
       at::cuda::getCurrentCUDAStream());
-  const dim3 grid_dim(
-      blocks_x,
-      std::min(static_cast<int32_t>(batch_size), max_grid_dim),
-      (batch_size + max_grid_dim - 1) / max_grid_dim);
+  const dim3 grid_dim(blocks_x, grid_dim_y, grid_dim_z);
 
   FBGEMM_DISPATCH_FLOATING_TYPES(
       pooled_embs[0].scalar_type(), "permute_multi_embedding", [&] {

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops.cu
@@ -111,18 +111,20 @@ Tensor permute_pooled_embs_gpu_impl(
   const int32_t max_grid_dim_y =
       32768; // The CUDA maximum is 65535, not a power of 2.
   const dim3 threads(fbgemm_gpu::kMaxThreads);
+  const int32_t blocks_y = std::min(static_cast<int32_t>(B), max_grid_dim_y);
+  const int32_t blocks_z = (B + max_grid_dim_y - 1) / max_grid_dim_y;
   // HIP enforces a hard limit of 2^32 total threads per launch.
-  // permute_pooled_embs_kernel grid-strides over t, so capping is
-  // correctness-preserving. y/z dims are already bounded by max_grid_dim_y.
+  // permute_pooled_embs_kernel grid-strides over t, so capping grid.x is
+  // correctness-preserving. cap_grid_dim_x bounds the *total* launch, so we
+  // must fold every other launch dimension (block threads and the y/z batch
+  // dims) into its per-column thread count -- otherwise a large B multiplies
+  // past 2^32 even though grid.x alone fits.
   // See: https://github.com/ROCm/hip/issues/2253
   const auto blocks_x = utils::cuda::cap_grid_dim_x(
       fbgemm_gpu::div_round_up(T, warp_per_block),
-      fbgemm_gpu::kMaxThreads,
+      static_cast<int64_t>(threads.x) * blocks_y * blocks_z,
       at::cuda::getCurrentCUDAStream());
-  const dim3 blocks(
-      blocks_x,
-      std::min(static_cast<int32_t>(B), max_grid_dim_y),
-      (B + max_grid_dim_y - 1) / max_grid_dim_y);
+  const dim3 blocks(blocks_x, blocks_y, blocks_z);
 
   FBGEMM_DISPATCH_FLOATING_TYPES(
       pooled_embs_contiguous.scalar_type(), "permute_pooled_embeddings", [&] {

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split.cu
@@ -111,19 +111,21 @@ Tensor permute_pooled_embs_split_gpu_impl(
   const int32_t max_grid_dim_y =
       32768; // The CUDA maximum is 65535, not a power of 2.
   const dim3 threads(fbgemm_gpu::kMaxThreads);
+  const int32_t blocks_y = std::min(static_cast<int32_t>(B), max_grid_dim_y);
+  const int32_t blocks_z = (B + max_grid_dim_y - 1) / max_grid_dim_y;
   // HIP enforces a hard limit of 2^32 total threads per launch.
   // permute_pooled_embs_kernel grid-strides over t (kernel-side change
-  // landed in the previous diff in this stack), so capping is
-  // correctness-preserving. y/z dims are already bounded by max_grid_dim_y.
+  // landed in the previous diff in this stack), so capping grid.x is
+  // correctness-preserving. cap_grid_dim_x bounds the *total* launch, so we
+  // must fold every other launch dimension (block threads and the y/z batch
+  // dims) into its per-column thread count -- otherwise a large B multiplies
+  // past 2^32 even though grid.x alone fits.
   // See: https://github.com/ROCm/hip/issues/2253
   const auto blocks_x = utils::cuda::cap_grid_dim_x(
       fbgemm_gpu::div_round_up(T, warp_per_block),
-      fbgemm_gpu::kMaxThreads,
+      static_cast<int64_t>(threads.x) * blocks_y * blocks_z,
       at::cuda::getCurrentCUDAStream());
-  const dim3 blocks(
-      blocks_x,
-      std::min(static_cast<int32_t>(B), max_grid_dim_y),
-      (B + max_grid_dim_y - 1) / max_grid_dim_y);
+  const dim3 blocks(blocks_x, blocks_y, blocks_z);
 
   FBGEMM_DISPATCH_FLOATING_TYPES(
       pooled_embs_contiguous.scalar_type(), "permute_pooled_embeddings", [&] {


### PR DESCRIPTION
Summary:
The permute embedding kernel launches cap grid.x via cap_grid_dim_x but
passed only the per-block thread count (kMaxThreads) as the threshold
argument, omitting the y/z batch dimensions. cap_grid_dim_x bounds the
*total* launch and requires all other launch dims folded into that
argument, so with a large batch the launch still exceeded HIP's 2^32
thread-per-launch limit even though grid.x alone fit, tripping
KernelLauncher::checkThreadCountNotExceeded on ROCm. The kernel-side
grid-stride + repro tests already landed (D105353645, D105354406,
D105355306) but these host call sites under-counted.

Fold block-threads * grid.y * grid.z into the cap so grid.x is clamped
against the full launch; the kernels already grid-stride over their
saturating dimension so a clamped grid.x still covers all work. Fixed at
all three host launch sites:
- permute_multi_embedding_ops.cu (permute_multi_embs_kernel)
- permute_pooled_embedding_ops.cu (permute_pooled_embs_kernel)
- permute_pooled_embedding_ops_split.cu (split frontend)

Differential Revision: D113884728


