### PR TITLE
Back out "Forward-compat nfp8_dtype fallback for torch.package re-export version blends"

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -28,28 +28,11 @@ from torch.autograd.profiler import record_function  # usort:skip
 # @manual=//deeplearning/fbgemm/fbgemm_gpu/codegen:split_embedding_codegen_lookup_invokers
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers as invokers
 from fbgemm_gpu.config import FeatureGate, FeatureGateName
-from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-
-try:
-    from fbgemm_gpu.split_embedding_configs import nfp8_dtype
-except ImportError:
-    # Forward-compat for torch.package re-export version blends (S685573): a
-    # model's frozen `split_embedding_configs`, bundled alongside this (newer)
-    # module at GMPP re-export time, may predate `nfp8_dtype` (added in
-    # D113263502). Import it defensively and fall back to the pre-arch-aware
-    # selection so this module finishes initializing regardless of the bundled
-    # `split_embedding_configs` version -- otherwise the failed top-level import
-    # leaves a poisoned partial module cached by the torch.package importer and
-    # a later `from ...ops_training import SplitTableBatchedEmbeddingBagsCodegen`
-    # fails. Mirrors the D110788115 `sparse_type_to_int` fallback pattern.
-    def nfp8_dtype() -> torch.dtype:
-        return (
-            torch.float8_e4m3fnuz
-            if torch.version.hip is not None
-            else torch.float8_e4m3fn
-        )
-
-
+from fbgemm_gpu.split_embedding_configs import (
+    EmbOptimType as OptimType,
+    nfp8_dtype,
+    SparseType,
+)
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     BoundsCheckMode,
     CacheAlgorithm,


### PR DESCRIPTION
Summary:
Backs out D113966884. That diff was a Python forward-fix for S685573 layered
on top of D113263502. We are now fully reverting D113263502 (via D113962469)
because it also caused a HIP binary-size relocation overflow in
sigrid.predictor.hip (cxx_relocation_overflow: doubled FP8 kernel
instantiations pushed .text past the 2^32 PC-relative limit), which a Python
fix cannot address.

Backing this out first restores split_table_batched_embeddings_ops_training.py
to the D113263502 state so the D113263502 backout (D113962469) applies cleanly
and the tree returns to the exact pre-D113263502 state. Left in place, this
forward-compat shim would become dead code (split_embedding_configs loses
nfp8_dtype after the D113263502 backout, so the try-import always hits the
fallback).

Reviewed By: ericluometa

Differential Revision: D114033024


