### PR TITLE
Add grid-stride + ROCm cap to ssd_generate/update_row_addrs kernels

### DIFF
--- a/fbgemm_gpu/src/split_embeddings_utils/transpose_embedding_input.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils/transpose_embedding_input.cu
@@ -83,61 +83,73 @@ __global__ __launch_bounds__(kMaxThreads) void linearize_index_kernel(
     const uint32_t* const __restrict__ vbe_b_t_map,
     FixedDivisor fd) {
   const auto T = hash_size_cumsum.size(0) - 1;
-  auto b_t = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto total_B = offsets.size(0) - 1;
+  const uint32_t lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
   int32_t b;
   int32_t t;
-  const auto total_B = offsets.size(0) - 1;
-  bool valid = b_t < total_B;
-  // info must be uint32_t (using auto will assign int32_t to info)
-  uint32_t info = 0;
+  // Grid-stride over b_t so the kernel covers the whole workload even when the
+  // launch caps grid.x -- ROCm does that to stay within the HIP 2^32
+  // threads-per-launch limit. On CUDA the grid already spans total_B, so the
+  // body executes exactly once per thread.
+  //
+  // The bound is warp-aligned (b_t - lane_id) so whole warps iterate together
+  // and the shfl_sync collectives below always have every lane present; the
+  // per-lane `valid` masking keeps out-of-range lanes inert. The comparison is
+  // done in 64 bits so a large total_B cannot truncate.
+  for (auto b_t = blockIdx.x * blockDim.x + threadIdx.x;
+       static_cast<int64_t>(b_t - lane_id) < total_B;
+       b_t += gridDim.x * blockDim.x) {
+    const bool valid = b_t < total_B;
+    // info must be uint32_t (using auto will assign int32_t to info)
+    uint32_t info = 0;
 
-  if (vbe && valid) {
-    info = vbe_b_t_map[b_t];
-    reinterpret_cast<uint32_t*>(&t)[0] = info >> info_B_num_bits;
-    reinterpret_cast<uint32_t*>(&b)[0] = info & info_B_mask;
-  } else {
-    fd.DivMod(b_t, &t, &b);
-  }
+    if (vbe && valid) {
+      info = vbe_b_t_map[b_t];
+      reinterpret_cast<uint32_t*>(&t)[0] = info >> info_B_num_bits;
+      reinterpret_cast<uint32_t*>(&b)[0] = info & info_B_mask;
+    } else {
+      fd.DivMod(b_t, &t, &b);
+    }
 
-  const index_t hash_offset = valid ? hash_size_cumsum[t] : -1;
-  const auto indices_start = valid ? offsets[b_t] : -1;
-  const auto L = valid ? offsets[b_t + 1] - indices_start : 0;
-  const uint32_t lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
+    const index_t hash_offset = valid ? hash_size_cumsum[t] : -1;
+    const auto indices_start = valid ? offsets[b_t] : -1;
+    const auto L = valid ? offsets[b_t + 1] - indices_start : 0;
 
-  // Compile-time conditional
-  if (nobag) {
-    for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
-      const auto indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
-      const auto t_warp = fbgemm_gpu::shfl_sync(t, j);
-      const auto L_warp = fbgemm_gpu::shfl_sync(L, j);
-      const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
-      for (auto i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
-        const index_t idx = __ldg(&indices[indices_start_warp + i]);
-        const auto l_t = (indices_start_warp + i) * T + t_warp;
-        infos[indices_start_warp + i] = l_t;
-        linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
+    // Compile-time conditional
+    if (nobag) {
+      for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
+        const auto indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
+        const auto t_warp = fbgemm_gpu::shfl_sync(t, j);
+        const auto L_warp = fbgemm_gpu::shfl_sync(L, j);
+        const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
+        for (auto i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
+          const index_t idx = __ldg(&indices[indices_start_warp + i]);
+          const auto l_t = (indices_start_warp + i) * T + t_warp;
+          infos[indices_start_warp + i] = l_t;
+          linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
+        }
+      }
+    } else {
+      // Store t in upper (32 - DEFAULT_INFO_B_NUM_BITS).
+      // Store b in lower (DEFAULT_INFO_B_NUM_BITS).
+      if (!vbe && valid) {
+        info = (reinterpret_cast<uint32_t*>(&t)[0] << info_B_num_bits) |
+            reinterpret_cast<uint32_t*>(&b)[0];
+      }
+      for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
+        const auto indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
+        const auto info_warp = fbgemm_gpu::shfl_sync(info, j);
+        const auto L_warp = fbgemm_gpu::shfl_sync(L, j);
+        const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
+        for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
+          const index_t idx = __ldg(&indices[indices_start_warp + i]);
+          reinterpret_cast<uint32_t*>(&infos[0])[indices_start_warp + i] =
+              info_warp;
+          linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
+        }
       }
     }
-  } else {
-    // Store t in upper (32 - DEFAULT_INFO_B_NUM_BITS).
-    // Store b in lower (DEFAULT_INFO_B_NUM_BITS).
-    if (!vbe && valid) {
-      info = (reinterpret_cast<uint32_t*>(&t)[0] << info_B_num_bits) |
-          reinterpret_cast<uint32_t*>(&b)[0];
-    }
-    for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
-      const auto indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
-      const auto info_warp = fbgemm_gpu::shfl_sync(info, j);
-      const auto L_warp = fbgemm_gpu::shfl_sync(L, j);
-      const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
-      for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
-        const index_t idx = __ldg(&indices[indices_start_warp + i]);
-        reinterpret_cast<uint32_t*>(&infos[0])[indices_start_warp + i] =
-            info_warp;
-        linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
-      }
-    }
-  }
+  } // for b_t (warp-aligned grid-stride loop)
 }
 
 template <typename index_t, typename info_acc_t>
@@ -155,46 +167,59 @@ __launch_bounds__(kMaxThreads) void linearize_index_index_select_kernel(
     FixedDivisor fd,
     int32_t fixed_L_per_warp) {
   const auto T = hash_size_cumsum.size(0) - 1;
-  auto b_t = blockIdx.x * blockDim.x + threadIdx.x;
+  // Flattened (B * T) extent this kernel walks. Computed in 64 bits so it
+  // cannot truncate.
+  const auto total_b_t = static_cast<int64_t>(fd.D()) * T;
+  const uint32_t lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
   int32_t b;
   int32_t t;
+  // Grid-stride over b_t so the kernel covers the whole workload even when the
+  // launch caps grid.x -- ROCm does that to stay within the HIP 2^32
+  // threads-per-launch limit. On CUDA the grid already spans the workload, so
+  // the body executes exactly once per thread.
+  //
+  // The bound is warp-aligned (b_t - lane_id) so whole warps iterate together
+  // and the shfl_sync collectives below always have every lane present; the
+  // per-lane `t < T` masking keeps out-of-range lanes inert.
+  for (auto b_t = blockIdx.x * blockDim.x + threadIdx.x;
+       static_cast<int64_t>(b_t - lane_id) < total_b_t;
+       b_t += gridDim.x * blockDim.x) {
+    fd.DivMod(b_t, &t, &b);
 
-  fd.DivMod(b_t, &t, &b);
-
-  const uint32_t lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
-
-  index_t hash_offset = -1;
-  index_t indices_start = -1;
-  int32_t L = 0;
-  int32_t L_start = 0;
-  if (t < T) {
-    const auto total_L_start = total_L_offsets[t];
-    const auto total_L = total_L_offsets[t + 1] - total_L_start;
-    L_start = b * fixed_L_per_warp;
-    if (L_start < total_L) {
-      hash_offset = hash_size_cumsum[t];
-      indices_start = total_L_start + L_start;
-      L = (total_L - L_start >= fixed_L_per_warp) ? fixed_L_per_warp
-                                                  : (total_L - L_start);
+    index_t hash_offset = -1;
+    index_t indices_start = -1;
+    int32_t L = 0;
+    int32_t L_start = 0;
+    if (t < T) {
+      const auto total_L_start = total_L_offsets[t];
+      const auto total_L = total_L_offsets[t + 1] - total_L_start;
+      L_start = b * fixed_L_per_warp;
+      if (L_start < total_L) {
+        hash_offset = hash_size_cumsum[t];
+        indices_start = total_L_start + L_start;
+        L = (total_L - L_start >= fixed_L_per_warp) ? fixed_L_per_warp
+                                                    : (total_L - L_start);
+      }
     }
-  }
 
-  // Compile-time conditional
-  for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
-    const index_t indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
-    const auto t_warp = fbgemm_gpu::shfl_sync(t, j);
-    const auto L_warp = fbgemm_gpu::shfl_sync(L, j);
-    const auto L_start_warp = fbgemm_gpu::shfl_sync(L_start, j);
-    const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
-    for (auto i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
-      const index_t idx = __ldg(&indices[indices_start_warp + i]);
-      // l is the relative l in the feature (i.e., the first l in the feature
-      // is 0)
-      const int64_t l_t = (L_start_warp + i) * T + t_warp;
-      infos[indices_start_warp + i] = l_t;
-      linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
+    // Compile-time conditional
+    for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
+      const index_t indices_start_warp =
+          fbgemm_gpu::shfl_sync(indices_start, j);
+      const auto t_warp = fbgemm_gpu::shfl_sync(t, j);
+      const auto L_warp = fbgemm_gpu::shfl_sync(L, j);
+      const auto L_start_warp = fbgemm_gpu::shfl_sync(L_start, j);
+      const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
+      for (auto i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
+        const index_t idx = __ldg(&indices[indices_start_warp + i]);
+        // l is the relative l in the feature (i.e., the first l in the feature
+        // is 0)
+        const int64_t l_t = (L_start_warp + i) * T + t_warp;
+        infos[indices_start_warp + i] = l_t;
+        linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
+      }
     }
-  }
+  } // for b_t (warp-aligned grid-stride loop)
 }
 
 DLL_PUBLIC std::tuple<
@@ -234,6 +259,12 @@ transpose_embedding_input(
       (total_L_offsets.has_value() &&
        total_L_offsets.value().numel() == T + 1));
 
+  // The linearize_index kernels flatten (B, T) into a 32-bit thread index b_t
+  // and hand it to FixedDivisor::DivMod, which takes an int32_t. Assert the
+  // bound here so an oversized workload fails loudly instead of silently
+  // wrapping the grid-stride index inside the kernel.
+  TORCH_CHECK_LE(total_B, std::numeric_limits<int32_t>::max());
+
   auto infos = at::empty_like(
       indices,
       indices.options().dtype(
@@ -255,7 +286,8 @@ transpose_embedding_input(
              : linearize_index_kernel<index_t, INFO_ACC_T, NOBAG, false>); \
     FBGEMM_LAUNCH_KERNEL(                                                  \
         linearize_index_kernel_,                                           \
-        div_round_up(total_B, kMaxThreads),                                \
+        utils::cuda::cap_grid_dim_x_from_workload(                         \
+            total_B, kMaxThreads, at::cuda::getCurrentCUDAStream()),       \
         kMaxThreads,                                                       \
         0,                                                                 \
         at::cuda::getCurrentCUDAStream(),                                  \
@@ -289,7 +321,8 @@ transpose_embedding_input(
                 // fixed_L_per_warp)
                 FBGEMM_LAUNCH_KERNEL(
                     (linearize_index_index_select_kernel<index_t, int64_t>),
-                    div_round_up(total_B, kMaxThreads),
+                    utils::cuda::cap_grid_dim_x_from_workload(
+                        total_B, kMaxThreads, at::cuda::getCurrentCUDAStream()),
                     kMaxThreads,
                     0,
                     at::cuda::getCurrentCUDAStream(),

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_embeddings_cache_cuda.cu
@@ -17,6 +17,7 @@
 #include "fbgemm_gpu/split_embeddings_cache_cuda.cuh"
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
 #include "fbgemm_gpu/utils/bitonic_sort.cuh"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 #include "fbgemm_gpu/utils/dispatch_macros.h"
 #include "fbgemm_gpu/utils/kernel_launcher.cuh"
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
@@ -498,36 +499,45 @@ __global__ __launch_bounds__(kMaxThreads) void ssd_generate_row_addrs_kernel(
     const int* N_unique,
     const uint64_t cache_row_bytes // has to be 64 bits to prevent overflow
 ) {
+#ifdef USE_ROCM
+  for (auto n = blockDim.y * blockIdx.x + threadIdx.y; n < *N_unique;
+       n += blockDim.y * gridDim.x) {
+#else
   const auto n = blockDim.y * blockIdx.x + threadIdx.y;
   if (n >= *N_unique) {
     return;
   }
+#endif
 
-  const auto cache_set_id = cache_set_inverse_indices[n];
-  const auto segment_start = unique_indices_count_cumsum[cache_set_id];
-  const auto segment_end = unique_indices_count_cumsum[cache_set_id + 1];
-  // Cache locations
-  const auto cache_loc =
-      lxu_cache_locations[linear_index_inverse_indices[segment_start]];
+    const auto cache_set_id = cache_set_inverse_indices[n];
+    const auto segment_start = unique_indices_count_cumsum[cache_set_id];
+    const auto segment_end = unique_indices_count_cumsum[cache_set_id + 1];
+    // Cache locations
+    const auto cache_loc =
+        lxu_cache_locations[linear_index_inverse_indices[segment_start]];
 
-  const uint64_t ptr_addr = (cache_loc == -1)
-      // Conflict miss
-      ? (inserted_ssd_weights_addr + (n * cache_row_bytes))
-      // Not conflict miss
-      : (lxu_cache_weights_addr + (cache_loc * cache_row_bytes));
+    const uint64_t ptr_addr = (cache_loc == -1)
+        // Conflict miss
+        ? (inserted_ssd_weights_addr + (n * cache_row_bytes))
+        // Not conflict miss
+        : (lxu_cache_weights_addr + (cache_loc * cache_row_bytes));
 
-  // Set post backward evicted indices
-  if (assigned_cache_slots[n] == -1 && cache_loc == -1) {
-    post_bwd_evicted_indices[n] = cache_set_sorted_unique_indices[n];
-  } else {
-    post_bwd_evicted_indices[n] = -1;
-  }
+    // Set post backward evicted indices
+    if (assigned_cache_slots[n] == -1 && cache_loc == -1) {
+      post_bwd_evicted_indices[n] = cache_set_sorted_unique_indices[n];
+    } else {
+      post_bwd_evicted_indices[n] = -1;
+    }
 
-  // Set pointer address
-  for (auto l = segment_start + threadIdx.x; l < segment_end; l += blockDim.x) {
-    auto dst = linear_index_inverse_indices[l];
-    *reinterpret_cast<uint64_t*>(&ssd_row_addrs[dst]) = ptr_addr;
-  }
+    // Set pointer address
+    for (auto l = segment_start + threadIdx.x; l < segment_end;
+         l += blockDim.x) {
+      auto dst = linear_index_inverse_indices[l];
+      *reinterpret_cast<uint64_t*>(&ssd_row_addrs[dst]) = ptr_addr;
+    }
+#ifdef USE_ROCM
+  } // for n (grid-stride loop, ROCm only)
+#endif
 }
 
 std::tuple<Tensor, Tensor> ssd_generate_row_addrs_cuda(
@@ -577,7 +587,10 @@ std::tuple<Tensor, Tensor> ssd_generate_row_addrs_cuda(
         using index_t = scalar_t;
         FBGEMM_LAUNCH_KERNEL(
             (ssd_generate_row_addrs_kernel<index_t>),
-            div_round_up(lxu_cache_locations.numel(), kNumWarps),
+            utils::cuda::cap_grid_dim_x(
+                div_round_up(lxu_cache_locations.numel(), kNumWarps),
+                kMaxThreads,
+                at::cuda::getCurrentCUDAStream()),
             dim3(kWarpSizeHost(), kNumWarps),
             0,
             at::cuda::getCurrentCUDAStream(),
@@ -617,42 +630,56 @@ __global__ __launch_bounds__(kMaxThreads) void ssd_update_row_addrs_kernel(
     const int* N_unique_curr,
     const uint64_t cache_row_bytes // has to be 64 bits to prevent overflow
 ) {
+#ifdef USE_ROCM
+  for (auto n_curr = blockDim.y * blockIdx.x + threadIdx.y;
+       n_curr < *N_unique_curr;
+       n_curr += blockDim.y * gridDim.x) {
+#else
   const auto n_curr = blockDim.y * blockIdx.x + threadIdx.y;
   if (n_curr >= *N_unique_curr) {
     return;
   }
+#endif
 
-  // Find mapping between n_curr and n_next
-  const auto n_next = ssd_curr_next_map[n_curr];
+    // Find mapping between n_curr and n_next
+    const auto n_next = ssd_curr_next_map[n_curr];
 
-  // Return if the row is not used in both previous and next iterations
-  if (n_next < 0) {
+    // Return if the row is not used in both previous and next iterations
+    if (n_next < 0) {
+#ifdef USE_ROCM
+      continue;
+#else
     return;
-  }
+#endif
+    }
 
-  // Find out if the row gets moved to the nextent iteration's scratch pad or
-  // L1 by checking the lxu_cache_locations_curr
-  const auto cache_set_id_curr = cache_set_inverse_indices_curr[n_curr];
-  const auto segment_start_curr =
-      unique_indices_count_cumsum_curr[cache_set_id_curr];
-  const auto segment_end_curr =
-      unique_indices_count_cumsum_curr[cache_set_id_curr + 1];
-  const auto cache_loc_curr = lxu_cache_locations_curr
-      [linear_index_inverse_indices_curr[segment_start_curr]];
+    // Find out if the row gets moved to the nextent iteration's scratch pad or
+    // L1 by checking the lxu_cache_locations_curr
+    const auto cache_set_id_curr = cache_set_inverse_indices_curr[n_curr];
+    const auto segment_start_curr =
+        unique_indices_count_cumsum_curr[cache_set_id_curr];
+    const auto segment_end_curr =
+        unique_indices_count_cumsum_curr[cache_set_id_curr + 1];
+    const auto cache_loc_curr = lxu_cache_locations_curr
+        [linear_index_inverse_indices_curr[segment_start_curr]];
 
-  const uint64_t ptr_addr = (cache_loc_curr == -1)
-      // The row is moved from the previous iteration's scratch pad to the
-      // next iteration's scratch pad
-      ? (inserted_ssd_weights_addr_next + (n_next * cache_row_bytes))
-      // The row is moved from the previous iteration's scratch pad to L1 cache
-      : (lxu_cache_weights_addr + (cache_loc_curr * cache_row_bytes));
+    const uint64_t ptr_addr = (cache_loc_curr == -1)
+        // The row is moved from the previous iteration's scratch pad to the
+        // next iteration's scratch pad
+        ? (inserted_ssd_weights_addr_next + (n_next * cache_row_bytes))
+        // The row is moved from the previous iteration's scratch pad to L1
+        // cache
+        : (lxu_cache_weights_addr + (cache_loc_curr * cache_row_bytes));
 
-  // Set pointer address
-  for (auto l = segment_start_curr + threadIdx.x; l < segment_end_curr;
-       l += blockDim.x) {
-    auto dst = linear_index_inverse_indices_curr[l];
-    *reinterpret_cast<uint64_t*>(&ssd_row_addrs_curr[dst]) = ptr_addr;
-  }
+    // Set pointer address
+    for (auto l = segment_start_curr + threadIdx.x; l < segment_end_curr;
+         l += blockDim.x) {
+      auto dst = linear_index_inverse_indices_curr[l];
+      *reinterpret_cast<uint64_t*>(&ssd_row_addrs_curr[dst]) = ptr_addr;
+    }
+#ifdef USE_ROCM
+  } // for n_curr (grid-stride loop, ROCm only)
+#endif
 }
 
 void ssd_update_row_addrs_cuda(
@@ -688,7 +715,10 @@ void ssd_update_row_addrs_cuda(
 
   FBGEMM_LAUNCH_KERNEL(
       (ssd_update_row_addrs_kernel),
-      div_round_up(ssd_row_addrs_curr.numel(), kNumWarps),
+      utils::cuda::cap_grid_dim_x(
+          div_round_up(ssd_row_addrs_curr.numel(), kNumWarps),
+          kMaxThreads,
+          at::cuda::getCurrentCUDAStream()),
       dim3(kWarpSizeHost(), kNumWarps),
       0,
       at::cuda::getCurrentCUDAStream(),


### PR DESCRIPTION
Summary:
ssd_generate_row_addrs_kernel and ssd_update_row_addrs_kernel launch
grid = div_round_up(numel, kNumWarps) with block = dim3(kWarpSize, kNumWarps),
so total threads ~= numel * kWarpSize exceeds the HIP 2^32 threads-per-launch
limit on ROCm for large lxu_cache_locations / ssd_row_addrs counts.

Cap both launches with utils::cuda::cap_grid_dim_x(..., OverflowOnly) and add a
ROCm grid-stride loop over the warp index (n / n_curr). In the update kernel the
"row not used in both iterations" early-return (n_next < 0) becomes `continue`
under ROCm. Added the cuda_utilities.cuh include. No-op on CUDA.

Reviewed By: henrylhtsang

Differential Revision: D113351690


