### PR TITLE
Enable Pyrefly for deeplearning/fbgemm (#6099)

### DIFF
--- a/fbgemm_gpu/bench/jagged_tensor_benchmark.py
+++ b/fbgemm_gpu/bench/jagged_tensor_benchmark.py
@@ -1089,6 +1089,7 @@ def keyed_jagged_index_select_dim1(
         )
     if baseline:
         time_ref, _ = benchmark_torch_function(
+            # pyrefly: ignore [unbound-name]
             functools.partial(output_ref.backward, retain_graph=True),
             (grad,),
             iters=iters,

--- a/fbgemm_gpu/bench/merge_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/merge_embeddings_benchmark.py
@@ -94,6 +94,7 @@ def generate_requests(
         rs.append(
             get_table_batched_offsets_from_dense(all_indices.view(T, B, L), gpu_num)
         )
+    # pyrefly: ignore [bad-return]
     return rs
 
 

--- a/fbgemm_gpu/bench/sparse_ops_benchmark.py
+++ b/fbgemm_gpu/bench/sparse_ops_benchmark.py
@@ -1402,6 +1402,7 @@ def index_select_bench(
         )
 
     if timeline:
+        # pyrefly: ignore [missing-attribute]
         prof.export_chrome_trace("index_select_fwd_trace.json")
 
     grads = [torch.rand_like(out) for out in out_pyt]
@@ -1442,6 +1443,7 @@ def index_select_bench(
         )
 
     if timeline:
+        # pyrefly: ignore [missing-attribute]
         prof.export_chrome_trace("index_select_bwd_trace.json")
 
     logging.info(
@@ -1722,10 +1724,13 @@ def permute_1d_sparse_data_bench(
     embedding tables.
     """
     if index_dtype == "int":
+        # pyrefly: ignore [bad-assignment]
         index_dtype = torch.int32
     elif index_dtype == "int64":
+        # pyrefly: ignore [bad-assignment]
         index_dtype = torch.int64
     elif index_dtype == "float":
+        # pyrefly: ignore [bad-assignment]
         index_dtype = torch.float32
     else:
         raise RuntimeError(f"Does not support data type {index_dtype}")
@@ -1744,8 +1749,10 @@ def permute_1d_sparse_data_bench(
     total_indices = int(lengths.sum().item())
     # Generate indices
     if index_dtype == torch.float32:
+        # pyrefly: ignore [no-matching-overload]
         indices = torch.rand(total_indices, dtype=index_dtype, device=device)
     else:
+        # pyrefly: ignore [no-matching-overload]
         indices = torch.randint(
             low=0,
             high=2**31 - 1,
@@ -1881,14 +1888,19 @@ def permute_2d_sparse_data_bench(
     systems to reorder embedding tables.
     """
     if index_dtype == "int":
+        # pyrefly: ignore [bad-assignment]
         index_dtype = torch.int32
     elif index_dtype == "int64":
+        # pyrefly: ignore [bad-assignment]
         index_dtype = torch.int64
     elif index_dtype == "float":
+        # pyrefly: ignore [bad-assignment]
         index_dtype = torch.float32
     elif index_dtype == "bf16":
+        # pyrefly: ignore [bad-assignment]
         index_dtype = torch.bfloat16
     elif index_dtype == "fp16":
+        # pyrefly: ignore [bad-assignment]
         index_dtype = torch.float16
     else:
         raise RuntimeError(f"Does not support data type {index_dtype}")
@@ -1909,9 +1921,12 @@ def permute_2d_sparse_data_bench(
         * emb_dim
     )
     total_indices = int(lengths.sum().item())
+    # pyrefly: ignore [missing-attribute]
     if index_dtype.is_floating_point:
+        # pyrefly: ignore [no-matching-overload]
         indices = torch.rand(total_indices, dtype=index_dtype, device=device)
     else:
+        # pyrefly: ignore [no-matching-overload]
         indices = torch.randint(
             low=0,
             high=2**31 - 1,

--- a/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
@@ -2047,6 +2047,7 @@ def device_from_files(  # noqa C901
     _Ds: list[int]
     emb_loc: list[EmbeddingLocation]
     compute_device: list[ComputeDevice]
+    # pyrefly: ignore [bad-assignment]
     _Es, _Ds, emb_loc, compute_device = zip(*embedding_specs)
 
     # Determine location suffix for trace URL based on embedding locations

--- a/fbgemm_gpu/bench/tbe/tbe_cache_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_cache_benchmark.py
@@ -272,12 +272,14 @@ def lxu_cache_lookup(
     tbe: nn.Module = IntNBitTableBatchedEmbeddingBagsCodegen(
         embedding_specs, cache_load_factor=cache_load_factor
     )
+    # pyrefly: ignore [not-callable]
     tbe.fill_random_weights()
 
     # Imitate execution flow by performing prefetching once.
     indices, offsets = create_request(
         num_tables, num_embeddings, batch, avg_pooling_factor
     )
+    # pyrefly: ignore [not-callable]
     tbe.prefetch(indices, offsets)
 
     linearized_indices = torch.ops.fbgemm.linearize_cache_indices(
@@ -333,6 +335,7 @@ def lru_cache_populate_byte(
     cc: nn.Module = IntNBitTableBatchedEmbeddingBagsCodegen(
         embedding_specs, cache_load_factor=cache_load_factor
     )
+    # pyrefly: ignore [not-callable]
     cc.fill_random_weights()
 
     warm_up_requests = []
@@ -389,6 +392,7 @@ def lru_cache_populate_byte(
     replay_cc: nn.Module = IntNBitTableBatchedEmbeddingBagsCodegen(
         embedding_specs, cache_load_factor=cache_load_factor
     )
+    # pyrefly: ignore [not-callable]
     replay_cc.fill_random_weights()
 
     replay_timestep: int = 1
@@ -464,6 +468,7 @@ def lfu_cache_populate_byte(
         cache_load_factor=cache_load_factor,
         cache_algorithm=CacheAlgorithm.LFU,
     )
+    # pyrefly: ignore [not-callable]
     cc.fill_random_weights()
 
     warm_up_requests = []
@@ -517,6 +522,7 @@ def lfu_cache_populate_byte(
         cache_load_factor=cache_load_factor,
         cache_algorithm=CacheAlgorithm.LFU,
     )
+    # pyrefly: ignore [not-callable]
     replay_cc.fill_random_weights()
 
     def replay_populate(linear_indices: Tensor) -> None:

--- a/fbgemm_gpu/bench/tbe/tbe_inference_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_inference_benchmark.py
@@ -874,6 +874,7 @@ def nbit_device_with_spec(  # noqa C901
                 TBERequest(
                     req.indices.cpu().int(),
                     req.offsets.cpu().int(),
+                    # pyrefly: ignore [missing-attribute]
                     req.per_sample_weigths.cpu() if req.per_sample_weights else None,
                 )
                 for req in requests
@@ -1197,6 +1198,7 @@ def nbit_uvm(
     )
 
     if T_gpu > 0:
+        # pyrefly: ignore [unbound-name]
         nparams_byte = sum(w.numel() for (w, _) in emb_mixed.split_embedding_weights())
         logging.info(
             f"{weights_precision} Embedding tables: {E * T_gpu + E_uvm * T_uvm} rows, {nparams_byte / param_size_multiplier / 1.0e9: .2f} GParam, "
@@ -1647,6 +1649,7 @@ def nbit_cache(  # noqa C901
             )
             for d in Ds
         ],
+        # pyrefly: ignore [not-callable]
         record_cache_metrics=RecordCacheMetrics(
             record_cache_miss_counter, record_tablewise_cache_miss
         ),

--- a/fbgemm_gpu/bench/tbe/tbe_training_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_training_benchmark.py
@@ -639,6 +639,7 @@ def device_with_speclist(  # noqa C901
     # pyre-ignore[53]
     def _kineto_trace_handler(p: profile, phase: str) -> None:
         p.export_chrome_trace(
+            # pyrefly: ignore [missing-attribute]
             benchconfig.trace_url.format(
                 emb_op_type=emb_op_type, phase=phase, ospid=os.getpid()
             )

--- a/fbgemm_gpu/codegen/genscript/generate_backward_split.py
+++ b/fbgemm_gpu/codegen/genscript/generate_backward_split.py
@@ -26,6 +26,7 @@ try:
     from .optimizer_args import annotation_dict, OptimizerArgsSet
     from .scripts_argsparse import args
 except ImportError:
+    # pyrefly: ignore [missing-import]
     from optimizers import *
 
     # pyre-ignore[21]
@@ -118,6 +119,7 @@ class BackwardSplitGenerator:
         ]:
             BackwardSplitGenerator.render_backward_templates(
                 template_filepath,
+                # pyrefly: ignore [bad-argument-type]
                 optimizer,
                 filename_format,
                 kwargs,
@@ -141,6 +143,7 @@ class BackwardSplitGenerator:
             ]:
                 BackwardSplitGenerator.render_backward_templates(
                     template_filepath,
+                    # pyrefly: ignore [bad-argument-type]
                     optimizer,
                     filename_format,
                     kwargs,
@@ -241,7 +244,7 @@ class BackwardSplitGenerator:
         if kwargs.get("has_cpu_support"):
             CodeTemplate.load(
                 "training/backward/embedding_backward_split_cpu_approx_template.cpp"
-                if "approx" in optimizer
+                if "approx" in optimizer  # pyrefly: ignore [not-iterable]
                 else "training/backward/embedding_backward_split_cpu_template.cpp"
             ).write(f"gen_embedding_backward_{optimizer}_split_cpu.cpp", **kwargs)
 

--- a/fbgemm_gpu/codegen/genscript/generate_embedding_optimizer.py
+++ b/fbgemm_gpu/codegen/genscript/generate_embedding_optimizer.py
@@ -36,6 +36,7 @@ class EmbeddingOptimizerGenerator:
 
         optimizer = kwargs.get("optimizer")
         kwargs["optimizer_class_name"] = "".join(
+            # pyrefly: ignore [missing-attribute]
             [optim.capitalize() for optim in optimizer.split("_")]
         )
         kwargs["args"] = kwargs["args"].cuda

--- a/fbgemm_gpu/codegen/genscript/jinja_environment.py
+++ b/fbgemm_gpu/codegen/genscript/jinja_environment.py
@@ -58,20 +58,26 @@ else:
 # BT_block_size * 4 * 4 * 32 * (max_D // 128) <= 64 * 1024 (V100) or 96 * 1024 (A100)
 # Since BT_block_size >= 1, max_D <= 16K (V100) or 24K (A100).
 # Note that if we increase max_D, it will increase the compilation time significantly.
+# pyrefly: ignore [unsupported-operation]
 env.globals["max_embedding_dim"] = 2048
 
 # Max embedding dimension for legacy embedding kernels. TBE v2 can support
 # larger max embedding dimension.
+# pyrefly: ignore [unsupported-operation]
 env.globals["legacy_max_embedding_dim"] = 1024
 
 # An optimization for ROCm
+# pyrefly: ignore [unsupported-operation]
 env.globals["items_per_warp"] = 128 if args.is_rocm is False else 256
 
 # The fixed max vectors per thread for different kernels.  The numbers were
 # derived from empirical studies
+# pyrefly: ignore [unsupported-operation]
 env.globals["fixed_max_vecs_per_thread"] = {"backward": 2, "backward_indice_weights": 6}
 
+# pyrefly: ignore [unsupported-operation]
 env.globals["dense"] = False
+# pyrefly: ignore [unsupported-operation]
 env.globals["is_rocm"] = args.is_rocm
 
 
@@ -343,15 +349,24 @@ def compute_global_weight_decay(is_global_weight_decay_kernel: bool) -> str:
 ################################################################################
 
 env.globals["generate_optimized_grad_sum_loop_access"] = (
+    # pyrefly: ignore [unsupported-operation]
     generate_optimized_grad_sum_loop_access
 )
+# pyrefly: ignore [unsupported-operation]
 env.globals["get_max_vecs_template_configs"] = get_max_vecs_template_configs
+# pyrefly: ignore [unsupported-operation]
 env.globals["dispatch_optimal_kernel"] = dispatch_optimal_kernel
+# pyrefly: ignore [unsupported-operation]
 env.globals["dispatch_non_vec_blocking_kernel"] = dispatch_non_vec_blocking_kernel
+# pyrefly: ignore [unsupported-operation]
 env.globals["dispatch_vec_blocking_kernel"] = dispatch_vec_blocking_kernel
+# pyrefly: ignore [unsupported-operation]
 env.globals["is_valid_forward_config"] = is_valid_forward_config
+# pyrefly: ignore [unsupported-operation]
 env.globals["has_experimental_support"] = has_experimental_support
+# pyrefly: ignore [unsupported-operation]
 env.globals["is_valid_gwd_config"] = is_valid_gwd_config
+# pyrefly: ignore [unsupported-operation]
 env.globals["compute_global_weight_decay"] = compute_global_weight_decay
 
 ################################################################################

--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp4_quantize.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp4_quantize.py
@@ -5650,4 +5650,5 @@ def quantize_nvfp4_naive(
         )
     )
 
+    # pyrefly: ignore [bad-return]
     return xqs, x_scales

--- a/fbgemm_gpu/experimental/gemm/triton_gemm/grouped_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/grouped_gemm.py
@@ -337,6 +337,7 @@ def _fbgemm_grouped_gemm(
             if USE_TMA_STORE:
                 c_desc_ptr = tl.make_tensor_descriptor(
                     c_ptr + M_start_offset * N,
+                    # pyrefly: ignore [bad-argument-type]
                     shape=[m_size, n_size],
                     # pyre-ignore
                     strides=[n_size, 1],
@@ -347,6 +348,7 @@ def _fbgemm_grouped_gemm(
                 tl.static_assert(K % BLOCK_SIZE_K == 0)
                 a_desc_ptr = tl.make_tensor_descriptor(
                     a_ptr + M_start_offset * K,
+                    # pyrefly: ignore [bad-argument-type]
                     shape=[m_size, K],
                     # pyre-ignore
                     strides=[K, 1],
@@ -374,7 +376,9 @@ def _fbgemm_grouped_gemm(
                     m_offset = (tile_m_idx * BLOCK_SIZE_M).to(tl.int32)
                     n_offset = (tile_n_idx * BLOCK_SIZE_N).to(tl.int32)
                     for k_offset in range(0, K, BLOCK_SIZE_K):
+                        # pyrefly: ignore [bad-argument-type, unbound-name]
                         a = a_desc_ptr.load([m_offset, k_offset])
+                        # pyrefly: ignore [bad-argument-type, unbound-name]
                         b = b_desc_ptr.load([n_offset, k_offset])
                         if USE_FAST_ACCUM:
                             accumulator = tl.dot(a, b.T, accumulator)
@@ -512,6 +516,7 @@ def _fbgemm_grouped_gemm_ws(
             if USE_TMA_STORE:
                 c_desc_ptr = tl.make_tensor_descriptor(
                     c_ptr + M_start_offset * N,
+                    # pyrefly: ignore [bad-argument-type]
                     shape=[m_size, N],
                     # pyre-ignore
                     strides=[N, 1],
@@ -659,6 +664,7 @@ def _fbgemm_grouped_gemm_fp8_rowwise(
             if USE_TMA_STORE:
                 c_desc_ptr = tl.make_tensor_descriptor(
                     c_ptr + M_start_offset * N,
+                    # pyrefly: ignore [bad-argument-type]
                     shape=[m_size, n_size],
                     # pyre-ignore
                     strides=[n_size, 1],
@@ -668,6 +674,7 @@ def _fbgemm_grouped_gemm_fp8_rowwise(
             if USE_TMA_LOAD:
                 a_desc_ptr = tl.make_tensor_descriptor(
                     a_ptr + M_start_offset * K,
+                    # pyrefly: ignore [bad-argument-type]
                     shape=[m_size, K],
                     # pyre-ignore
                     strides=[K, 1],
@@ -695,7 +702,9 @@ def _fbgemm_grouped_gemm_fp8_rowwise(
                     m_offset = (tile_m_idx * BLOCK_SIZE_M).to(tl.int32)
                     n_offset = (tile_n_idx * BLOCK_SIZE_N).to(tl.int32)
                     for k_offset in range(0, K, BLOCK_SIZE_K):
+                        # pyrefly: ignore [bad-argument-type, unbound-name]
                         a = a_desc_ptr.load([m_offset, k_offset])
+                        # pyrefly: ignore [bad-argument-type, unbound-name]
                         b = b_desc_ptr.load([n_offset, k_offset])
                         if USE_FAST_ACCUM:
                             accumulator = tl.dot(a, b.T, accumulator)
@@ -835,6 +844,7 @@ def _fbgemm_grouped_gemm_fp8_rowwise_ws(
             if USE_TMA_STORE:
                 c_desc_ptr = tl.make_tensor_descriptor(
                     c_ptr + M_start_offset * N,
+                    # pyrefly: ignore [bad-argument-type]
                     shape=[m_size, N],
                     # pyre-ignore
                     strides=[N, 1],

--- a/fbgemm_gpu/experimental/gen_ai/gen_ai/moe/layers.py
+++ b/fbgemm_gpu/experimental/gen_ai/gen_ai/moe/layers.py
@@ -1070,6 +1070,7 @@ class MetaShufflingMoE(BaselineMoE):
         scores = torch.sigmoid(scores)
         assert scores.shape == (B * T, self.E)
 
+        # pyrefly: ignore [not-callable]
         token_counts, expert_indices, token_indices = index_shuffling(
             scores,  # num_tokens
         )

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/common/scripts/make_heuristic.py
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/common/scripts/make_heuristic.py
@@ -88,6 +88,7 @@ def get_kernel_assignment(file_path: str, threshold: float) -> dict[ProblemShape
         for row in file:
             problem_shape_str, kernel, time_ms_str = row.strip().split(",")
             shape_tuple = tuple(int(x) for x in problem_shape_str.split("_"))
+            # pyrefly: ignore [bad-argument-type]
             problem_shape = ProblemShape.from_tuple(shape_tuple)
             time_ms = float(time_ms_str)
 
@@ -110,6 +111,7 @@ def get_kernel_assignment(file_path: str, threshold: float) -> dict[ProblemShape
 
     # Prefer kernels that are used more often across all problem shapes
     while len(kernel_assignment) < len(kernel_candidates):
+        # pyrefly: ignore [no-matching-overload]
         top_kernel = sorted(kernel_count.keys(), key=kernel_count.get, reverse=True)[0]
         for problem_shape, candidates in kernel_candidates.items():
             if problem_shape not in kernel_assignment and top_kernel in candidates:

--- a/fbgemm_gpu/experimental/gen_ai/test/attention/bert_padding.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/attention/bert_padding.py
@@ -27,6 +27,7 @@ class IndexFirstAxis(torch.autograd.Function):
         ).reshape(-1, *other_shape)
 
     @staticmethod
+    # pyrefly: ignore [bad-override]
     def backward(ctx, grad_output):
         (indices,) = ctx.saved_tensors
         assert grad_output.ndim >= 2
@@ -63,6 +64,7 @@ class IndexPutFirstAxis(torch.autograd.Function):
         return output
 
     @staticmethod
+    # pyrefly: ignore [bad-override]
     def backward(ctx, grad_output):
         (indices,) = ctx.saved_tensors
         # TD [2022-03-04] For some reason torch.gather is a bit faster than indexing.
@@ -88,6 +90,7 @@ class IndexFirstAxisResidual(torch.autograd.Function):
         return output, input.detach()
 
     @staticmethod
+    # pyrefly: ignore [bad-override]
     def backward(ctx, grad_output, grad_residual):
         (indices,) = ctx.saved_tensors
         assert grad_output.ndim >= 2

--- a/fbgemm_gpu/experimental/gen_ai/test/attention/blackwell_fmha_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/attention/blackwell_fmha_test.py
@@ -559,7 +559,9 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
         # Compare outputs
         if is_paged:
             # Compare paged output with both reference and non paged output
+            # pyrefly: ignore [bad-argument-type]
             self._allclose(out_paged, out_ref, out_pt)
+            # pyrefly: ignore [bad-argument-type]
             self._allclose(out_paged, out, out_pt)
         else:
             self._allclose(out, out_ref, out_pt)
@@ -613,6 +615,7 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
                 dq_d,
                 dk_d,
                 dv_d,
+                # pyrefly: ignore [no-matching-overload]
             ) = torch.autograd.grad(out_d, (q, k, v), g)
             assert torch.equal(dq, dq_d)
             assert torch.equal(dk, dk_d)
@@ -769,7 +772,9 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
         # Compare outputs
         if is_paged:
             # Compare paged output with both reference and non paged output
+            # pyrefly: ignore [bad-argument-type]
             self._allclose(out_paged, out_ref, out_pt)
+            # pyrefly: ignore [bad-argument-type]
             self._allclose(out_paged, out, out_pt)
         else:
             self._allclose(out, out_ref, out_pt)
@@ -815,6 +820,7 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
 
         if deterministic:
             # Rerun the test. The outputs must be bit-wise exact
+            # pyrefly: ignore [no-matching-overload]
             dq_unpad_d, dk_unpad_d, dv_unpad_d = torch.autograd.grad(
                 out_unpad_d, (q_unpad, k_unpad, v_unpad), g_unpad
             )

--- a/fbgemm_gpu/experimental/gen_ai/test/kv_cache/rope_padded.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/kv_cache/rope_padded.py
@@ -415,12 +415,18 @@ def rope_padded(
             seqlenk.stride(0),
             out_q.stride(1),
             out_q.stride(2),
+            # pyrefly: ignore [bad-argument-type]
             _INTERNAL_DTYPE_MAP[internal_dtype],
+            # pyrefly: ignore [bad-argument-type]
             const_batch_strides=False,
             cache_padding_length=0,
+            # pyrefly: ignore [bad-argument-type]
             seqlenk_shift=0,
+            # pyrefly: ignore [bad-argument-type]
             BLOCK_SIZE=BLOCK_SIZE,
+            # pyrefly: ignore [bad-argument-type]
             adjacents=adjacents,
+            # pyrefly: ignore [unexpected-keyword]
             num_warps=num_warps,
         )
     return out_q

--- a/fbgemm_gpu/experimental/gen_ai/test/moe/parallelism.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/moe/parallelism.py
@@ -119,6 +119,7 @@ def init_parallel(
             # ProcessGroup here. Narrow it so the Optional[ProcessGroup] global assigns.
             assert isinstance(group, ProcessGroup)
             if global_rank in ranks:
+                # pyrefly: ignore [bad-assignment]
                 _ROUTED_EXPERTS_MP_GROUP = group
 
     global _EP_GROUP
@@ -133,4 +134,5 @@ def init_parallel(
         # ProcessGroup here. Narrow it so the Optional[ProcessGroup] global assigns.
         assert isinstance(group, ProcessGroup)
         if global_rank in ranks:
+            # pyrefly: ignore [bad-assignment]
             _EP_GROUP = group

--- a/fbgemm_gpu/experimental/hstu/hstu/cuda_hstu_attention.py
+++ b/fbgemm_gpu/experimental/hstu/hstu/cuda_hstu_attention.py
@@ -643,6 +643,7 @@ class HstuAttnVarlenFunc(torch.autograd.Function):
             )
 
         # q & k grad shape
+        # pyrefly: ignore [bad-return]
         return (
             dq,
             dk,

--- a/fbgemm_gpu/fbgemm_gpu/sll/triton/triton_jagged_dense_flash_attention.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/triton/triton_jagged_dense_flash_attention.py
@@ -228,6 +228,7 @@ def jagged_dense_flash_attention_fwd(
         attn_out.stride(2),
         D,
         T,
+        # pyrefly: ignore [bad-argument-type]
         allow_tf32,
         BLOCK_T,  # pyre-ignore
         BLOCK_L,  # pyre-ignore
@@ -737,6 +738,7 @@ def jagged_dense_flash_attention_bwd(
         BLOCK_T,  # pyre-ignore
         BLOCK_L,  # pyre-ignore
         BLOCK_D,
+        # pyrefly: ignore [bad-argument-type]
         allow_tf32,
     )
 
@@ -780,6 +782,7 @@ def jagged_dense_flash_attention_bwd(
         BLOCK_T,  # pyre-ignore
         BLOCK_L,  # pyre-ignore
         BLOCK_D,
+        # pyrefly: ignore [bad-argument-type]
         allow_tf32,
     )
 

--- a/fbgemm_gpu/fbgemm_gpu/sll/triton/triton_jagged_flash_attention_basic.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/triton/triton_jagged_flash_attention_basic.py
@@ -362,6 +362,7 @@ def _jagged_flash_attention_bwd_basic_kernel(
         Di = tl.load(delta_ptr + offs_m_temp + begin, mask=offs_m_temp < M)
         dp_masked = dp
         if use_mask:
+            # pyrefly: ignore [unsupported-operation]
             dp_masked = tl.where(attn_mask > 0, dp, 0.0)
 
         ds = p * (dp_masked - Di[:, None] * max_seq_len)

--- a/fbgemm_gpu/fbgemm_gpu/sll/triton/triton_jagged_self_substraction_jagged_out.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/triton/triton_jagged_self_substraction_jagged_out.py
@@ -67,6 +67,7 @@ def triton_jagged_self_substraction_jagged_out(
         offsets_a,
         offsets_b,
         max_seq_len,
+        # pyrefly: ignore [bad-argument-type]
         BLOCK_SIZE,
     )
 

--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -203,7 +203,9 @@ def get_source_mask_meta(
 ) -> Tensor:
     if output_size is None:
         ctx = torch.library.get_ctx()
+        # pyrefly: ignore [bad-assignment]
         output_size = ctx.new_dynamic_size()
+    # pyrefly: ignore [no-matching-overload]
     return torch.empty([output_size], dtype=torch.bool)
 
 
@@ -954,7 +956,10 @@ def keyed_jagged_index_select_dim1_abstract(
             [indices + i * batch_size for i in range(num_batches)]
         )
         selected_lengths_sum = (
-            torch.index_select(lengths, 0, length_indices).sum().item()
+            # pyrefly: ignore [bad-assignment]
+            torch.index_select(lengths, 0, length_indices)
+            .sum()
+            .item()
         )
 
     ret: list[torch.Tensor] = [
@@ -1534,6 +1539,7 @@ def _setup() -> None:
         if key not in torch.library._impls:
             torch.library.register_autograd(op_name, fn, setup_context=setup_context)
 
+    # pyrefly: ignore [missing-attribute]
     if not _setup.done:
         impl_autograd(
             "fbgemm::permute_2D_sparse_data",
@@ -1746,6 +1752,7 @@ def _setup() -> None:
             "fbgemm::PaddedFP8RowwiseQuantizedToFloat",
             padded_fp8_rowwise_quantized_to_float,
         )
+        # pyrefly: ignore [missing-attribute]
         _setup.done = True
 
 

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -244,6 +244,7 @@ class EmbOptimType(enum.Enum):
         embedding_specs: list[tuple[int, int]],  # Tuple of (rows, dims)
         optimizer_state_dtypes: dict[str, "SparseType"] = {},  # noqa: B006
         enable_optimizer_offloading: bool = False,
+        # pyrefly: ignore [not-a-type]
     ) -> list[tuple[SplitState, str, torch.dtype]]:
         """
         Returns the split planning for the optimizer states
@@ -278,6 +279,7 @@ class EmbOptimType(enum.Enum):
 
         return [
             (
+                # pyrefly: ignore [not-callable]
                 SplitState(
                     dev_size=(
                         cumsum_table[-1] if not enable_optimizer_offloading else 0

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_inference_converter.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_inference_converter.py
@@ -153,7 +153,10 @@ class SplitEmbInferenceConverter:
                 q_child = IntNBitTableBatchedEmbeddingBagsCodegen(
                     embedding_specs=new_embedding_specs,
                     index_remapping=(
-                        index_remapping_list if self.pruning_ratio is not None else None
+                        # pyrefly: ignore [bad-argument-type]
+                        index_remapping_list
+                        if self.pruning_ratio is not None
+                        else None
                     ),
                     pooling_mode=child.pooling_mode,
                     device="cpu" if use_cpu else torch.cuda.current_device(),

--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/bench_config.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/bench_config.py
@@ -57,6 +57,7 @@ class TBEBenchmarkingConfig:
 
 
 @dataclasses.dataclass(frozen=True)
+# pyrefly: ignore [bad-class-definition]
 class TBEBenchmarkingHelperText(Enum):
     BENCH_ITERATIONS = "Number of benchmark iterations to run"
     BENCH_NUM_REQUESTS = "Number of input batches to generate. If the value is smaller than the number of benchmark iterations, input batches will be re-used"

--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/bench_runs.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/bench_runs.py
@@ -207,6 +207,7 @@ def benchmark_cpu_requests_mp(
     worker_pool.terminate()
 
     if start_script:
+        # pyrefly: ignore [unbound-name]
         p_start.terminate()
 
     if end_script:
@@ -310,6 +311,7 @@ def benchmark_requests(  # noqa: C901
             torch.cuda.nvtx.range_push(f"{nvtx_range}-{it}")
 
         if bwd_only:
+            # pyrefly: ignore [unbound-name]
             out.backward(grad)
         else:
             func(indices, offsets, weights)
@@ -504,6 +506,7 @@ def benchmark_requests_refer(
                     device=get_device(),
                 )
                 torch.cuda.synchronize()
+            # pyrefly: ignore [unbound-name]
             start_event.record()
 
         nn_embedding_output = (
@@ -540,6 +543,7 @@ def benchmark_requests_refer(
             )
 
         if torch.cuda.is_available():
+            # pyrefly: ignore [unbound-name]
             end_event.record()
             torch.cuda.synchronize()
             # pyre-fixme[61]: `end_event` is undefined, or not always defined.

--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/eval_compression.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/eval_compression.py
@@ -111,9 +111,18 @@ def benchmark_eval_compression(
 
     compressed_avg = statistics.median(times)
     compressed_fwd = statistics.median(fwd_times)
+    # pyrefly: ignore [bad-assignment]
     reindex = statistics.median(reindex_times)
     compressed_bwd = statistics.median(bwd_times)
 
     return EvalCompressionBenchmarkOutput(
-        avg, fwd, bwd, compressed_avg, compressed_fwd, reindex, compressed_bwd
+        # pyrefly: ignore [bad-argument-type]
+        avg,
+        fwd,
+        bwd,
+        compressed_avg,
+        compressed_fwd,
+        # pyrefly: ignore [bad-argument-type]
+        reindex,
+        compressed_bwd,
     )

--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/tbe_data_config_bench_helper.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/tbe_data_config_bench_helper.py
@@ -297,6 +297,7 @@ def generate_requests_with_Llist(
     for i in range(len(Bs)):
         L = L_list[i]
         B = Bs[i]
+        # pyrefly: ignore [no-matching-overload]
         Ls_iter = np.random.normal(
             loc=L, scale=tbe_data_config.pooling_params.sigma_L, size=B
         ).astype(int)

--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/tbe_data_config_loader.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/tbe_data_config_loader.py
@@ -26,6 +26,7 @@ from fbgemm_gpu.tbe.bench.tbe_data_config import (
 
 
 @dataclasses.dataclass(frozen=True)
+# pyrefly: ignore [bad-class-definition]
 class TBEDataConfigHelperText(Enum):
     # Config File
     TBE_CONFIG = "TBE data configuration filepath.  If provided, all other `--tbe-*` options are ignored."

--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/utils.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/utils.py
@@ -38,6 +38,7 @@ def fill_random_scale_bias(
                 shifts = np.random.normal(-2, 2, size=(E,)).astype(np.float16)
             scale_shift.copy_(
                 torch.tensor(
+                    # pyrefly: ignore [bad-argument-type]
                     np.stack([scales, shifts], axis=1)
                     .astype(np.float16)
                     .view(np.uint8),

--- a/fbgemm_gpu/fbgemm_gpu/tbe/config/embedding_config.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/config/embedding_config.py
@@ -158,11 +158,13 @@ class EmbeddingSpecInfo(enum.IntEnum):
     embedding_location = 4
 
 
+# pyrefly: ignore [bad-assignment]
 RecordCacheMetrics: NamedTuple = NamedTuple(
     "RecordCacheMetrics",
     [("record_cache_miss_counter", bool), ("record_tablewise_cache_miss", bool)],
 )
 
+# pyrefly: ignore [bad-assignment]
 SplitState: NamedTuple = NamedTuple(
     "SplitState",
     [

--- a/fbgemm_gpu/fbgemm_gpu/tbe/monitoring/bench_params_reporter.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/monitoring/bench_params_reporter.py
@@ -292,7 +292,9 @@ class TBEBenchmarkParamsReporter:
 
         return TBEDataConfig(
             T=T,
+            # pyrefly: ignore [bad-argument-type]
             E=E,
+            # pyrefly: ignore [bad-argument-type]
             D=D,
             mixed_dim=mixed_dim,
             weighted=(per_sample_weights is not None),

--- a/fbgemm_gpu/fbgemm_gpu/tbe/monitoring/runtime_monitor.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/monitoring/runtime_monitor.py
@@ -163,6 +163,7 @@ class AsyncSeriesTimerRecordedContext:
         context: T,
         stream: torch.cuda.Stream | None = None,
     ) -> None:
+        # pyrefly: ignore [invalid-type-var]
         self._context = context
         self._stream = stream
         self._timer = timer
@@ -192,10 +193,12 @@ class AsyncSeriesTimer:
     """
 
     def __init__(self, report_functor: Callable[[T, float], None]) -> None:
+        # pyrefly: ignore [invalid-type-var]
         self._events_queue: deque[tuple[torch.cuda.Event, torch.cuda.Event, T]] = (
             deque()
         )
         self._active_start_event: torch.cuda.Event | None = None
+        # pyrefly: ignore [invalid-type-var]
         self._report_functor = report_functor
 
     def start(self, stream: torch.cuda.Stream | None = None) -> None:

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/utils/partially_materialized_tensor.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/utils/partially_materialized_tensor.py
@@ -200,6 +200,7 @@ class PartiallyMaterializedTensor:
         return layout
 
     @property
+    # pyrefly: ignore [bad-override]
     def __class__(self):
         # this is a hack to avoid assertion error in torch.nn.Module.register_parameter()
         return torch.nn.Parameter

--- a/fbgemm_gpu/fbgemm_gpu/tbe/utils/requests.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/utils/requests.py
@@ -164,6 +164,7 @@ def generate_int_data_from_stats(
         lower_bound = mu
         # sigma represetns the upper bound when the uniform distribution is used
         upper_bound = sigma + 1
+        # pyrefly: ignore [no-matching-overload]
         return np.random.randint(
             lower_bound,
             upper_bound,
@@ -171,6 +172,7 @@ def generate_int_data_from_stats(
             dtype=np.int32,
         )
     else:  # normal dist
+        # pyrefly: ignore [missing-attribute]
         return np.random.normal(loc=mu, scale=sigma, size=size).astype(int)
 
 

--- a/fbgemm_gpu/test/faster_hash_test.py
+++ b/fbgemm_gpu/test/faster_hash_test.py
@@ -36,6 +36,7 @@ class HashZchKernelEvictionPolicy(IntEnum):
 
 class FasterHashTest(unittest.TestCase):
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_simple_zch_no_evict(self) -> None:
         """
@@ -148,6 +149,7 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(torch.equal(output_readonly.cpu(), output_readonly_cpu))
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_simple_zch_no_evict_rand(self) -> None:
         """
@@ -212,6 +214,7 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(torch.equal(output.cpu(), output_readonly_cpu))
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_simple_zch_evict(self) -> None:
         """
@@ -281,6 +284,7 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(torch.equal(output, output_readonly))
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_simple_zch_evict_with_rand_unique_numbers(self) -> None:
         """
@@ -336,6 +340,7 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(torch.equal(output, output_readonly))
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_eviction_during_lookup(self) -> None:
         """
@@ -422,6 +427,7 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(evict_slots.numel() == 1)
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_zch_int64_nohash_identity(self) -> None:
         """
@@ -485,6 +491,7 @@ class FasterHashTest(unittest.TestCase):
             f"{identities=} vs {numbers_100_200=}",
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_zch_int32_nohash_identity(self) -> None:
         """
@@ -548,6 +555,7 @@ class FasterHashTest(unittest.TestCase):
             f"{identities=} vs {numbers_100_200=}",
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_fallback(self) -> None:
         """
@@ -646,6 +654,7 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(torch.all(remapped_ids[-20:] == -1))
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_simple_zch_individual_score_evict(self) -> None:
         """
@@ -750,6 +759,7 @@ class FasterHashTest(unittest.TestCase):
         # metadata should not be overwritten
         self.assertTrue(torch.equal(metadata, metadata0))
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_zch_lru_evict(self) -> None:
         """
@@ -898,6 +908,7 @@ class FasterHashTest(unittest.TestCase):
             f"{output_readonly_cpu=} v.s {output_readonly.cpu()=}",
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_zch_lru_evict_with_unexpired_slots(self) -> None:
         """
@@ -1037,6 +1048,7 @@ class FasterHashTest(unittest.TestCase):
             f"{output_readonly_cpu=} v.s {output_readonly.cpu()=}",
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_rand_numbers_zch_lru_evict(self) -> None:
         """
@@ -1142,6 +1154,7 @@ class FasterHashTest(unittest.TestCase):
             f"{output_readonly_cpu=} v.s {output_readonly.cpu()=}",
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_zch_lru_evict_with_offsets(self) -> None:
         """
@@ -1312,6 +1325,7 @@ class FasterHashTest(unittest.TestCase):
             f"{set(second_half[second_half >= 300].tolist())=}, {set(random_numbers_300_350.tolist())=}",
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_opt_in_with_prob(self) -> None:
         """
@@ -1511,6 +1525,7 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(torch.equal(output_readonly_cpu, output_readonly.cpu()))
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_zch_lru_evict_train_eval(self) -> None:
         """
@@ -1599,6 +1614,7 @@ class FasterHashTest(unittest.TestCase):
             f"{output_readonly_cpu=} v.s {output_readonly=}",
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_murmur_hash(self) -> None:
         """
@@ -1622,6 +1638,7 @@ class FasterHashTest(unittest.TestCase):
         output_item_second_round = torch.ops.fbgemm.murmur_hash3(input_item, 0, 0)
         self.assertTrue(torch.equal(output_item_first_round, output_item_second_round))
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     @settings(deadline=None)
     # pyre-ignore [56]

--- a/fbgemm_gpu/test/layout_transform_ops_test.py
+++ b/fbgemm_gpu/test/layout_transform_ops_test.py
@@ -31,6 +31,7 @@ MAX_EXAMPLES = 20
 
 
 class LayoutTransformOpsTest(unittest.TestCase):
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     # pyre-fixme[56]
     @given(
@@ -58,6 +59,7 @@ class LayoutTransformOpsTest(unittest.TestCase):
             sharded_grad_output_impl.cpu(), sharded_grad_output.cpu()
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     # pyre-fixme[56]
     @given(
@@ -101,6 +103,7 @@ class LayoutTransformOpsTest(unittest.TestCase):
             sharded_grad_output_impl.cpu(), sharded_grad_output.cpu()
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     # pyre-fixme[56]
     @given(
@@ -188,6 +191,7 @@ class LayoutTransformOpsTest(unittest.TestCase):
             sharded_grad_output_impl.cpu(), sharded_grad_output.cpu()
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore[56]: Pyre cannot infer the type of `gpu_memory_lt_gb`
     # through the open-source / non-open-source import branch above.

--- a/fbgemm_gpu/test/quantize/common.py
+++ b/fbgemm_gpu/test/quantize/common.py
@@ -46,6 +46,7 @@ def floats_to_bytes(floats: npt.NDArray) -> npt.NDArray:
         if isinstance(as_bytes[0], int):
             byte_matrix[i] = list(as_bytes)
         else:
+            # pyrefly: ignore [bad-argument-type]
             byte_matrix[i] = list(map(ord, as_bytes))
     return byte_matrix
 

--- a/fbgemm_gpu/test/quantize/fp8_rowwise_test.py
+++ b/fbgemm_gpu/test/quantize/fp8_rowwise_test.py
@@ -44,6 +44,7 @@ class TestFP8RowwiseQuantizationConversion(unittest.TestCase):
             f"Setting torch._dynamo.config.cache_size_limit = {self.max_examples}"
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     # pyre-fixme[56]:
     @given(
@@ -136,6 +137,7 @@ class TestFP8RowwiseQuantizationConversion(unittest.TestCase):
 
         torch.testing.assert_close(qref.cpu(), dq.cpu(), rtol=0.1, atol=0.05)
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     # pyre-fixme[56]:
     @given(
@@ -227,6 +229,7 @@ class TestFP8RowwiseQuantizationConversion(unittest.TestCase):
 
         torch.testing.assert_close(dqcat, qref, rtol=0.1, atol=0.05)
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_padded_fp8_rowwise_input_validation(self) -> None:
         fp32 = SparseType.FP32.as_int()
@@ -263,6 +266,7 @@ class TestFP8RowwiseQuantizationConversion(unittest.TestCase):
                 output_dtype=fp32,
             )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_padded_fp8_rowwise_1d_roundtrip(self) -> None:
         # Exercises the nrows == 1 path where _get_padding_value_kernel used

--- a/fbgemm_gpu/test/quantize/fused_8bit_rowwise_test.py
+++ b/fbgemm_gpu/test/quantize/fused_8bit_rowwise_test.py
@@ -296,6 +296,7 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
             # pyre-fixme[61]: `dequantized_data_gpu` is undefined, or not always
             #  defined.
             dequantized_data_trimmed = dequantized_data_gpu[:, :ncols].cpu()
+            # pyrefly: ignore [unbound-name]
             quantize_data_numpy = quantized_data_gpu.cpu().numpy()
             if quant_padding_float_type:
                 reference = torch.from_numpy(

--- a/fbgemm_gpu/test/quantize/fused_nbit_rowwise_test.py
+++ b/fbgemm_gpu/test/quantize/fused_nbit_rowwise_test.py
@@ -294,6 +294,7 @@ class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):
                         )
                     )
             if nrows == 0 or ncols == 0:
+                # pyrefly: ignore [unbound-name]
                 assert dequantized_data_gpu.numel() == 0
                 return
             # compare quantized data
@@ -319,6 +320,7 @@ class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):
                 raise NotImplementedError(
                     f"Unsupported output dtype for gpu ops {output_dtype}"
                 )
+            # pyrefly: ignore [unbound-name]
             torch.testing.assert_close(dequantized_data_gpu.cpu(), reference)
 
     @unittest.skipIf(no_long_tests, "Slow test, requires buck build to run.")  # noqa
@@ -418,6 +420,7 @@ class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):
             torch.testing.assert_close(dequantized_data.cpu(), reference)
 
     @optests.dontGenerateOpCheckTests("Large grid HIP regression — uses ~4 GB HBM")
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore[56]: gpu_memory_lt_gb is typed (bool, str), but Pyre cannot
     # infer the unpacked arg type through the open-source import shim above.

--- a/fbgemm_gpu/test/quantize/mixed_dim_int8_test.py
+++ b/fbgemm_gpu/test/quantize/mixed_dim_int8_test.py
@@ -44,6 +44,7 @@ class TestMixedDimInt8DequantizationConversion(unittest.TestCase):
         )
         assert mixed_dim_dequant_output.numel() == 0
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
     #  `hypothesis.strategies.integers($parameter$min_value = 0, $parameter$max_value =
@@ -66,6 +67,7 @@ class TestMixedDimInt8DequantizationConversion(unittest.TestCase):
     ) -> None:
         self.run_mixed_dim_8bit_dequantize_op_test(B, T, output_dtype, min_dim, max_dim)
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
     #  `hypothesis.strategies.integers($parameter$min_value = 0, $parameter$max_value =
@@ -88,6 +90,7 @@ class TestMixedDimInt8DequantizationConversion(unittest.TestCase):
     ) -> None:
         self.run_mixed_dim_8bit_dequantize_op_test(B, T, output_dtype, min_dim, max_dim)
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
     #  `hypothesis.strategies.integers($parameter$min_value = 0, $parameter$max_value =

--- a/fbgemm_gpu/test/quantize/msfp_test.py
+++ b/fbgemm_gpu/test/quantize/msfp_test.py
@@ -27,6 +27,7 @@ else:
 
 
 class TestMSFPQuantizationConversion(unittest.TestCase):
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
     @given(
@@ -57,6 +58,7 @@ class TestMSFPQuantizationConversion(unittest.TestCase):
         )
         torch.testing.assert_close(dequantized_data.cpu(), input_data, rtol=1, atol=0)
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore[56]: Pyre cannot infer the type of `gpu_memory_lt_gb`
     # through the open-source / non-open-source import branch above.

--- a/fbgemm_gpu/test/quantize/mx/common.py
+++ b/fbgemm_gpu/test/quantize/mx/common.py
@@ -95,6 +95,7 @@ def _get_format_params(  # noqa
     """
 
     if type(fmt) is str:
+        # pyrefly: ignore [bad-assignment]
         fmt = ElemFormat.from_str(fmt)
 
     if fmt in _FORMAT_CACHE:
@@ -178,6 +179,7 @@ def _reshape_to_blocks(
     for axis in axes:
         pre_pad_size = orig_shape[axis]
         if isinstance(pre_pad_size, torch.Tensor):
+            # pyrefly: ignore [missing-attribute]
             pre_pad_size = int(pre_pad_size.value)
         # Don't pad if the axis is short enough to fit inside one tile
         if pre_pad_size % block_size == 0:
@@ -312,7 +314,9 @@ def check_diff_quantize(
     x = np.array(x) if type(x) is list else x
     # pyre-fixme[9]: x has type `Tensor`; used as `ndarray[Any, Any] | Tensor`.
     x = x.cpu().numpy() if type(x) is torch.Tensor else x
+    # pyrefly: ignore [bad-assignment]
     y1 = y1.detach().cpu().numpy()
+    # pyrefly: ignore [bad-assignment]
     y2 = y2.detach().cpu().numpy()
 
     torch_infs = np.isinf(y1) | np.isnan(y1)
@@ -335,13 +339,17 @@ def check_diff_quantize(
         print("First and last mismatch:")
         # pyre-fixme[6]: For 1st argument expected `float` but got `Tensor`.
         print("Orig:", x[where_diff][0], get_s_e_m(x[where_diff][0]))
+        # pyrefly: ignore [bad-argument-type]
         print("y1:  ", y1[where_diff][0], get_s_e_m(y1[where_diff][0]))
+        # pyrefly: ignore [bad-argument-type]
         print("y2:  ", y2[where_diff][0], get_s_e_m(y2[where_diff][0]))
         if np.count_nonzero(where_diff) > 1:
             print("--------------------")
             # pyre-fixme[6]: For 1st argument expected `float` but got `Tensor`.
             print("Orig:", x[where_diff][-1], get_s_e_m(x[where_diff][-1]))
+            # pyrefly: ignore [bad-argument-type]
             print("y1:  ", y1[where_diff][-1], get_s_e_m(y1[where_diff][-1]))
+            # pyrefly: ignore [bad-argument-type]
             print("y2:  ", y2[where_diff][-1], get_s_e_m(y2[where_diff][-1]))
         # raise ValueError
         return False
@@ -565,6 +573,7 @@ def _quantize_elemwise_core(
 
     if A_is_sparse:
         out = torch.sparse_coo_tensor(
+            # pyrefly: ignore [unbound-name]
             sparse_A.indices(),
             out,
             sparse_A.size(),

--- a/fbgemm_gpu/test/quantize/mx4_test.py
+++ b/fbgemm_gpu/test/quantize/mx4_test.py
@@ -147,6 +147,7 @@ def fake_quantize_mx(
 
 # @optests.generate_opcheck_tests()
 class TestMXQuantizationConversion(unittest.TestCase):
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     # pyre-fixme[56]:
     @given(
@@ -231,6 +232,7 @@ class TestMXQuantizationConversion(unittest.TestCase):
         assert check_diff_quantize(input, output_triton, output_cpu)
         assert check_diff_quantize(input, output_cuda, output_from_ops)
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     # pyre-fixme[56]:
     @given(
@@ -287,6 +289,7 @@ class TestMXQuantizationConversion(unittest.TestCase):
         # I give quite a bit of wiggle room to make sure this isnt flaky.
         torch.testing.assert_close(input, mx_dequantized, rtol=1.0, atol=magnitude / 2)
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     # pyre-fixme[56]:
     @given(

--- a/fbgemm_gpu/test/sll/array_jagged_bmm_jagged_out_test.py
+++ b/fbgemm_gpu/test/sll/array_jagged_bmm_jagged_out_test.py
@@ -31,7 +31,9 @@ class ArrayJaggedBmmJaggedTest(unittest.TestCase):
         max_L=st.integers(1, 200),
         D=st.integers(1, 100),
     )
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*running_on_rocm)
     @settings(deadline=30000)
     def test_triton_array_jagged_bmm_jagged_out(
@@ -157,7 +159,9 @@ class ArrayJaggedBmmJaggedTest(unittest.TestCase):
         D=st.integers(1, 100),
         device_type=st.sampled_from(["cpu", "cuda"]),
     )
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*running_on_rocm)
     @settings(deadline=30000)
     def test_triton_array_jagged_bmm_jagged_out_with_grad(
@@ -244,7 +248,9 @@ class ArrayJaggedBmmJaggedTest(unittest.TestCase):
         D=st.integers(1, 100),
         device_type=st.sampled_from(["meta"]),
     )
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*running_on_rocm)
     @settings(deadline=30000)
     def test_triton_array_jagged_bmm_jagged_out_meta_backend(
@@ -323,12 +329,14 @@ class ArrayJaggedBmmJaggedTest(unittest.TestCase):
         assert (
             # pyre-fixme[16]: Optional type has no attribute `is_meta`.
             array_x1.grad.is_meta
-            and array_x2.grad.is_meta
+            and array_x2.grad.is_meta  # pyrefly: ignore [missing-attribute]
             # pyre-fixme[16]: Optional type has no attribute `size`.
             and array_x1.grad.size() == array_x2.grad.size()
         )
         assert (
+            # pyrefly: ignore [missing-attribute]
             jagged_y1.grad.is_meta
-            and jagged_y2.grad.is_meta
-            and jagged_y1.grad.size() == jagged_y2.grad.size()
+            and jagged_y2.grad.is_meta  # pyrefly: ignore [missing-attribute]
+            and jagged_y1.grad.size()  # pyrefly: ignore [missing-attribute]
+            == jagged_y2.grad.size()  # pyrefly: ignore [missing-attribute]
         )

--- a/fbgemm_gpu/test/sll/dense_jagged_cat_jagged_out_test.py
+++ b/fbgemm_gpu/test/sll/dense_jagged_cat_jagged_out_test.py
@@ -21,7 +21,9 @@ else:
 
 
 class DenseJaggedCatJaggedOutTest(unittest.TestCase):
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*running_on_rocm)
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
     @given(

--- a/fbgemm_gpu/test/sll/jagged2_to_padded_dense_test.py
+++ b/fbgemm_gpu/test/sll/jagged2_to_padded_dense_test.py
@@ -21,7 +21,9 @@ else:
 
 
 class Jagged2ToPaddedDenseTest(unittest.TestCase):
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*running_on_rocm)
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
     @given(

--- a/fbgemm_gpu/test/sll/jagged_dense_bmm_test.py
+++ b/fbgemm_gpu/test/sll/jagged_dense_bmm_test.py
@@ -20,7 +20,9 @@ else:
     from fbgemm_gpu.test.test_utils import gpu_unavailable, running_on_rocm
 
 
+# pyrefly: ignore [bad-argument-type]
 @unittest.skipIf(*gpu_unavailable)
+# pyrefly: ignore [bad-argument-type]
 @unittest.skipIf(*running_on_rocm)
 class JaggedDenseBMMTest(unittest.TestCase):
     # pyre-fixme[56]: Pyre was not able to infer the type of argument

--- a/fbgemm_gpu/test/sll/jagged_dense_elementwise_add_test.py
+++ b/fbgemm_gpu/test/sll/jagged_dense_elementwise_add_test.py
@@ -32,6 +32,7 @@ class JaggedDenseElementwiseAddTest(unittest.TestCase):
         use_fbgemm_kernel=st.booleans(),
         device_type=st.sampled_from(["cpu", "cuda"]),
     )
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     @settings(deadline=30000)
     def test_triton_jagged_dense_add(

--- a/fbgemm_gpu/test/sll/jagged_dense_elementwise_mul_jagged_out_test.py
+++ b/fbgemm_gpu/test/sll/jagged_dense_elementwise_mul_jagged_out_test.py
@@ -20,7 +20,9 @@ else:
     from fbgemm_gpu.test.test_utils import gpu_unavailable, running_on_rocm
 
 
+# pyrefly: ignore [bad-argument-type]
 @unittest.skipIf(*gpu_unavailable)
+# pyrefly: ignore [bad-argument-type]
 @unittest.skipIf(*running_on_rocm)
 class JaggedDenseElementwiseMulJaggedOutTest(unittest.TestCase):
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
@@ -153,6 +155,7 @@ class JaggedDenseElementwiseMulJaggedOutTest(unittest.TestCase):
         ref.backward(grad_output)
         result.backward(grad_output)
 
+        # pyrefly: ignore [bad-argument-type]
         assert torch.allclose(jagged_A_ref.grad, jagged_A.grad)
 
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
@@ -219,5 +222,8 @@ class JaggedDenseElementwiseMulJaggedOutTest(unittest.TestCase):
         result.backward(grad_output)
 
         assert (
-            jagged_A.grad.is_meta and jagged_A_ref.grad.size() == jagged_A.grad.size()
+            # pyrefly: ignore [missing-attribute]
+            jagged_A.grad.is_meta
+            and jagged_A_ref.grad.size()  # pyrefly: ignore [missing-attribute]
+            == jagged_A.grad.size()  # pyrefly: ignore [missing-attribute]
         )

--- a/fbgemm_gpu/test/sll/jagged_dense_flash_attention_test.py
+++ b/fbgemm_gpu/test/sll/jagged_dense_flash_attention_test.py
@@ -32,7 +32,9 @@ class JaggedDenseFlashAttentionTest(unittest.TestCase):
         allow_tf32=st.booleans(),
         device_type=st.sampled_from(["cpu", "cuda"]),
     )
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*running_on_rocm)
     @settings(deadline=30000)
     def test_jagged_dense_flash_attention(

--- a/fbgemm_gpu/test/sll/jagged_flash_attention_basic_test.py
+++ b/fbgemm_gpu/test/sll/jagged_flash_attention_basic_test.py
@@ -32,7 +32,9 @@ class JaggedFlashAttentionBasicTest(unittest.TestCase):
         allow_tf32=st.booleans(),
         device_type=st.sampled_from(["cpu", "cuda"]),
     )
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*running_on_rocm)
     @settings(deadline=40000)
     def test_triton_jagged_flash_attention_basic(

--- a/fbgemm_gpu/test/sll/jagged_jagged_bmm_jagged_out_test.py
+++ b/fbgemm_gpu/test/sll/jagged_jagged_bmm_jagged_out_test.py
@@ -32,6 +32,7 @@ class JaggedJaggedBmmJaggedOutTest(unittest.TestCase):
         max_L=st.integers(1, 200),
         K=st.integers(1, 100),
     )
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     @settings(deadline=30000)
     def test_triton_jagged_jagged_bmm_jagged_out(
@@ -107,6 +108,7 @@ class JaggedJaggedBmmJaggedOutTest(unittest.TestCase):
         K=st.integers(1, 100),
         device_type=st.sampled_from(["meta"]),
     )
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     @settings(deadline=30000)
     def test_triton_jagged_jagged_bmm_jagged_out_meta_backend(
@@ -153,4 +155,5 @@ class JaggedJaggedBmmJaggedOutTest(unittest.TestCase):
         # pyre-fixme[16]: Optional type has no attribute `is_meta`.
         # pyre-fixme[16]: Optional type has no attribute `size`.
         assert jagged_A.grad.is_meta and jagged_A.grad.size() == jagged_A.size()
+        # pyrefly: ignore [missing-attribute]
         assert jagged_B.grad.is_meta and jagged_B.grad.size() == jagged_B.size()

--- a/fbgemm_gpu/test/sll/jagged_jagged_bmm_test.py
+++ b/fbgemm_gpu/test/sll/jagged_jagged_bmm_test.py
@@ -21,7 +21,9 @@ else:
     from fbgemm_gpu.test.test_utils import gpu_unavailable, running_on_rocm
 
 
+# pyrefly: ignore [bad-argument-type]
 @unittest.skipIf(*gpu_unavailable)
+# pyrefly: ignore [bad-argument-type]
 @unittest.skipIf(*running_on_rocm)
 class JaggedJaggedBMMTest(unittest.TestCase):
     # pyre-fixme[56]: Pyre was not able to infer the type of argument

--- a/fbgemm_gpu/test/sll/jagged_self_substraction_jagged_out_test.py
+++ b/fbgemm_gpu/test/sll/jagged_self_substraction_jagged_out_test.py
@@ -22,7 +22,9 @@ else:
 
 
 class JaggedSelfSubtractionJaggedOutTest(unittest.TestCase):
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*running_on_rocm)
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
     @given(

--- a/fbgemm_gpu/test/sll/jagged_softmax_test.py
+++ b/fbgemm_gpu/test/sll/jagged_softmax_test.py
@@ -21,7 +21,9 @@ else:
     from fbgemm_gpu.test.test_utils import gpu_unavailable, running_on_rocm
 
 
+# pyrefly: ignore [bad-argument-type]
 @unittest.skipIf(*gpu_unavailable)
+# pyrefly: ignore [bad-argument-type]
 @unittest.skipIf(*running_on_rocm)
 class JaggedSoftmaxTest(unittest.TestCase):
     # pyre-fixme[56]: Pyre was not able to infer the type of argument

--- a/fbgemm_gpu/test/sll/multi_head_jagged_flash_attention_test.py
+++ b/fbgemm_gpu/test/sll/multi_head_jagged_flash_attention_test.py
@@ -38,6 +38,7 @@ class MultiHeadJaggedFlashAttentionTest(unittest.TestCase):
         d_per_head=st.sampled_from([32]),
         device_type=st.sampled_from(["cuda"]),
     )
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     @settings(deadline=None)
     def test_multi_head_jagged_flash_attention(

--- a/fbgemm_gpu/test/tbe/common.py
+++ b/fbgemm_gpu/test/tbe/common.py
@@ -568,6 +568,7 @@ def v1_lookup(
 
         # Increment the iteration counter
         iter_int = int(emb_op.iter_cpu.add_(1).item())  # used for local computation
+        # pyrefly: ignore [not-callable]
         emb_op.iter.add_(1)  # used for checkpointing
         iter = int(emb_op.iter_cpu.item())
 
@@ -576,10 +577,13 @@ def v1_lookup(
                 emb_op._max_counter_update_freq > 0
                 and iter_int % emb_op._max_counter_update_freq == 0
             ):
+                # pyrefly: ignore [not-callable]
                 row_counter_dev = emb_op.row_counter_dev.detach()
                 if row_counter_dev.numel() > 0:
+                    # pyrefly: ignore [unsupported-operation]
                     emb_op.max_counter[0] = torch.max(row_counter_dev).cpu().item() + 1
                 else:
+                    # pyrefly: ignore [unsupported-operation]
                     emb_op.max_counter[0] = 1
 
     common_kwargs: dict[str, Any] = {
@@ -670,6 +674,7 @@ def v1_lookup(
             "row_counter_offsets": emb_op.row_counter_offsets,
             "row_counter_placements": emb_op.row_counter_placements,
             "learning_rate": emb_op.learning_rate_tensor.item(),
+            # pyrefly: ignore [not-callable]
             "max_counter": emb_op.max_counter.item(),
             "use_rowwise_adagrad_with_counter": emb_op._used_rowwise_adagrad_with_counter,
             # optimizer_args fields

--- a/fbgemm_gpu/test/tbe/config/embedding_config_test.py
+++ b/fbgemm_gpu/test/tbe/config/embedding_config_test.py
@@ -82,6 +82,7 @@ class EmbeddingConfigClassmethodTest(unittest.TestCase):
             EmbeddingLocation.HOST,
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_embedding_location_from_device_and_clf_cuda_managed(self) -> None:
         from fbgemm_gpu.tbe.config import EmbeddingLocation
@@ -93,6 +94,7 @@ class EmbeddingConfigClassmethodTest(unittest.TestCase):
             EmbeddingLocation.MANAGED,
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_embedding_location_from_device_and_clf_cuda_device(self) -> None:
         from fbgemm_gpu.tbe.config import EmbeddingLocation
@@ -104,6 +106,7 @@ class EmbeddingConfigClassmethodTest(unittest.TestCase):
             EmbeddingLocation.DEVICE,
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_embedding_location_from_device_and_clf_cuda_caching(self) -> None:
         from fbgemm_gpu.tbe.config import EmbeddingLocation
@@ -115,6 +118,7 @@ class EmbeddingConfigClassmethodTest(unittest.TestCase):
             EmbeddingLocation.MANAGED_CACHING,
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_embedding_location_from_device_and_clf_invalid_raises(self) -> None:
         from fbgemm_gpu.tbe.config import EmbeddingLocation
@@ -176,6 +180,7 @@ class EmbeddingConfigJITTest(unittest.TestCase):
     3. Module-level references breaking due to import rewriting
     """
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_tbe_jit_script_with_new_import_paths(self) -> None:
         """Critical: Ensure TBE can still be JIT-scripted."""

--- a/fbgemm_gpu/test/tbe/dram_kv/dram_kv_inference_test.py
+++ b/fbgemm_gpu/test/tbe/dram_kv/dram_kv_inference_test.py
@@ -200,10 +200,12 @@ class DramKvInferenceTest(unittest.TestCase):
                         f"id1: {embs[1][:4]} failed",
                     )
                     self.assertTrue(
+                        # pyrefly: ignore [bad-argument-type]
                         equal_one_of(embs[2][:4], possible_embs + [9, 10, 11, 12]),
                         f"id2: {embs[2][:4]} failed",
                     )
                     self.assertTrue(
+                        # pyrefly: ignore [bad-argument-type]
                         equal_one_of(embs[3][:4], possible_embs + [13, 14, 15, 16]),
                         f"id3: {embs[3][:4]} failed",
                     )

--- a/fbgemm_gpu/test/tbe/inference/inference_converter_test.py
+++ b/fbgemm_gpu/test/tbe/inference/inference_converter_test.py
@@ -239,7 +239,9 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
             rtol=1.0e-1,
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*on_arm_platform)
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*running_on_github)
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
     #  `hypothesis.strategies.booleans() if test_utils.gpu_available else

--- a/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
@@ -37,6 +37,7 @@ default_settings: dict[str, Any] = {
 }
 
 
+# pyrefly: ignore [bad-argument-type]
 @unittest.skipIf(*running_in_oss)
 class KvTensorWrapperTest(TestCase):
 
@@ -116,11 +117,15 @@ class KvTensorWrapperTest(TestCase):
             weights = torch.arange(N * D, dtype=weights_dtype).view(N, D)
             padded_weights = torch.nn.functional.pad(weights, (0, max_D - D))
             count = torch.tensor([N])
+            # pyrefly: ignore [missing-attribute]
             ssd_db.set(indices, padded_weights, count)
 
             # create a view tensor wrapper
             snapshot = (
-                ssd_db.create_snapshot() if backend_type == BackendType.SSD else None
+                # pyrefly: ignore [missing-attribute]
+                ssd_db.create_snapshot()
+                if backend_type == BackendType.SSD
+                else None
             )
             tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
                 [E, D], weights.dtype, 0, snapshot
@@ -154,6 +159,7 @@ class KvTensorWrapperTest(TestCase):
             del tensor_wrapper
             del snapshot
             if backend_type == BackendType.SSD:
+                # pyrefly: ignore [missing-attribute]
                 self.assertEqual(ssd_db.get_snapshot_count(), 0)
 
     # pyre-ignore[56]
@@ -203,7 +209,10 @@ class KvTensorWrapperTest(TestCase):
 
             # create a view tensor wrapper
             snapshot = (
-                ssd_db.create_snapshot() if backend_type == BackendType.SSD else None
+                # pyrefly: ignore [missing-attribute]
+                ssd_db.create_snapshot()
+                if backend_type == BackendType.SSD
+                else None
             )
 
             for table_idx, offset in enumerate(table_offsets):
@@ -247,6 +256,7 @@ class KvTensorWrapperTest(TestCase):
 
             del snapshot
             if backend_type == BackendType.SSD:
+                # pyrefly: ignore [missing-attribute]
                 self.assertEqual(ssd_db.get_snapshot_count(), 0)
 
     # pyre-ignore[56]
@@ -301,7 +311,10 @@ class KvTensorWrapperTest(TestCase):
 
             # create a view tensor wrapper
             snapshot = (
-                ssd_db.create_snapshot() if backend_type == BackendType.SSD else None
+                # pyrefly: ignore [missing-attribute]
+                ssd_db.create_snapshot()
+                if backend_type == BackendType.SSD
+                else None
             )
 
             for table_idx, offset in enumerate(table_offsets):
@@ -352,6 +365,7 @@ class KvTensorWrapperTest(TestCase):
 
             del snapshot
             if backend_type == BackendType.SSD:
+                # pyrefly: ignore [missing-attribute]
                 self.assertEqual(ssd_db.get_snapshot_count(), 0)
 
     # pyre-ignore[56]
@@ -396,7 +410,10 @@ class KvTensorWrapperTest(TestCase):
 
             # create a view tensor wrapper
             snapshot = (
-                ssd_db.create_snapshot() if backend_type == BackendType.SSD else None
+                # pyrefly: ignore [missing-attribute]
+                ssd_db.create_snapshot()
+                if backend_type == BackendType.SSD
+                else None
             )
             tensor_wrapper0.set_weights_and_ids(new_weights_after_snapshot, indices)
             tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
@@ -441,6 +458,7 @@ class KvTensorWrapperTest(TestCase):
             del tensor_wrapper
             del snapshot
             if backend_type == BackendType.SSD:
+                # pyrefly: ignore [missing-attribute]
                 self.assertEqual(ssd_db.get_snapshot_count(), 0)
 
     # pyre-ignore[56]
@@ -477,6 +495,7 @@ class KvTensorWrapperTest(TestCase):
             padded_weights = torch.nn.functional.pad(weights, (0, max_D - D), value=1.0)
 
             count = torch.tensor([N])
+            # pyrefly: ignore [missing-attribute]
             ssd_db.set(indices, padded_weights, count)
 
             """
@@ -485,7 +504,10 @@ class KvTensorWrapperTest(TestCase):
             """
             # case 0
             snapshot = (
-                ssd_db.create_snapshot() if backend_type == BackendType.SSD else None
+                # pyrefly: ignore [missing-attribute]
+                ssd_db.create_snapshot()
+                if backend_type == BackendType.SSD
+                else None
             )
             tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
                 [E, D], weights.dtype, 0, snapshot
@@ -576,6 +598,7 @@ class KvTensorWrapperTest(TestCase):
             del tensor_wrapper
             del snapshot
             if backend_type == BackendType.SSD:
+                # pyrefly: ignore [missing-attribute]
                 self.assertEqual(ssd_db.get_snapshot_count(), 0)
 
     def test_dram_kv_and_rdb_snapshot_check(self) -> None:

--- a/fbgemm_gpu/test/tbe/ssd/ssd_utils_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_utils_test.py
@@ -22,7 +22,9 @@ from ..common import gpu_unavailable, running_in_oss
 MAX_EXAMPLES = 20
 
 
+# pyrefly: ignore [bad-argument-type]
 @unittest.skipIf(*running_in_oss)
+# pyrefly: ignore [bad-argument-type]
 @unittest.skipIf(*gpu_unavailable)
 class SSDUtilsTest(unittest.TestCase):
     def execute_masked_index_test(
@@ -270,10 +272,12 @@ class SSDUtilsTest(unittest.TestCase):
 
             # Insert indices into the map
             sp_map = {}
+            # pyrefly: ignore [bad-index]
             for i, idx in enumerate(sp_indices[: count.item()]):
                 sp_map[idx] = i
 
             # Lookup
+            # pyrefly: ignore [bad-argument-type]
             for i in range(lookup_count.item()):
                 ssd_idx = ssd_indices[i]
                 if ssd_idx in sp_map:

--- a/fbgemm_gpu/test/tbe/stats/tbe_bench_params_reporter_test.py
+++ b/fbgemm_gpu/test/tbe/stats/tbe_bench_params_reporter_test.py
@@ -156,6 +156,7 @@ class TestTBEBenchmarkParamsReporter(unittest.TestCase):
         B=st.integers(20, 100),
     )
     @settings(max_examples=1, deadline=None)
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*running_in_oss)
     def test_report_fb_files(
         self,

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
@@ -251,8 +251,11 @@ def execute_backward_adagrad(  # noqa C901
         bs = [b.half() for b in bs]
 
     # Get optimizer parameters - use tbe_op's values if provided, otherwise use defaults
+    # pyrefly: ignore [not-callable]
     lr = tbe_op.get_learning_rate() if tbe_op else 0.5
+    # pyrefly: ignore [not-callable]
     eps = tbe_op.optimizer_args.eps if tbe_op else 0.2
+    # pyrefly: ignore [not-callable]
     max_norm = tbe_op.optimizer_args.max_norm if tbe_op else max_norm
 
     optimizer = (
@@ -263,7 +266,7 @@ def execute_backward_adagrad(  # noqa C901
 
     cc = (
         tbe_op
-        if tbe_op
+        if tbe_op  # pyrefly: ignore [not-callable]
         else emb_op(
             embedding_specs=[
                 (E, D, M, compute_device) for (E, D, M) in zip(Es, Ds, managed)
@@ -451,6 +454,7 @@ def execute_backward_adagrad(  # noqa C901
         else:
             (m1,) = split_optimizer_states[t]
 
+        # pyrefly: ignore [missing-attribute]
         grads = bs[t].weight.grad.float().cpu().to_dense()
         weights_ref = torch.addcdiv(
             bs[t].weight.float().cpu(),
@@ -475,6 +479,7 @@ def execute_backward_adagrad(  # noqa C901
         if weights_precision == SparseType.NFP8:
             weights_ref = weights_ref.to(fp8_dtype).to(torch.float)
         torch.testing.assert_close(
+            # pyrefly: ignore [missing-attribute]
             cc.split_embedding_weights()[t].float().cpu(),
             weights_ref,
             atol=tolerance,
@@ -557,6 +562,7 @@ def execute_backward_adagrad(  # noqa C901
         batch_size_per_feature_per_rank=batch_size_per_feature_per_rank,
     )
     y.sum().backward()
+    # pyrefly: ignore [missing-attribute]
     indice_weight_grad_mask = per_sample_weights.grad.clone().cpu()
 
     if gpu_available and not TEST_WITH_ROCM:

--- a/fbgemm_gpu/test/tbe/training/forward_backward_int32_overflow_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_backward_int32_overflow_test.py
@@ -116,6 +116,7 @@ class ForwardBackwardInt32OverflowTest(unittest.TestCase):
         # Delete the op to save space
         del op
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_forward_nobag_large_grid(self) -> None:
         """
@@ -186,6 +187,7 @@ class ForwardBackwardInt32OverflowTest(unittest.TestCase):
         torch.testing.assert_close(out[-1].cpu(), sentinel.cpu())
         del op, indices, offsets, out
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     @given(**common_st)
     @settings(**common_settings)
@@ -200,6 +202,7 @@ class ForwardBackwardInt32OverflowTest(unittest.TestCase):
             **kwargs,
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     @given(**common_st)
     @settings(**common_settings)
@@ -214,6 +217,7 @@ class ForwardBackwardInt32OverflowTest(unittest.TestCase):
             **kwargs,
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     @given(**common_st)
     @settings(**common_settings)
@@ -228,6 +232,7 @@ class ForwardBackwardInt32OverflowTest(unittest.TestCase):
             **kwargs,
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     @given(**common_st)
     @settings(**common_settings)

--- a/fbgemm_gpu/test/tbe/training/res_enabled_tables_test.py
+++ b/fbgemm_gpu/test/tbe/training/res_enabled_tables_test.py
@@ -62,6 +62,7 @@ class ResEnabledTablesTest(unittest.TestCase):
             res_params=res_params,
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_empty_allowlist_enables_all(self) -> None:
         # Empty allowlist => no scoping; preserves the pre-allowlist behavior.
@@ -70,6 +71,7 @@ class ResEnabledTablesTest(unittest.TestCase):
         mask = tbe.get_buffer("res_enabled_feature_mask")
         self.assertEqual(mask.tolist(), [True, True, True])
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_all_tables_listed_short_circuits(self) -> None:
         # Listing every table is equivalent to the empty/all-enabled fast path.
@@ -78,6 +80,7 @@ class ResEnabledTablesTest(unittest.TestCase):
         mask = tbe.get_buffer("res_enabled_feature_mask")
         self.assertEqual(mask.tolist(), [True, True, True])
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_subset_allowlist_builds_feature_mask(self) -> None:
         tbe = self._build_tbe(["t0", "t1", "t2"], res_enabled_tables=["t1"])
@@ -86,6 +89,7 @@ class ResEnabledTablesTest(unittest.TestCase):
         # one feature per table => mask lines up with table order
         self.assertEqual(mask.tolist(), [False, True, False])
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_unknown_table_name_ignored(self) -> None:
         # A name not in this TBE contributes nothing (no error, not enabled) --
@@ -95,6 +99,7 @@ class ResEnabledTablesTest(unittest.TestCase):
         mask = tbe.get_buffer("res_enabled_feature_mask")
         self.assertEqual(mask.tolist(), [False, True])
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_get_enabled_feature_mask_and_indices(self) -> None:
         rows = 64

--- a/fbgemm_gpu/test/tbe/training/store_prefetched_tensors_test.py
+++ b/fbgemm_gpu/test/tbe/training/store_prefetched_tensors_test.py
@@ -27,6 +27,7 @@ else:
 
 
 class StorePrefetchedTensorsTest(unittest.TestCase):
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_get_prefetched_info(self) -> None:
         hash_zch_identities = torch.tensor(
@@ -112,6 +113,7 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
             prefetched_info.hash_zch_runtime_meta.tolist(),
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_get_prefetched_info_with_duplicate_hash_zch_identities(self) -> None:
         """
@@ -203,6 +205,7 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
             ],
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_get_prefetched_info_mixed_cache_non_cache(self) -> None:
         """
@@ -307,6 +310,7 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
             ],
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_get_prefetched_info_without_identities(self) -> None:
         """
@@ -349,6 +353,7 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
         # Identities should be None when not provided
         self.assertIsNone(prefetched_info.hash_zch_identities)
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_store_prefetched_tensors_disabled(self) -> None:
         """
@@ -384,6 +389,7 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
 
         self.assertEqual(len(tbe.prefetched_info_list), 0)
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_store_prefetched_tensors_filters_non_cached_indices(self) -> None:
         """
@@ -481,6 +487,7 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
         self.assertEqual(prefetched_info.linear_unique_cache_indices.shape[0], 6)
         self.assertEqual(prefetched_info.linear_unique_indices.shape[0], 6)
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_get_prefetched_info_with_only_runtime_meta(self) -> None:
         """
@@ -537,6 +544,7 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
             prefetched_info.hash_zch_runtime_meta.tolist(),
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_get_prefetched_info_with_only_hash_zch_identities(self) -> None:
         """
@@ -593,6 +601,7 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
         )
         self.assertIsNone(prefetched_info.hash_zch_runtime_meta)
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_get_prefetched_info_with_neither(self) -> None:
         """
@@ -626,6 +635,7 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
         self.assertIsNone(prefetched_info.hash_zch_identities)
         self.assertIsNone(prefetched_info.hash_zch_runtime_meta)
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_register_res_buffers_default_dim(self) -> None:
         """
@@ -647,10 +657,12 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
                 enable_raw_embedding_streaming=True,
                 res_params=res_params,
             )
+        # pyrefly: ignore [not-callable]
         cache_size = tbe.lxu_cache_weights.size(0)
         self.assertGreater(cache_size, 0)
         self.assertEqual(tbe.res_runtime_meta.shape, (cache_size, 1))
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_register_empty_res_buffers_default_dim(self) -> None:
         """
@@ -662,8 +674,10 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
             ],
             enable_raw_embedding_streaming=False,
         )
+        # pyrefly: ignore [bad-index]
         self.assertEqual(tbe.res_runtime_meta.shape[1], 1)
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_lazy_resize_runtime_meta(self) -> None:
         """
@@ -686,6 +700,7 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
                 enable_raw_embedding_streaming=True,
                 res_params=res_params,
             )
+        # pyrefly: ignore [not-callable]
         cache_size = tbe.lxu_cache_weights.size(0)
         # Initially dim=1
         self.assertEqual(tbe.res_runtime_meta.shape, (cache_size, 1))
@@ -701,6 +716,7 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
         # Manually trigger the resize logic
         data = runtime_meta_data
         if (
+            # pyrefly: ignore [bad-index]
             data.shape[1] != tbe.res_runtime_meta.shape[1]
             or data.dtype != tbe.res_runtime_meta.dtype
         ):
@@ -717,12 +733,15 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
         # After resize, dim should be 2
         self.assertEqual(tbe.res_runtime_meta.shape, (cache_size, 2))
         # Copy should succeed
+        # pyrefly: ignore [bad-index]
         tbe.res_runtime_meta[:n].copy_(runtime_meta_data)
         self.assertEqual(
             runtime_meta_data.tolist(),
+            # pyrefly: ignore [bad-index]
             tbe.res_runtime_meta[:n].tolist(),
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_res_runtime_meta_not_in_state_dict(self) -> None:
         """
@@ -752,6 +771,7 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
             "res_runtime_meta should not be in state_dict",
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_prefetched_info_with_multi_dim_runtime_meta(self) -> None:
         """
@@ -798,6 +818,7 @@ class StorePrefetchedTensorsTest(unittest.TestCase):
             prefetched_info.hash_zch_runtime_meta.tolist(),
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_copy_runtime_meta_none_skipped(self) -> None:
         """

--- a/fbgemm_gpu/test/tbe/utils/generate_vbe_metadata_test.py
+++ b/fbgemm_gpu/test/tbe/utils/generate_vbe_metadata_test.py
@@ -73,6 +73,7 @@ class GenerateVBEMetadataTest(unittest.TestCase):
         )
         # pyre-ignore: Missing argument [20]
         dummy_offsets = torch.sparse_coo_tensor(
+            # pyrefly: ignore [bad-argument-type]
             (total_B + 1,),
             dtype=torch.long,
         )
@@ -151,6 +152,7 @@ class GenerateVBEMetadataTest(unittest.TestCase):
         assert torch.equal(row_output_offsets.cpu(), row_output_offsets_cpu)
         assert torch.equal(b_t_map.cpu(), b_t_map_cpu)
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_generate_vbe_metadata_kernel(self):
         self.execute_generate_vbe_metadata_kernel(
@@ -159,6 +161,7 @@ class GenerateVBEMetadataTest(unittest.TestCase):
             max_B=32,
         )
 
+    # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_generate_vbe_metadata_kernel_large(self):
         self.execute_generate_vbe_metadata_kernel(

--- a/fbgemm_gpu/test/test_utils.py
+++ b/fbgemm_gpu/test/test_utils.py
@@ -147,6 +147,7 @@ def cpu_and_maybe_gpu() -> st.SearchStrategy[list[torch.device]]:
     # lint-fixme: TorchDeviceCuda, TorchFunctionCallCudaDevice
     # CUDA specifically required: GPU device strategy for FBGEMM tests
     gpu_devices = [torch.device("cuda")] if gpu_available else []
+    # pyrefly: ignore [bad-return]
     return st.sampled_from([torch.device("cpu")] + gpu_devices)
 
 
@@ -261,6 +262,7 @@ def gradcheck(
 
 
 def cpu_only() -> st.SearchStrategy[list[torch.device]]:
+    # pyrefly: ignore [bad-return]
     return st.sampled_from([torch.device("cpu")])
 
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3003

Enables Pyrefly for `deeplearning/fbgemm` by setting `python.set_pyrefly(True)` in the subdirectory PACKAGE file and adding targeted `# pyrefly: ignore` annotations. Part of splitting D113608658 into a per-subdirectory stack; the final diff performs the directory-level flip.

#buildall

Differential Revision: D113962589
