### PR TITLE
Add grid-stride + ROCm cap to nbit inference forward kernel_small_L

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_host_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_host_template.cu
@@ -9,6 +9,7 @@
 // clang-format off
 {%- set wdesc =  "weighted" if weighted else "unweighted" %}
 #include "fbgemm_gpu/embedding_forward_template_helpers.cuh"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 #include "fbgemm_gpu/utils/kernel_launcher.cuh"
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
 #include "fbgemm_gpu/config/feature_gates.h"
@@ -71,7 +72,10 @@ __global__ void {{ type_map[emb_weight_type].enum_name }}_split_embedding{{ "_no
     #define X(DeviceOnly, PackedMode, OutputRowsPerThread, InputRowsInFlight, MinNum128BRows, MaxNum128BRows) \
       FBGEMM_LAUNCH_KERNEL( \
         ({{ func_name }}<index_t, output_t, OutputRowsPerThread, kWarpsPerBlock, InputRowsInFlight, MinNum128BRows, MaxNum128BRows, DeviceOnly, PackedMode>), \
-        nbit::div_round_up(T * nbit::div_round_up(B, num_packed_bags * OutputRowsPerThread), kWarpsPerBlock), \
+        utils::cuda::cap_grid_dim_x( \
+            nbit::div_round_up(T * nbit::div_round_up(B, num_packed_bags * OutputRowsPerThread), kWarpsPerBlock), \
+            kWarpSize * kWarpsPerBlock, \
+            at::cuda::getCurrentCUDAStream()), \
         dim3(kWarpSize, kWarpsPerBlock), \
         0, \
         at::cuda::getCurrentCUDAStream(), \

--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
@@ -57,10 +57,19 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
   {% else %}
   const int32_t B = (offsets.size(0) - 1) / T;
   {% endif %}
+  // On ROCm the launch caps the grid to stay within the HIP 2^32
+  // threads-per-launch limit, so we grid-stride to cover the full workload.
+  // On CUDA the grid is not capped and the loop body runs once per warp.
+#ifdef USE_ROCM
+  for (auto bb_t = blockIdx.x * blockDim.y + threadIdx.y;
+       bb_t < fd_B.D() * T;
+       bb_t += blockDim.y * gridDim.x) {
+#else
   const auto bb_t = blockIdx.x * blockDim.y + threadIdx.y;
   if (bb_t >= fd_B.D() * T) {
     return;
   }
+#endif
   static_assert(
     std::is_same_v<output_t, float> || std::is_same_v<output_t, at::BFloat16> || std::is_same_v<output_t, at::Half> || std::is_same_v<output_t, uint8_t>,
     "output_t can only be float or half or bytes now"
@@ -77,14 +86,22 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
   {% endif %}
   SparseType weight_ty = static_cast<SparseType>(weights_tys[t]);
   if (weight_ty != SparseType::{{ emb_weight_type.enum_name }}) {
+#ifdef USE_ROCM
+      continue;
+#else
       return;
+#endif
   }
 
   // default to 16 byte alignment for GPU TBE
   const int32_t D_bytes = padded_row_size_in_bytes(D, weight_ty, row_alignment);
 
   if (D_bytes <= MinNum128BRows * 128 || D_bytes > MaxNum128BRows * 128) {
+#ifdef USE_ROCM
+    continue;
+#else
     return;
+#endif
   }
   // Number of requests to row during accumulate and store stages w.r.t. different warp/wave sizes
   constexpr int32_t AccumulateStoreRequests = (kWarpSize == 64) ? (MaxNum128BRows + 1) / 2 : MaxNum128BRows;
@@ -550,6 +567,9 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
     }
   }
   {% endif %}
+#ifdef USE_ROCM
+  } // for bb_t (grid-stride loop, ROCm only)
+#endif
 }
 
 // kWarpsPerBlock is defined in embedding_forward_quantized_split_nbit_host_template.cu
@@ -619,4 +639,4 @@ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if nobag else ""
 
 }
 
-                                                                            // clang-format on
+                                                                              // clang-format on

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
@@ -37,10 +37,19 @@ void split_{{ optimizer }}_update_kernel(
     at::PhiloxCudaState stochastic_rounding_philox_args,
     {{ args.split_kernel_args | replace_pta_namespace() | join(",\n    ") }}
 ) {
+    // On ROCm the launch caps the grid to stay within the HIP 2^32
+    // threads-per-launch limit, so we grid-stride to cover the full workload.
+    // On CUDA the grid is not capped and the loop body runs once per warp.
+#ifdef USE_ROCM
+    for (auto run_id = blockIdx.x * blockDim.y + threadIdx.y;
+         run_id < grad_dev_indices.size(0);
+         run_id += blockDim.y * gridDim.x) {
+#else
     const auto run_id = blockIdx.x * blockDim.y + threadIdx.y;
     if (run_id >= grad_dev_indices.size(0)) {
       return;
     }
+#endif
 
 #ifdef FBGEMM_USE_SUBWARP_SHUFFLE
     const unsigned int shfl_sync_mask =
@@ -99,6 +108,9 @@ void split_{{ optimizer }}_update_kernel(
           shfl_sync_mask,
           kMaxVecsPerThread,
           {{ args.split_kernel_arg_names | join(", ") }});
+#ifdef USE_ROCM
+    } // for run_id (grid-stride loop, ROCm only)
+#endif
 }
 
 {%- for use_subwarp in [True, False] %}

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_template.cu
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_template.cu
@@ -192,7 +192,10 @@ void split_embedding_{{ optimizer }}_update(
                             kMaxVecsPerThread,
                             kThreadGroupSize,
                             4>),
-                        div_round_up(grad_dev_indices.numel(), kMaxThreads / kThreadGroupSize),
+                        utils::cuda::cap_grid_dim_x(
+                            div_round_up(grad_dev_indices.numel(), kMaxThreads / kThreadGroupSize),
+                            kMaxThreads,
+                            at::cuda::getCurrentCUDAStream()),
                         dim3(kThreadGroupSize, kMaxThreads / kThreadGroupSize, 1),
                         0, // Shared memory is not needed because uint8_t is not supported
                         at::cuda::getCurrentCUDAStream(),


### PR DESCRIPTION
Summary:
The nbit inference forward (int_nbit_split_embedding..._kernel_small_L) launches
grid = div_round_up(T * div_round_up(B, ...), kWarpsPerBlock) with
block = dim3(kWarpSize, kWarpsPerBlock), so total threads scale with T * B and
exceed the HIP 2^32 threads-per-launch limit on ROCm for large T * B.

Cap the launch with utils::cuda::cap_grid_dim_x(..., OverflowOnly) and add a
ROCm grid-stride loop over bb_t to the kernel. The kernel's per-warp early
exits (weight-type mismatch, D-range mismatch) become `continue` under ROCm so
non-matching warps are skipped rather than terminating the whole grid-stride.
No-op on CUDA.

Reviewed By: henrylhtsang

Differential Revision: D113351692


