### PR TITLE
Skip pruned -1 indices in float autovec/reference SpMDM CPU kernels

### DIFF
--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_autovec_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_autovec_test.py
@@ -15,12 +15,24 @@ import unittest
 import hypothesis.strategies as st
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
+from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
+    IntNBitTableBatchedEmbeddingBagsCodegen,
+)
 from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
-from fbgemm_gpu.tbe.config.embedding_config import PoolingMode
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
+from fbgemm_gpu.tbe.utils import quantize_embs
 from hypothesis import given, settings, Verbosity
 
 from ..common import MAX_EXAMPLES, TEST_WITH_ROCM
 from .common import get_nbit_weights_ty, NBitFowardTestCommon
+
+# Force the autovec CPU kernels for this whole test process. The backend
+# selection reads FBGEMM_FORCE_AUTOVEC / FBGEMM_NO_ASMJIT exactly once (a
+# function-local static in Utils.cc), so the vars must be set before the first
+# kernel dispatch. Setting them at import time is the earliest reliable point
+# and pins the backend regardless of test execution order.
+os.environ["FBGEMM_FORCE_AUTOVEC"] = "1"
+os.environ["FBGEMM_NO_ASMJIT"] = "1"
 
 VERBOSITY: Verbosity = Verbosity.verbose
 
@@ -102,6 +114,96 @@ class NBitFowardAutovecTest(NBitFowardTestCommon):
 
         del os.environ["FBGEMM_FORCE_AUTOVEC"]
         del os.environ["FBGEMM_NO_ASMJIT"]
+
+    def test_nbit_forward_cpu_multi_table_pooled_pruned_autovec(self) -> None:
+        """Autovec CPU SUM-pooled nbit forward zeroes empty/fully-pruned bags
+        for FLOAT (FP16) weights.
+
+        This is the regression guard for the float autovec/reference SpMDM `-1`
+        handling. The base FP32/FP16/BF16 SpMDM kernel is reached with
+        ``scale_bias_last == false`` (CPU TBE), where ``-1`` marks a pruned row
+        that must contribute 0. Previously the float autovec kernel returned
+        ``false`` on ``-1`` (unlike the int8/nbit/asmjit paths that skip it),
+        leaving whole pooled tables unwritten -- observed as an all-zero table
+        on ARM/OSS once the redundant ``output.fill_(0)`` pre-zero is dropped.
+
+        The test forces the autovec kernel (via FBGEMM_FORCE_AUTOVEC, set at
+        module import) and pins the invariant directly: every embedding row is
+        1.0, so each output column must equal the count of non-pruned indices in
+        that (table, bag); empty (L == 0) and fully-pruned bags must be exactly
+        0. Without the `-1` skip this fails; with it, it passes.
+        """
+        E = 100
+        Ds = [16, 24, 40]  # distinct per-table widths -> non-trivial D_offsets
+        T = len(Ds)
+        # Ragged per-(table, bag) lengths; include empty bags (L == 0).
+        Ls = [
+            [0, 2, 5, 0, 3, 4],
+            [1, 0, 4, 2, 0, 6],
+            [3, 3, 0, 1, 5, 0],
+        ]
+        B = len(Ls[0])
+        fully_pruned = [4, 2, 3]  # per table: a non-empty bag whose indices are all -1
+
+        for output_dtype in (SparseType.FP32, SparseType.FP16, SparseType.BF16):
+            with self.subTest(output_dtype=output_dtype):
+                op = IntNBitTableBatchedEmbeddingBagsCodegen(
+                    embedding_specs=[
+                        # FP16 weights -> the float (base) SpMDM kernel path.
+                        ("", E, Ds[t], SparseType.FP16, EmbeddingLocation.HOST)
+                        for t in range(T)
+                    ],
+                    output_dtype=output_dtype,
+                    pooling_mode=PoolingMode.SUM,
+                    device="cpu",
+                )
+                op.fill_random_weights()
+
+                # Overwrite every row of every table with 1.0 (exact in fp16).
+                for t in range(T):
+                    quant_weights, quant_scale_shift = quantize_embs(
+                        torch.ones(E, Ds[t]), SparseType.FP16
+                    )
+                    weights, scale_shift = op.split_embedding_weights()[t]
+                    weights.copy_(quant_weights)
+                    if quant_scale_shift is not None:
+                        self.assertIsNotNone(scale_shift)
+                        scale_shift.copy_(quant_scale_shift)
+
+                # Build indices/offsets in (table, bag) order, pruning ~1/3 of
+                # indices plus the designated fully-pruned bag per table.
+                all_indices: list[int] = []
+                offsets: list[int] = [0]
+                expected = torch.zeros(B, sum(Ds), dtype=torch.float)
+                d_prefix = [0]
+                for d in Ds:
+                    d_prefix.append(d_prefix[-1] + d)
+                running = 0
+                for t in range(T):
+                    for b in range(B):
+                        kept = 0
+                        for _ in range(Ls[t][b]):
+                            prune = (b == fully_pruned[t]) or (running % 3 == 0)
+                            all_indices.append(-1 if prune else (running % E))
+                            kept += 0 if prune else 1
+                            running += 1
+                        offsets.append(len(all_indices))
+                        expected[b, d_prefix[t] : d_prefix[t + 1]] = float(kept)
+
+                output = op(
+                    indices=torch.tensor(all_indices, dtype=torch.int),
+                    offsets=torch.tensor(offsets, dtype=torch.int),
+                )
+
+                self.assertEqual(tuple(output.shape), (B, sum(Ds)))
+                self.assertTrue(torch.isfinite(output.float()).all().item())
+                torch.testing.assert_close(
+                    output.float().cpu(),
+                    expected,
+                    atol=1.0e-2,
+                    rtol=1.0e-2,
+                    equal_nan=False,  # leaked uninitialized data (NaN) must fail
+                )
 
 
 if __name__ == "__main__":

--- a/src/EmbeddingSpMDMAutovec.cc
+++ b/src/EmbeddingSpMDMAutovec.cc
@@ -800,6 +800,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDM_autovec(
     const bool use_offsets,
     const int64_t output_stride,
     const int64_t input_stride,
+    const bool scale_bias_last,
     const bool no_bag,
     const bool is_bf16_out,
     const bool is_bf16_in) {
@@ -909,6 +910,13 @@ static bool ALWAYS_INLINE EmbeddingSpMDM_autovec(
     for (int i = 0; i < len; ++i) {
       int64_t idx = indices[current];
       if (idx < 0 || idx >= data_size) {
+        // Skip pruned rows. When scale_bias_last == false, this is a table
+        // batched embedding (TBE) forward where -1 marks a pruned row that
+        // contributes nothing to the pooled result.
+        if (idx == -1 && !scale_bias_last) {
+          ++current;
+          continue;
+        }
         return false;
       }
 
@@ -1436,6 +1444,7 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
           use_offsets,
           output_stride,
           input_stride,
+          scale_bias_last,
           no_bag,
           is_bf16_out,
           is_bf16_in);
@@ -1519,6 +1528,7 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
           kUseOffsets,
           output_stride,
           kInputStride,
+          ScaleBiasLast,
           kNoBag,
           is_bf16_out,
           is_bf16_in);

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -1386,6 +1386,12 @@ bool EmbeddingSpMDM_ref(
       }
       for (int i = 0; i < len; ++i) {
         int64_t idx = indices[current];
+        if (!scale_bias_last && idx == -1) {
+          // When scale_bias_last == false, assume this is for table batched
+          // embedding (TBE) that can get -1 for pruned rows.
+          ++current;
+          continue;
+        }
         if (idx < 0 || idx >= data_size) {
           return false;
         }


### PR DESCRIPTION
Summary:
The CPU quantized (nbit) TBE forward calls the SpMDM kernels with `scale_bias_last == false`. In this mode, a `-1` index is a pruned row. A pruned row must add 0 to the pooled result.

The int8, nbit, and x86 asmjit kernels skip the `-1` index. The float (FP32/FP16/BF16) autovec kernel `EmbeddingSpMDM_autovec` and the float branch of the reference kernel `EmbeddingSpMDM_ref` do not skip it. These two kernels return `false` on a `-1` index and stop the bag loop. As a result, the kernel does not write the pooled rows after the first `-1`.

The `!success` path calls `report_embedding_error` with `allow_minus_one=true`. This call does not throw on a `-1` index. As a result, the forward returns wrong data and does not report an error.

The x86 asmjit kernel hides this defect. On the ARM autovec path and the reference path, a float table with a pruned row returns wrong pooled sums. The rows after the first `-1` keep the value 0. This defect is present today. It does not depend on the pre-zero.

## This change
- Add a `scale_bias_last` parameter to the float `EmbeddingSpMDM_autovec` kernel. Pass the value from the two call sites.
- Skip the `-1` index in the float autovec kernel and the float reference kernel when `scale_bias_last` is `false`. This matches the int8, nbit, and asmjit kernels.
- Change the pooled path only. Do not change the no_bag path.
- A hook mirrors the two source files to the `xplat/` copies.

## Relation to D113243671
D113243671 removes the redundant `output.fill_(0)` pre-zero from the same CPU pooled forward. The safety of D113243671 depends on one rule: the kernel writes every output element. This rule is false today on the float autovec and reference paths. As a result, D113243671 is not safe on those backends, and it fails the OSS CI with a ~45% element mismatch.

This change makes the rule true on all backends. Land this change before D113243671. This change is also a standalone bug fix, so you can land it independently.

Reviewed By: knoebelja

Differential Revision: D114139867


