### PR TITLE
Add permute sparse-data benchmark scripts and --embed-dim option (#6090)

### DIFF
--- a/fbgemm_gpu/bench/sparse_ops_benchmark.py
+++ b/fbgemm_gpu/bench/sparse_ops_benchmark.py
@@ -1684,6 +1684,12 @@ def cat_reorder_batched_ad_indices_bench(
 @click.option("--num-segments", default=100)
 @click.option("--max-segment-length", default=10000)
 @click.option(
+    "--emb-dim",
+    default=256,
+    help="Multiplier applied to each segment length (indices per segment). "
+    "Set to 1 to match prod pooling factors; larger values model wider rows.",
+)
+@click.option(
     "--index-dtype", type=click.Choice(["int", "int64", "float"]), default="float"
 )
 @click.option("--has-weight", is_flag=True, default=False)
@@ -1702,6 +1708,7 @@ def cat_reorder_batched_ad_indices_bench(
 def permute_1d_sparse_data_bench(
     num_segments: int,
     max_segment_length: int,
+    emb_dim: int,
     index_dtype: str,
     has_weight: bool,
     device: str,
@@ -1724,7 +1731,6 @@ def permute_1d_sparse_data_bench(
         raise RuntimeError(f"Does not support data type {index_dtype}")
 
     # Generate variable-length segments to test vectorization
-    emb_dim = 256
     lengths = (
         torch.randint(
             low=max_segment_length // 2,
@@ -1832,6 +1838,12 @@ def permute_1d_sparse_data_bench(
 @click.option("--batch-size", default=128)
 @click.option("--max-segment-length", default=2000)
 @click.option(
+    "--emb-dim",
+    default=256,
+    help="Multiplier applied to each segment length (indices per segment). "
+    "Set to 1 to match prod pooling factors; larger values model wider rows.",
+)
+@click.option(
     "--index-dtype",
     type=click.Choice(["int", "int64", "float", "bf16", "fp16"]),
     default="float",
@@ -1854,6 +1866,7 @@ def permute_2d_sparse_data_bench(
     num_segments: int,
     batch_size: int,
     max_segment_length: int,
+    emb_dim: int,
     index_dtype: str,
     has_weight: bool,
     device: str,
@@ -1885,7 +1898,6 @@ def permute_2d_sparse_data_bench(
     # Use int64 to avoid integer overflow when summing large configurations
     # (e.g., num_segments=40, batch_size=512, max_segment_length=2000, emb_dim=256
     # can exceed INT32_MAX ~2.1 billion)
-    emb_dim = 256
     lengths = (
         torch.randint(
             low=max_segment_length // 2,

--- a/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
@@ -20,7 +20,6 @@ from fbgemm_gpu.split_embedding_configs import SparseType
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
-from fbgemm_gpu.split_table_batched_embeddings_ops_training import DEFAULT_ASSOC
 from fbgemm_gpu.tbe.config.embedding_config import (
     EmbeddingLocation,
     EmbeddingSpecInfo,


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2993

# TLDR;
Benchmarking tooling for the CUDA sparse permute ops (`permute_1D_sparse_data`, `permute_2D_sparse_data`), driven by representative prod shapes. Split out below the validation diff (D113841223) so both its baseline and the validation diff can run the sweep.

# Changes;
- Add `--embed-dim` to `permute_1d_sparse_data_bench` / `permute_2d_sparse_data_bench` (default 256; set to 1 to match prod pooling), replacing the hardcoded `emb_dim`.
- Add `run_permute_benchmark.sh`:
  - resolves machine/arch (h100/b200a/gh100/gh200/gb200/mi300/mi350), cuda version, and GPU
  - sweeps 4 1D + 5 2D prod shapes with weights off/on (18 runs); `--1d`/`--2d` restrict to one op set
  - exports per-config kineto traces (config-encoded names); writes a CSV via the analyzer
- Add `analyze_bench_permute.py`: parses the benchmark log (total CPU+GPU `fbgemm_gpu time` + bandwidth) into a table and CSV.

# Usage;
Run the sweep:
```
${HOME}/fbsource/fbcode/ai_codesign/nonprod/supadchaya/scripts/fbgemm/run_permute_benchmark.sh -c h100
${HOME}/fbsource/fbcode/ai_codesign/nonprod/supadchaya/scripts/fbgemm/run_permute_benchmark.sh -c gh200 --2d
```
Parse a log standalone:
```
python3 ${HOME}/fbsource/fbcode/ai_codesign/nonprod/supadchaya/scripts/fbgemm/analyze_bench_permute.py permute.log --csv out.csv
```

Reviewed By: q10

Differential Revision: D114045941


