### PR TITLE
Migrate `-c fbcode.platform010_cuda_version` to the cuda constraint modifier (#6100)

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/benchmarks.sh
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/benchmarks.sh
@@ -15,7 +15,7 @@ for i in "${!batch_sizes[@]}"; do
   seq=${seq_lengths[i]}
   echo "Running with batch size $batch and sequence length $seq"
 
-  ~/fbsource/fbcode/triton/scripts/denoise.sh buck run @mode/opt -c fbcode.enable_gpu_sections=true -c fbcode.platform010_cuda_version=12.8 -c fbcode.nvcc_arch=b200a \
+  ~/fbsource/fbcode/triton/scripts/denoise.sh buck run @mode/opt -c fbcode.enable_gpu_sections=true -m ovr_config//third-party/cuda/constraints:12.8 -c fbcode.nvcc_arch=b200a \
     ai_acceleration/kernels/attentions/cutlass_blackwell_fmha:blackwell_fmha_${option} -- \
     --b=$batch --h=16 --d=128 --k=$seq >> ${option}.txt
 done
@@ -28,7 +28,7 @@ for i in "${!batch_sizes[@]}"; do
   seq=${seq_lengths[i]}
   echo "Running --mask=causal with batch size $batch and sequence length $seq"
 
-  ~/fbsource/fbcode/triton/scripts/denoise.sh buck run @mode/opt -c fbcode.enable_gpu_sections=true -c fbcode.platform010_cuda_version=12.8 -c fbcode.nvcc_arch=b200a \
+  ~/fbsource/fbcode/triton/scripts/denoise.sh buck run @mode/opt -c fbcode.enable_gpu_sections=true -m ovr_config//third-party/cuda/constraints:12.8 -c fbcode.nvcc_arch=b200a \
     ai_acceleration/kernels/attentions/cutlass_blackwell_fmha:blackwell_fmha_${option} -- \
     --b=$batch --h=16 --d=128 --mask=causal --k=$seq >> ${option}.txt
 done


### PR DESCRIPTION
Summary:

X-link: https://github.com/meta-pytorch/torchcomms/pull/3360

X-link: https://github.com/facebookresearch/FBGEMM/pull/3005

This is the mechanical half of that migration (misc-1): every
`-c fbcode.platform010_cuda_version=<V>` invocation becomes
`-m ovr_config//third-party/cuda/constraints:<V>`.

Differential Revision: D114299816


