### PR TITLE
Fix CUDA-13 cudafe++ device-stub const mismatch (backward GWD warp kernel) (#6093)

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -433,7 +433,12 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row
     const int32_t max_vecs_per_thread,
     {%- if is_gwd_kernel %}
     {%- if "prev_iter_dev" not in args.split_function_arg_names %}
-    const pta::PackedTensorAccessor64<float, 1, at::RestrictPtrTraits> prev_iter_dev,
+    {#- /* The top-level `const` here must match the kernel declaration above (no
+          `const`). Under CUDA 13, cudafe++ emits the device stub with by-reference
+          params, so a top-level `const` on this parameter would make the stub
+          `const T&` while the kernel definition yields `T&`, and the explicit
+          instantiation would fail to match the device-stub template. */ #}
+    pta::PackedTensorAccessor64<float, 1, at::RestrictPtrTraits> prev_iter_dev,
     {%- endif %}
     {%- if "iter" not in args.split_function_arg_names %}
     const int64_t iter,

--- a/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
@@ -20,7 +20,6 @@ from fbgemm_gpu.split_embedding_configs import SparseType
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
-from fbgemm_gpu.split_table_batched_embeddings_ops_training import DEFAULT_ASSOC
 from fbgemm_gpu.tbe.config.embedding_config import (
     EmbeddingLocation,
     EmbeddingSpecInfo,


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2996

Building `deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops_training_gpu`
under CUDA 13.x fails to compile the generated `*_gwd_kernel_warp.cu` files:

  error: no function template matches function template specialization
  '__wrapper__device_stub_split_embedding_backward_codegen_rowwise_adagrad_weighted_gwd_kernel_warp_per_row_1'

Under CUDA 13, cudafe++ emits the `__wrapper__device_stub_...` with the kernel
parameters passed by reference. A top-level `const` on a kernel parameter then
makes the stub `const T&` while the kernel definition yields `T&`, so the
explicit template instantiation fails to match the generated device-stub
template.

In `embedding_backward_split_kernel_warp_template.cu` the GWD-only parameter
`prev_iter_dev` was declared WITHOUT `const` in the kernel definition (and host
declaration) but WITH a top-level `const` in the explicit instantiation — a
mismatch that only manifests on the GWD warp kernels (the CTA template is
already consistent, `prev_iter_dev` non-const on both sides, which is why only
`*_gwd_kernel_warp.cu` failed).

Drop the mismatched top-level `const` in the instantiation so it matches the
kernel definition. The change is unconditional (harmless on CUDA 12.x, where a
redundant top-level `const` on a by-reference parameter has no semantic effect)
and covers all optimizer / weighted / unweighted / vbe variants generated from
this template.

Differential Revision: D114081048


