### PR TITLE
Forward-compat nfp8_dtype fallback for torch.package re-export version blends

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -28,11 +28,28 @@ from torch.autograd.profiler import record_function  # usort:skip
 # @manual=//deeplearning/fbgemm/fbgemm_gpu/codegen:split_embedding_codegen_lookup_invokers
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers as invokers
 from fbgemm_gpu.config import FeatureGate, FeatureGateName
-from fbgemm_gpu.split_embedding_configs import (
-    EmbOptimType as OptimType,
-    nfp8_dtype,
-    SparseType,
-)
+from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
+
+try:
+    from fbgemm_gpu.split_embedding_configs import nfp8_dtype
+except ImportError:
+    # Forward-compat for torch.package re-export version blends (S685573): a
+    # model's frozen `split_embedding_configs`, bundled alongside this (newer)
+    # module at GMPP re-export time, may predate `nfp8_dtype` (added in
+    # D113263502). Import it defensively and fall back to the pre-arch-aware
+    # selection so this module finishes initializing regardless of the bundled
+    # `split_embedding_configs` version -- otherwise the failed top-level import
+    # leaves a poisoned partial module cached by the torch.package importer and
+    # a later `from ...ops_training import SplitTableBatchedEmbeddingBagsCodegen`
+    # fails. Mirrors the D110788115 `sparse_type_to_int` fallback pattern.
+    def nfp8_dtype() -> torch.dtype:
+        return (
+            torch.float8_e4m3fnuz
+            if torch.version.hip is not None
+            else torch.float8_e4m3fn
+        )
+
+
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     BoundsCheckMode,
     CacheAlgorithm,


### PR DESCRIPTION
Summary:
Fix-forward for S685573 (keeps the D113263502 arch-aware FP8 change instead of
landing the backout D113962469).

D113263502 added a hard top-level import of the new `nfp8_dtype` symbol into
`split_table_batched_embeddings_ops_training.py`:

    from fbgemm_gpu.split_embedding_configs import (
        EmbOptimType as OptimType, nfp8_dtype, SparseType)

At GMPP model re-export, torch.package blends this (fresh, externed) module with
a model's frozen `split_embedding_configs` that predates `nfp8_dtype`, so the
import raises `ImportError: cannot import name 'nfp8_dtype'`. Because the failed
top-level import leaves a poisoned partial module cached (torch.package does not
evict partial modules on a failed import), a later
`from ...ops_training import SplitTableBatchedEmbeddingBagsCodegen` then hits the
half-initialized module and surfaces the reported cascade, blocking model
publish (e.g. frozen fixture 2140558908, offsite_cvr_ios_dedicated_model).

Fix: import `nfp8_dtype` defensively and fall back to the pre-arch-aware fnuz/fn
selection when the bundled `split_embedding_configs` lacks it, so this module
always finishes initializing regardless of the bundled version and no poisoned
partial is cached. Same forward-compat idiom used for `sparse_type_to_int` in
D110788115 (S674229). When the runtime `split_embedding_configs` is present (the
normal, non-blended case) the arch-aware behavior is unchanged.

Reviewed By: henrylhtsang

Differential Revision: D113966884


