### PR TITLE
Add opt-in host-side validation for CUDA sparse permute ops (#6095)

### DIFF
--- a/fbgemm_gpu/bench/sparse_ops_benchmark.py
+++ b/fbgemm_gpu/bench/sparse_ops_benchmark.py
@@ -1684,6 +1684,12 @@ def cat_reorder_batched_ad_indices_bench(
 @click.option("--num-segments", default=100)
 @click.option("--max-segment-length", default=10000)
 @click.option(
+    "--emb-dim",
+    default=256,
+    help="Multiplier applied to each segment length (indices per segment). "
+    "Set to 1 to match prod pooling factors; larger values model wider rows.",
+)
+@click.option(
     "--index-dtype", type=click.Choice(["int", "int64", "float"]), default="float"
 )
 @click.option("--has-weight", is_flag=True, default=False)
@@ -1702,6 +1708,7 @@ def cat_reorder_batched_ad_indices_bench(
 def permute_1d_sparse_data_bench(
     num_segments: int,
     max_segment_length: int,
+    emb_dim: int,
     index_dtype: str,
     has_weight: bool,
     device: str,
@@ -1724,7 +1731,6 @@ def permute_1d_sparse_data_bench(
         raise RuntimeError(f"Does not support data type {index_dtype}")
 
     # Generate variable-length segments to test vectorization
-    emb_dim = 256
     lengths = (
         torch.randint(
             low=max_segment_length // 2,
@@ -1832,6 +1838,12 @@ def permute_1d_sparse_data_bench(
 @click.option("--batch-size", default=128)
 @click.option("--max-segment-length", default=2000)
 @click.option(
+    "--emb-dim",
+    default=256,
+    help="Multiplier applied to each segment length (indices per segment). "
+    "Set to 1 to match prod pooling factors; larger values model wider rows.",
+)
+@click.option(
     "--index-dtype",
     type=click.Choice(["int", "int64", "float", "bf16", "fp16"]),
     default="float",
@@ -1854,6 +1866,7 @@ def permute_2d_sparse_data_bench(
     num_segments: int,
     batch_size: int,
     max_segment_length: int,
+    emb_dim: int,
     index_dtype: str,
     has_weight: bool,
     device: str,
@@ -1885,7 +1898,6 @@ def permute_2d_sparse_data_bench(
     # Use int64 to avoid integer overflow when summing large configurations
     # (e.g., num_segments=40, batch_size=512, max_segment_length=2000, emb_dim=256
     # can exceed INT32_MAX ~2.1 billion)
-    emb_dim = 256
     lengths = (
         torch.randint(
             low=max_segment_length // 2,

--- a/fbgemm_gpu/src/sparse_ops/common.cuh
+++ b/fbgemm_gpu/src/sparse_ops/common.cuh
@@ -12,6 +12,11 @@
 #include "fbgemm_gpu/utils/cuda_utilities.cuh"
 #include "fbgemm_gpu/utils/ops_utils.h"
 
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <string>
+
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/op_registration/op_registration.h>
@@ -52,6 +57,240 @@ using Tensor = at::Tensor;
 namespace fbgemm_gpu {
 
 constexpr int MAX_ELEMENTS_PER_THREAD = 4;
+
+// Opt-in host-side validation for the sparse permute ops. Every check below
+// performs a D2H sync, so it is gated behind an env var which is off by
+// default. Enable with FBGEMM_DEBUG_PERMUTE=1 for additional debugging with a
+// performance penalty. When disabled, callers see a single cached-bool branch
+// and no syncs.
+inline bool is_debug_permute_enabled() {
+  static const bool enabled = [] {
+    const char* v = std::getenv("FBGEMM_DEBUG_PERMUTE");
+    if (v == nullptr || v[0] == '\0') {
+      return false;
+    }
+    // Accept common truthy spellings (case-insensitive) so users who set
+    // "true"/"yes"/"on"/"1" all get debugging. Anything else counts as
+    // disabled; warn so a typo or unsupported value isn't silently ignored.
+    std::string val(v);
+    std::transform(val.begin(), val.end(), val.begin(), [](unsigned char c) {
+      return std::tolower(c);
+    });
+    if (val == "1" || val == "true" || val == "yes" || val == "on") {
+      return true;
+    }
+    TORCH_WARN(
+        "[DEBUG permute] FBGEMM_DEBUG_PERMUTE=\"",
+        v,
+        "\" is not a recognized truthy value; debug validation stays disabled. "
+        "Use one of: 1, true, yes, on.");
+    return false;
+  }();
+  return enabled;
+}
+
+// Stage 1: validate the raw inputs. permute indexes lengths / input_offsets, so
+// an out-of-range value would cause an out-of-bounds read; lengths must be
+// non-negative and indices must cover the full input sum.
+// `permute_index_bound` is the exclusive upper bound for permute values
+// (lengths.numel() for 1D, lengths.size(0) for 2D). `weights` is the optional
+// per-index weights argument; its presence and column width are logged (not
+// validated).
+inline void debug_check_permute_inputs(
+    const char* tag,
+    const at::Tensor& permute,
+    const at::Tensor& lengths,
+    const at::Tensor& indices,
+    int64_t permute_index_bound,
+    const std::optional<at::Tensor>& weights) {
+  const auto permute_min = permute.min().item<int64_t>();
+  const auto permute_max = permute.max().item<int64_t>();
+  const auto lengths_min = lengths.min().item<int64_t>();
+  const auto lengths_max = lengths.max().item<int64_t>();
+  const auto lengths_sum = lengths.sum().item<int64_t>();
+  const auto indices_numel = indices.numel();
+  // indices can be empty (e.g. all lengths zero); min/max on an empty tensor
+  // throws, so only read them when there is data. When empty, min/max are
+  // logged as a placeholder 0 -- the numel=0 printed first disambiguates it.
+  const auto indices_min =
+      indices_numel > 0 ? indices.min().item<int64_t>() : 0;
+  const auto indices_max =
+      indices_numel > 0 ? indices.max().item<int64_t>() : 0;
+  // weights is optional and parallel to indices; log presence and the per-index
+  // column width (weights_columns), but do not validate it.
+  const bool has_weight = weights.has_value();
+  const auto weights_columns =
+      (has_weight && weights->dim() > 1) ? weights->size(1) : 1;
+  TORCH_WARN(
+      "[DEBUG ",
+      tag,
+      "] STAGE1 checking inputs | permute: numel=",
+      permute.numel(),
+      " min=",
+      permute_min,
+      " max=",
+      permute_max,
+      " | lengths: numel=",
+      lengths.numel(),
+      " min=",
+      lengths_min,
+      " max=",
+      lengths_max,
+      " sum=",
+      lengths_sum,
+      " | indices: numel=",
+      indices_numel,
+      " min=",
+      indices_min,
+      " max=",
+      indices_max,
+      " | weights: present=",
+      has_weight,
+      " columns=",
+      weights_columns);
+  TORCH_CHECK(
+      permute_min >= 0 && permute_max < permute_index_bound,
+      "[DEBUG ",
+      tag,
+      "] FAILED in Stage 1: permute out of range [0, ",
+      permute_index_bound,
+      "): min=",
+      permute_min,
+      " max=",
+      permute_max,
+      " -> lengths kernel will read OOB (corrupt caller input)");
+  TORCH_CHECK(
+      lengths_min >= 0,
+      "[DEBUG ",
+      tag,
+      "] FAILED in Stage 1: negative input length min=",
+      lengths_min,
+      " (corrupt caller input)");
+  // indices holds all input segments, so it must cover the full input sum; an
+  // undersized indices tensor means the data kernel reads OOB from it (stale
+  // metadata: lengths claims more elements than indices has).
+  TORCH_CHECK(
+      indices_numel >= lengths_sum,
+      "[DEBUG ",
+      tag,
+      "] FAILED in Stage 1: indices undersized: indices.numel()=",
+      indices_numel,
+      " < lengths.sum()=",
+      lengths_sum,
+      " -> data kernel reads OOB from indices (stale/mismatched metadata)");
+  // Per-element upper bound: sum(lengths) == indices.numel() and all lengths
+  // are non-negative, so no single length can exceed the total. A lone
+  // garbage-huge length that the aggregate sum check might not isolate is
+  // pinpointed here.
+  TORCH_CHECK(
+      lengths_max <= indices_numel,
+      "[DEBUG ",
+      tag,
+      "] FAILED in Stage 1: input length exceeds total indices: lengths.max()=",
+      lengths_max,
+      " > indices.numel()=",
+      indices_numel,
+      " (garbage/stale length value)");
+}
+
+// Stage 2: validate permuted_lengths after the lengths kernel. Each entry is a
+// copy of an input length, so values must be non-negative and no larger than
+// the total number of indices. Returns the sum so Stage 3 can reuse it without
+// a second D2H sync.
+inline int64_t debug_check_permuted_lengths(
+    const char* tag,
+    const at::Tensor& permuted_lengths,
+    int64_t indices_numel) {
+  const auto pl_min = permuted_lengths.min().item<int64_t>();
+  const auto pl_max = permuted_lengths.max().item<int64_t>();
+  const auto pl_sum = permuted_lengths.sum().item<int64_t>();
+  TORCH_WARN(
+      "[DEBUG ",
+      tag,
+      "] STAGE2 checking permuted_lengths | numel=",
+      permuted_lengths.numel(),
+      " min=",
+      pl_min,
+      " max=",
+      pl_max,
+      " sum=",
+      pl_sum);
+  TORCH_CHECK(
+      pl_min >= 0 && pl_max <= indices_numel,
+      "[DEBUG ",
+      tag,
+      "] FAILED in Stage 2: permuted_lengths corrupted after lengths kernel: min=",
+      pl_min,
+      " max=",
+      pl_max,
+      " sum=",
+      pl_sum,
+      " indices.numel()=",
+      indices_numel);
+  return pl_sum;
+}
+
+// Stage 3: validate the offsets. A complete cumsum must start at 0, be
+// monotonic non-decreasing, and its last element must equal the sum of
+// permuted_lengths. Checking the whole array, not just the last element,
+// isolates a cumsum that is wrong in the middle but right at the end.
+// `permuted_lengths_sum` is the independent Stage 2 result, reused to avoid an
+// extra D2H sync.
+inline void debug_check_output_offsets(
+    const char* tag,
+    const at::Tensor& output_offsets,
+    int64_t permuted_lengths_sum) {
+  // asynchronous_complete_cumsum_gpu returns at least one element, but guard
+  // empty defensively so a debug indexing throw never masks the real
+  // validation failure (symmetric with the min/max guards elsewhere here).
+  const auto oo_numel = output_offsets.numel();
+  const auto oo_last = oo_numel > 0 ? output_offsets[-1].item<int64_t>() : 0;
+  const auto oo_first = oo_numel > 0 ? output_offsets[0].item<int64_t>() : 0;
+  // When output_offsets has a single element, diff() is empty and min() would
+  // throw, so min_delta is set to a placeholder 0 (numel is printed first to
+  // disambiguate) and the monotonic check passes vacuously.
+  const auto min_delta = output_offsets.numel() > 1
+      ? output_offsets.diff().min().item<int64_t>()
+      : 0;
+  TORCH_WARN(
+      "[DEBUG ",
+      tag,
+      "] STAGE3 checking offsets | output_offsets: numel=",
+      output_offsets.numel(),
+      " dtype=",
+      output_offsets.scalar_type(),
+      " [0]=",
+      oo_first,
+      " [-1]=",
+      oo_last,
+      " min_delta=",
+      min_delta,
+      " permuted_lengths.sum()=",
+      permuted_lengths_sum);
+  TORCH_CHECK(
+      oo_last == permuted_lengths_sum,
+      "[DEBUG ",
+      tag,
+      "] FAILED in Stage 3: cumsum mismatch output_offsets[-1]=",
+      oo_last,
+      " != permuted_lengths.sum()=",
+      permuted_lengths_sum,
+      " (complete_cumsum bug or permuted_lengths mutated between STAGE2 and cumsum)");
+  TORCH_CHECK(
+      oo_first == 0,
+      "[DEBUG ",
+      tag,
+      "] FAILED in Stage 3: output_offsets[0]=",
+      oo_first,
+      " != 0 (corrupt complete_cumsum)");
+  TORCH_CHECK(
+      min_delta >= 0,
+      "[DEBUG ",
+      tag,
+      "] FAILED in Stage 3: output_offsets not monotonic, min delta=",
+      min_delta,
+      " (corrupt complete_cumsum)");
+}
 
 template <
     typename scalar_t,

--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_1d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_1d.cu
@@ -228,6 +228,16 @@ permute_1D_sparse_data_cuda(
         weights.has_value() ? std::make_optional(weights->clone())
                             : std::nullopt};
   }
+  int64_t debug_permuted_lengths_sum = 0;
+  if (is_debug_permute_enabled()) {
+    debug_check_permute_inputs(
+        "permute_1D",
+        permute_contig,
+        lengths_contig,
+        indices_contig,
+        lengths_size,
+        weights);
+  }
 
   Tensor permuted_lengths;
   Tensor permuted_indices;
@@ -267,10 +277,21 @@ permute_1D_sparse_data_cuda(
             });
       });
 
+  if (is_debug_permute_enabled()) {
+    debug_permuted_lengths_sum = debug_check_permuted_lengths(
+        "permute_1D", permuted_lengths, indices_contig.numel());
+  }
+
   // convert lengths to offsets
   const auto input_offsets = asynchronous_exclusive_cumsum_gpu(lengths_contig);
   const auto output_offsets =
       asynchronous_complete_cumsum_gpu(permuted_lengths.flatten());
+
+  if (is_debug_permute_enabled()) {
+    debug_check_output_offsets(
+        "permute_1D", output_offsets, debug_permuted_lengths_sum);
+  }
+
   int64_t permuted_indices_size = 0;
   if (permuted_lengths_sum.has_value()) {
     permuted_indices_size = permuted_lengths_sum.value();

--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
@@ -258,6 +258,17 @@ permute_2D_sparse_preallocated_out_cuda(
       ", T = ",
       T);
 
+  int64_t debug_permuted_lengths_sum = 0;
+  if (is_debug_permute_enabled()) {
+    debug_check_permute_inputs(
+        "permute_2D",
+        permute_contig,
+        lengths_contig,
+        indices_contig,
+        lengths.size(0),
+        weights);
+  }
+
   Tensor permuted_lengths;
   Tensor permuted_indices;
   Tensor permuted_weights;
@@ -288,10 +299,21 @@ permute_2D_sparse_preallocated_out_cuda(
             permuted_lengths.data_ptr<index_t>());
       });
 
+  if (is_debug_permute_enabled()) {
+    debug_permuted_lengths_sum = debug_check_permuted_lengths(
+        "permute_2D", permuted_lengths, indices_contig.numel());
+  }
+
   // convert lengths to offsets
   const auto input_offsets = asynchronous_exclusive_cumsum_gpu(lengths_contig);
   const auto output_offsets =
       asynchronous_complete_cumsum_gpu(permuted_lengths.flatten());
+
+  if (is_debug_permute_enabled()) {
+    debug_check_output_offsets(
+        "permute_2D", output_offsets, debug_permuted_lengths_sum);
+  }
+
   int64_t permuted_indices_size = 0;
   if (permuted_lengths_sum.has_value()) {
     permuted_indices_size = permuted_lengths_sum.value();

--- a/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
@@ -20,7 +20,6 @@ from fbgemm_gpu.split_embedding_configs import SparseType
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
-from fbgemm_gpu.split_table_batched_embeddings_ops_training import DEFAULT_ASSOC
 from fbgemm_gpu.tbe.config.embedding_config import (
     EmbeddingLocation,
     EmbeddingSpecInfo,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2999


# TLDR;
Add an opt-in, host-side validation mode for the CUDA sparse permute ops (`permute_1D_sparse_data`, `permute_2D_sparse_data` / `permute_2D_sparse_preallocated_out`).

To enable, set env variable `FBGEMM_DEBUG_PERMUTE=1`.

The debug is gated behind the `FBGEMM_DEBUG_PERMUTE` env flag.
- off by default: a single cached-bool branch, no device syncs, no performance penalty
- when enabled: adds D->H syncs and extra logging, which have a performance penalty

# Changes;
- Add shared helpers in `common.cuh`, reused by both the 1D and 2D paths:
  - `is_debug_permute_enabled`
  - `debug_check_permute_inputs`
  - `debug_check_permuted_lengths`
  - `debug_check_output_offsets`
- STAGE1 validates inputs: `permute` in range, `lengths >= 0`, `indices.numel()` covers `lengths.sum()`, no single length exceeds the total; also logs `weights` presence and column width.
- STAGE2 validates `permuted_lengths`: non-negative and bounded by `indices.numel()`.
- STAGE3 validates the cumsum: `output_offsets` starts at 0, is monotonic, and its last element equals `permuted_lengths.sum()`.
- Passing checks log `STAGE_N` stats via `TORCH_WARN`; a failing check aborts with `[DEBUG permute_*] FAILED in Stage N`.

The benchmark tooling used to characterize these prod shapes is in the diff below this one (D114045941).

# Benchmark results
Measured on `GH200 480GB` (Grace-Hopper, aarch64), `int64` indices, `emb_dim=1`, 1000 iters, over 18 prod-derived configs (4x `permute_1D` + 5x `permute_2D`, each with `with_weights` off/on). Full sheet: https://docs.google.com/spreadsheets/d/1FXqxaaVywmjcQpi3q8hbLvQnktPA-f6xo2SZLocmcFQ/edit

Three runs compared:
- `base` = baseline (D114045941, benchmark scripts only, no validation)
- `noflag` = this diff, `FBGEMM_DEBUG_PERMUTE` unset
- `flag` = this diff, `FBGEMM_DEBUG_PERMUTE=1`

## Full op latency (host + GPU), `fbgemm_gpu time` in ms
| Config | base (ms) | noflag (ms) | flag (ms) | noflag/base | flag/base |
| --- | --- | --- | --- | --- | --- |
| 1D ns103000 L2 w0 | 0.183 | 0.194 | 0.866 | 1.06 | 4.73 |
| 1D ns103000 L2 w1 | 0.203 | 0.181 | 0.869 | 0.89 | 4.28 |
| 1D ns261376 L2 w0 | 0.202 | 0.200 | 0.862 | 0.99 | 4.26 |
| 1D ns261376 L2 w1 | 0.208 | 0.216 | 0.858 | 1.04 | 4.13 |
| 1D ns524288 L2 w0 | 0.209 | 0.206 | 0.883 | 0.99 | 4.22 |
| 1D ns524288 L2 w1 | 0.238 | 0.239 | 0.896 | 1.00 | 3.77 |
| 1D ns612864 L2 w0 | 0.221 | 0.221 | 0.891 | 1.00 | 4.03 |
| 1D ns612864 L2 w1 | 0.270 | 0.273 | 0.942 | 1.01 | 3.49 |
| 2D T448 B512 L32 w0 | 0.211 | 0.203 | 0.798 | 0.96 | 3.77 |
| 2D T448 B512 L32 w1 | 0.232 | 0.228 | 0.823 | 0.98 | 3.55 |
| 2D T450 B512 L64 w0 | 0.228 | 0.204 | 0.860 | 0.90 | 3.78 |
| 2D T450 B512 L64 w1 | 0.224 | 0.223 | 0.862 | 0.99 | 3.85 |
| 2D T456 B512 L32 w0 | 0.203 | 0.202 | 0.811 | 1.00 | 4.00 |
| 2D T456 B512 L32 w1 | 0.220 | 0.217 | 0.848 | 0.98 | 3.85 |
| 2D T5 B33000 L2 w0 | 0.185 | 0.182 | 0.786 | 0.98 | 4.25 |
| 2D T5 B33000 L2 w1 | 0.202 | 0.197 | 0.794 | 0.98 | 3.92 |
| 2D T7 B14500 L2 w0 | 0.183 | 0.184 | 0.800 | 1.00 | 4.36 |
| 2D T7 B14500 L2 w1 | 0.205 | 0.195 | 0.843 | 0.95 | 4.11 |
| **geomean** | | | | **0.98** | **4.01** |

Analysis: with the flag unset the op latency is unchanged vs baseline (geomean `noflag/base = 0.98`) — the added code is a single cached-bool branch, so validation is effectively zero-cost when disabled. With `FBGEMM_DEBUG_PERMUTE=1` latency rises ~4x (geomean `flag/base = 4.01`), driven by the opt-in host-side D2H syncs (min/max/sum reductions) and `TORCH_WARN` logging. This overhead is expected and only paid in debugging mode.

## GPU kernel latency, `permute_(1D|2D)_data_kernel` median dur in us (from traces)
| Config | base (us) | noflag (us) | flag (us) | noflag/base | flag/base |
| --- | --- | --- | --- | --- | --- |
| 1D ns103000 L2 w0 | 28.6 | 28.1 | 26.5 | 0.98 | 0.93 |
| 1D ns103000 L2 w1 | 34.9 | 36.5 | 34.3 | 1.04 | 0.98 |
| 1D ns261376 L2 w0 | 70.7 | 69.9 | 65.8 | 0.99 | 0.93 |
| 1D ns261376 L2 w1 | 88.6 | 88.6 | 83.9 | 1.00 | 0.95 |
| 1D ns524288 L2 w0 | 139.7 | 139.8 | 128.4 | 1.00 | 0.92 |
| 1D ns524288 L2 w1 | 175.7 | 177.0 | 169.8 | 1.01 | 0.97 |
| 1D ns612864 L2 w0 | 163.0 | 163.0 | 151.5 | 1.00 | 0.93 |
| 1D ns612864 L2 w1 | 205.6 | 209.8 | 199.0 | 1.02 | 0.97 |
| 2D T448 B512 L32 w0 | 56.6 | 56.5 | 53.0 | 1.00 | 0.94 |
| 2D T448 B512 L32 w1 | 78.0 | 78.2 | 74.1 | 1.00 | 0.95 |
| 2D T450 B512 L64 w0 | 83.3 | 83.6 | 78.5 | 1.00 | 0.94 |
| 2D T450 B512 L64 w1 | 120.6 | 120.9 | 115.8 | 1.00 | 0.96 |
| 2D T456 B512 L32 w0 | 57.5 | 57.9 | 53.9 | 1.01 | 0.94 |
| 2D T456 B512 L32 w1 | 79.5 | 79.5 | 76.1 | 1.00 | 0.96 |
| 2D T5 B33000 L2 w0 | 28.0 | 27.8 | 24.9 | 0.99 | 0.89 |
| 2D T5 B33000 L2 w1 | 36.9 | 36.7 | 33.3 | 0.99 | 0.90 |
| 2D T7 B14500 L2 w0 | 18.1 | 17.9 | 16.0 | 0.99 | 0.88 |
| 2D T7 B14500 L2 w1 | 22.7 | 23.6 | 21.4 | 1.04 | 0.94 |
| **geomean** | | | | **1.00** | **0.94** |

Analysis: the CUDA data kernel latency is unchanged across all three runs (geomean `noflag/base = 1.00`), as expected — this diff touches only host-side validation, not kernel code. The `flag/base = 0.94` geomean is cross-run GPU drift, not a kernel effect (the flag adds only host-side syncs/logging around the same kernels).

Reviewed By: q10

Differential Revision: D113841223


