### PR TITLE
Reland: arch-aware FP8 host-boundary relabel + dispatch guardrails

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -67,7 +67,7 @@ enum SSDTensor {
     auto output = embedding_codegen_forward_op.call(
       flatten_dev_weights,
       {%- if not dense %}
-      uvm_weights,
+      relabeled_uvm_weights,
       lxu_cache_weights,
       weights_placements,
       {%- endif %}
@@ -827,9 +827,17 @@ class {{ autograd_func }} :
 
     {%- if optimizer == "none" %}
     // Flatten
-    const auto& flatten_dev_weights = dev_weights.flatten();
+    const auto flatten_dev_weights =
+        fbgemm_gpu::relabel_nfp8_for_dispatch(dev_weights.flatten());
     {%- else %}
-    const auto& flatten_dev_weights = dev_weights;
+    const auto flatten_dev_weights =
+        fbgemm_gpu::relabel_nfp8_for_dispatch(dev_weights);
+    {%- endif %}
+    {%- if not dense %}
+    // On ROCm a gfx950 NFP8 tensor is labeled fn but only the fnuz kernel
+    // variant is instantiated; relabel at the kernel boundary. No-op elsewhere.
+    const auto relabeled_uvm_weights =
+        fbgemm_gpu::relabel_nfp8_for_dispatch(uvm_weights);
     {%- endif %}
 
     {%- if nobag %}
@@ -874,6 +882,12 @@ class {{ autograd_func }} :
     auto uvm_weights = *savedItr++;
     auto lxu_cache_weights = *savedItr++;
     auto weights_placements = *savedItr++;
+    {%- endif %}
+    // Mirror the forward-side relabel: on ROCm a gfx950 NFP8 tensor is labeled
+    // fn, but only the fnuz kernel variant is instantiated. No-op elsewhere.
+    dev_weights = fbgemm_gpu::relabel_nfp8_for_dispatch(dev_weights);
+    {%- if not dense %}
+    uvm_weights = fbgemm_gpu::relabel_nfp8_for_dispatch(uvm_weights);
     {%- endif %}
     auto weights_offsets = *savedItr++;
     {%- if not nobag %}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -1302,6 +1302,25 @@ Tensor {{ embedding_cuda_op }}(
                     constexpr bool supported_grad_type = std::is_same_v<grad_t, float> || std::is_same_v<grad_t, at::Half> || std::is_same_v<grad_t, at::BFloat16>;
                     const bool cached = uvm_weights.numel() > 0 || lxu_cache_weights.numel() > 0;
 
+                    // FP8 must stay out of supported_weights_type. Unlike the generic
+                    // backward, this path converts emb_t through the *c10* FP8 types
+                    // (nearest_rounding_store_vector in
+                    // rocm/embedding_backward_split_device_kernel_template.hip,
+                    // accumulate_row_per_warp in rocm/split_embeddings_common.h) rather
+                    // than the arch-bound __nv_fp8_e4m3 alias. c10::Float8_e4m3fnuz uses
+                    // exponent bias 8 and c10::Float8_e4m3fn uses bias 7, so the
+                    // conversion is label-bound. dispatch_emb_cache_types() routes the
+                    // gfx950 "fn" tensor label into the single at::Float8_e4m3fnuz
+                    // instantiation, so admitting FP8 here would apply bias-8 math to OCP
+                    // data on gfx950, silently. Move those device sites onto the alias
+                    // before relaxing this.
+                    static_assert(
+                        !supported_weights_type ||
+                            (!std::is_same_v<emb_t, at::Float8_e4m3fnuz> &&
+                             !std::is_same_v<emb_t, at::Float8_e4m3fn>),
+                        "ROCm optimized backward converts emb_t via the label-bound c10 FP8 types; "
+                        "admitting FP8 emb_t here is incorrect on gfx950. See comment above.");
+
                     // The optimized HIP backward kernel uses warpSize-64-only
                     // intrinsics; it must only be dispatched on warpSize 64
                     // devices. warpSize 32 devices fall through to the generic

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_template.cu
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_template.cu
@@ -144,9 +144,13 @@ void split_embedding_{{ optimizer }}_update(
 
     CUDA_DEVICE_GUARD(dev_weights);
 
-    // Flatten dev_weights because it is currrently 2D
-    dev_weights = dev_weights.flatten();
-    const auto& flatten_grad_dev_weights = grad_dev_weights.flatten();
+    // Flatten dev_weights because it is currrently 2D.
+    // On ROCm a gfx950 NFP8 tensor is labeled fn but only the fnuz kernel
+    // variant is instantiated; relabel at the kernel boundary. No-op elsewhere.
+    dev_weights = fbgemm_gpu::relabel_nfp8_for_dispatch(dev_weights.flatten());
+    uvm_weights = fbgemm_gpu::relabel_nfp8_for_dispatch(uvm_weights);
+    const auto flatten_grad_dev_weights =
+        fbgemm_gpu::relabel_nfp8_for_dispatch(grad_dev_weights.flatten());
     const auto& flatten_grad_dev_indices = grad_dev_indices.flatten();
 
     fbgemm_gpu::dispatch_emb_cache_types(

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -152,7 +152,7 @@ enum SSDTensor {
     auto output = embedding_codegen_forward_op.call(
       weights_host,
       flatten_weights_dev,
-      weights_uvm,
+      relabeled_weights_uvm,
       weights_lxu_cache,
       weights_placements,
       weights_offsets,
@@ -931,10 +931,16 @@ class {{ autograd_func }} :
 
     {%- if optimizer == "none" %}
     // Flatten
-    const auto& flatten_weights_dev = weights_dev.flatten();
+    const auto flatten_weights_dev =
+        fbgemm_gpu::relabel_nfp8_for_dispatch(weights_dev.flatten());
     {%- else %}
-    const auto& flatten_weights_dev = weights_dev;
+    const auto flatten_weights_dev =
+        fbgemm_gpu::relabel_nfp8_for_dispatch(weights_dev);
     {%- endif %}
+    // On ROCm a gfx950 NFP8 tensor is labeled fn but only the fnuz kernel
+    // variant is instantiated; relabel at the kernel boundary. No-op elsewhere.
+    const auto relabeled_weights_uvm =
+        fbgemm_gpu::relabel_nfp8_for_dispatch(weights_uvm);
     {%- if nobag %}
     // nobag
       {{
@@ -981,6 +987,10 @@ static torch::autograd::variable_list backward(
     auto weights_host = *savedItr++;
     auto weights_dev = *savedItr++;
     auto weights_uvm = *savedItr++;
+    // Mirror the forward-side relabel: on ROCm a gfx950 NFP8 tensor is labeled
+    // fn, but only the fnuz kernel variant is instantiated. No-op elsewhere.
+    weights_dev = fbgemm_gpu::relabel_nfp8_for_dispatch(weights_dev);
+    weights_uvm = fbgemm_gpu::relabel_nfp8_for_dispatch(weights_uvm);
     auto weights_lxu_cache = *savedItr++;
     auto weights_placements = *savedItr++;
     auto weights_offsets = *savedItr++;

--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_common.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_common.h
@@ -10,6 +10,9 @@
 #include <ATen/ATen.h>
 #include <c10/macros/Macros.h>
 #include <cstdint>
+#ifdef USE_ROCM
+#include <ATen/detail/CUDAHooksInterface.h>
+#endif
 
 namespace fbgemm_gpu {
 
@@ -44,6 +47,85 @@ enum class BoundsCheckMode : uint8_t {
   IGNORE = 2,
 };
 
+// ---------------------------------------------------------------------------
+// NFP8 (FP8 e4m3) dtype flow on ROCm -- read this first
+//
+//   1. Allocation     getNFP8ScalarType() (C++) and nfp8_dtype() (Python) label
+//                     the weight buffer per-arch: fnuz on gfx94x/gfx90a, OCP fn
+//                     on gfx950 and CUDA. This is the label Python sees, and it
+//                     is never changed.
+//   2. Host boundary  relabel_nfp8_for_dispatch() takes a *view* labeled fnuz
+//                     immediately before the tensor enters a kernel, because
+//                     only the fnuz emb_t variant is instantiated. Metadata
+//                     only -- no copy, no conversion, no kernel launch.
+//   3. Dispatch       dispatch_emb_cache_types() selects that single fnuz
+//                     instantiation.
+//   4. Device         loads/stores reinterpret through the __nv_fp8_e4m3 alias
+//                     (utils/float.cuh), which the HIP headers bind to the
+//                     arch's physical encoding per device-compile pass. The c10
+//                     label is discarded here, so a gfx950 kernel does OCP fn
+//                     math no matter which label step 2 applied.
+//
+// INVARIANT: every host entry point that hands NFP8 embedding weights to a TBE
+// kernel must call relabel_nfp8_for_dispatch() first, and must not let the
+// relabeled view escape back to Python. Forget the first half and the tensor is
+// rejected by TensorAccessorBuilder or data_ptr<emb_t>(); forget the second and
+// callers observe the wrong dtype.
+// ---------------------------------------------------------------------------
+
+// Resolves the native FP8 (e4m3) scalar type for the current runtime device.
+//
+// The FP8 encoding is hardware-specific: the gfx94x family (gfx940/941/942,
+// MI300) and gfx90a use the "fnuz" encoding, while gfx950 and CUDA use the OCP
+// "fn" encoding. Because a ROCm build can be a fat binary spanning multiple
+// archs, this cannot be a compile-time decision on the host: it must query the
+// device actually in use at runtime so the host-allocated tensor dtype matches
+// what device kernels (whose format is selected per-arch at device-compile
+// time) read and write.
+inline at::ScalarType getNFP8ScalarType() {
+#ifdef USE_ROCM
+  // fnuz archs: the gfx94x family (gfx940/941/942, MI300) and gfx90a. The
+  // substring match mirrors split_embedding_configs.py:_nfp8_is_fnuz; keep the
+  // two in sync. Query goes through the ATen-cpu CUDA hooks so this header is
+  // safe to compile into the CPU/meta libraries (no ATen/cuda/CUDAContext.h).
+  const auto& cuda_hooks = at::detail::getCUDAHooks();
+  if (cuda_hooks.hasCUDA() && cuda_hooks.isGPUArch({"gfx94", "gfx90a"})) {
+    return at::kFloat8_e4m3fnuz;
+  }
+#endif
+  return at::kFloat8_e4m3fn;
+}
+
+// Relabels an NFP8 tensor's scalar type to fnuz for kernel dispatch.
+// Step 2 of the flow documented above.
+//
+// IMPORTANT: this does NOT change the FP8 encoding and does NOT force fnuz
+// numerics. It only rewrites the host tensor's dtype tag, on a view, so that it
+// matches the emb_t template parameter of the single instantiated kernel. The
+// physical encoding stays arch-bound in device code (step 4), so a gfx950
+// kernel does OCP fn math regardless of the label applied here.
+//
+// It is needed because emb_t must EQUAL the tensor's scalar type:
+// TensorAccessorBuilder::checkTensorConstraints and, un-patchably,
+// at::TensorBase::data_ptr<T>() both enforce that. Without this the gfx950
+// tensor (labeled fn by getNFP8ScalarType) cannot be passed to the fnuz kernel.
+//
+// Cost: metadata-only, ~400 ns and independent of tensor size.
+//
+// Exception worth knowing: the ROCm optimized backward converts emb_t through
+// the c10 FP8 types instead of the alias, which IS label-bound (exponent bias 8
+// vs 7), so step 4 does not apply there. FP8 is excluded from that path on the
+// host, pinned by a static_assert in
+// codegen/training/backward/embedding_backward_split_template.cu.
+inline at::Tensor relabel_nfp8_for_dispatch(const at::Tensor& tensor) {
+#ifdef USE_ROCM
+  if (tensor.defined() && tensor.scalar_type() == at::kFloat8_e4m3fn) {
+    return tensor.view(at::kFloat8_e4m3fnuz);
+  }
+#endif
+  return tensor;
+}
+
 inline at::ScalarType getScalarType(SparseType dtype) {
   switch (dtype) {
     case SparseType::FP32:
@@ -59,11 +141,7 @@ inline at::ScalarType getScalarType(SparseType dtype) {
     case SparseType::INT2:
       return at::kQUInt2x4;
     case SparseType::NFP8:
-#if (defined(USE_ROCM) && !HIP_FP8_TYPE_OCP)
-      return at::kFloat8_e4m3fnuz;
-#else
-      return at::kFloat8_e4m3fn;
-#endif
+      return getNFP8ScalarType();
     default:
       return at::ScalarType::Undefined;
   }

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/dispatch_macros.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/dispatch_macros.h
@@ -61,6 +61,28 @@ decltype(auto) dispatch_emb_cache_types(
       return dispatch_cache.template operator()<at::Half>();
     case c10::CppTypeToScalarType<fp8_e4m3_t>::value:
       return dispatch_cache.template operator()<fp8_e4m3_t>();
+#if defined(USE_ROCM)
+    // On gfx950 an NFP8 tensor is labeled fn (getNFP8ScalarType / nfp8_dtype),
+    // but only the fnuz emb_t variant is instantiated, so every host entry
+    // point must call fbgemm_gpu::relabel_nfp8_for_dispatch() on the embedding
+    // weight tensors first -- see the "NFP8 dtype flow" block in
+    // fbgemm_gpu/embedding_common.h.
+    //
+    // Reaching here still labeled fn means that call was missed. Fail now, with
+    // that explanation, instead of routing into the fnuz instantiation and
+    // dying further downstream inside TensorAccessorBuilder or
+    // data_ptr<emb_t>() with a bare scalar-type mismatch that points at the
+    // symptom rather than the omission.
+    case at::ScalarType::Float8_e4m3fn:
+      TORCH_CHECK(
+          false,
+          name,
+          ": embedding weights reached dispatch still labeled ",
+          toString(emb_type),
+          ". Call fbgemm_gpu::relabel_nfp8_for_dispatch() on them at the host "
+          "boundary first; see the NFP8 dtype flow note in "
+          "fbgemm_gpu/embedding_common.h.");
+#endif
     default:
       TORCH_CHECK(
           false, name, " not implemented for emb_t '", toString(emb_type), "'");
@@ -200,10 +222,13 @@ decltype(auto) dispatch_index_types(
 
 #if defined(USE_ROCM)
 
-#define FBGEMM_DISPATCH_FLOAT_HALF_AND_FP8_CASE(...)   \
-  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__) \
-  AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)  \
-  AT_DISPATCH_CASE(at::ScalarType::Float8_e4m3fnuz, __VA_ARGS__)
+// Both FP8 labels are dispatchable on ROCm because getNFP8ScalarType() picks
+// fnuz on gfx94x/gfx90a and fn on gfx950.
+#define FBGEMM_DISPATCH_FLOAT_HALF_AND_FP8_CASE(...)             \
+  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__)           \
+  AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)            \
+  AT_DISPATCH_CASE(at::ScalarType::Float8_e4m3fnuz, __VA_ARGS__) \
+  AT_DISPATCH_CASE(at::ScalarType::Float8_e4m3fn, __VA_ARGS__)
 
 #else
 

--- a/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate.cu
@@ -177,6 +177,10 @@ void lfu_cache_insert_cuda(
 
   CUDA_DEVICE_GUARD(weights);
 
+  // On ROCm a gfx950 NFP8 tensor is labeled fn but only the fnuz kernel
+  // variant is instantiated; relabel at the kernel boundary. No-op elsewhere.
+  weights = fbgemm_gpu::relabel_nfp8_for_dispatch(weights);
+
   const int32_t N = cache_set_sorted_unique_indices.numel();
 
   fbgemm_gpu::dispatch_emb_cache_types(

--- a/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate.cu
@@ -200,6 +200,10 @@ void lru_cache_insert_cuda(
 
   CUDA_DEVICE_GUARD(weights);
 
+  // On ROCm a gfx950 NFP8 tensor is labeled fn but only the fnuz kernel
+  // variant is instantiated; relabel at the kernel boundary. No-op elsewhere.
+  weights = fbgemm_gpu::relabel_nfp8_for_dispatch(weights);
+
   const int32_t N = cache_set_sorted_unique_indices.numel();
   fbgemm_gpu::dispatch_emb_cache_types(
       weights.scalar_type(),

--- a/fbgemm_gpu/src/split_embeddings_cache/lxu_cache.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lxu_cache.cu
@@ -103,6 +103,10 @@ DLL_PUBLIC void lxu_cache_flush_cuda(
 
   CUDA_DEVICE_GUARD(lxu_cache_weights);
 
+  // On ROCm a gfx950 NFP8 tensor is labeled fn but only the fnuz kernel
+  // variant is instantiated; relabel at the kernel boundary. No-op elsewhere.
+  uvm_weights = fbgemm_gpu::relabel_nfp8_for_dispatch(uvm_weights);
+
   const int32_t T = D_offsets.numel() - 1;
   TORCH_CHECK(
       T > 0,

--- a/fbgemm_gpu/src/split_embeddings_cache/reset_weight_momentum.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/reset_weight_momentum.cu
@@ -236,6 +236,11 @@ DLL_PUBLIC void reset_weight_momentum_cuda(
       lxu_cache_state);
   CUDA_DEVICE_GUARD(dev_weights);
 
+  // On ROCm a gfx950 NFP8 tensor is labeled fn but only the fnuz kernel
+  // variant is instantiated; relabel at the kernel boundary. No-op elsewhere.
+  dev_weights = fbgemm_gpu::relabel_nfp8_for_dispatch(dev_weights);
+  uvm_weights = fbgemm_gpu::relabel_nfp8_for_dispatch(uvm_weights);
+
   const int64_t num_pruned_indices = pruned_indices.size(0);
   const int32_t num_pruned_tables = buffer_ids.size(0);
   const int32_t blocks_per_table = get_sm_count_();

--- a/fbgemm_gpu/test/utils/dispatch_macros_test.cu
+++ b/fbgemm_gpu/test/utils/dispatch_macros_test.cu
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "fbgemm_gpu/embedding_common.h"
+#include "fbgemm_gpu/utils/dispatch_macros.h"
+
+namespace fbgemm_gpu {
+
+// Only the fnuz emb_t variant of the TBE kernels is instantiated, so on archs
+// where getNFP8ScalarType() labels NFP8 weights "fn" (gfx950, CUDA) every host
+// entry point must call relabel_nfp8_for_dispatch() before dispatching. See the
+// "NFP8 dtype flow" block in embedding_common.h.
+//
+// If that call is missed, the tensor must be rejected here, by name, rather
+// than routed into the fnuz instantiation to die further downstream inside
+// TensorAccessorBuilder or data_ptr<emb_t>() with a bare scalar-type mismatch
+// that points at the symptom instead of the omission.
+//
+// This is only meaningful on ROCm: on CUDA fp8_e4m3_t *is* Float8_e4m3fn, so
+// the label is the dispatchable one and there is nothing to reject.
+#ifdef USE_ROCM
+
+TEST(DispatchMacrosTest, UnrelabeledNFP8IsRejectedByName) {
+  bool invoked = false;
+  const auto dispatch = [&]() {
+    dispatch_emb_cache_types(
+        at::kFloat8_e4m3fn,
+        at::kFloat,
+        "test_kernel",
+        [&]<typename emb_t, typename cache_t>() { invoked = true; });
+  };
+
+  EXPECT_THROW(dispatch(), c10::Error);
+  EXPECT_FALSE(invoked) << "an un-relabeled fn tensor must not reach a kernel";
+
+  try {
+    dispatch();
+    FAIL() << "expected dispatch to throw";
+  } catch (const c10::Error& e) {
+    const std::string msg = e.what();
+    EXPECT_NE(msg.find("relabel_nfp8_for_dispatch"), std::string::npos)
+        << "the error must name the helper the caller forgot; got: " << msg;
+  }
+}
+
+// The label the kernels are actually instantiated for still dispatches.
+TEST(DispatchMacrosTest, FnuzNFP8Dispatches) {
+  bool invoked = false;
+  dispatch_emb_cache_types(
+      at::kFloat8_e4m3fnuz,
+      at::kFloat,
+      "test_kernel",
+      [&]<typename emb_t, typename cache_t>() { invoked = true; });
+  EXPECT_TRUE(invoked);
+}
+
+#endif // USE_ROCM
+
+} // namespace fbgemm_gpu


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3022

Adds the C++ mechanism that lets a single FP8 kernel instantiation serve both
AMD FP8 e4m3 encodings. This diff is deliberately INERT on its own -- it does
not change any behavior. The follow-up diff activates it by making the host
dtype selection arch-aware.

FP8 e4m3 has two encodings: AMD gfx94x (MI300) and gfx90a use "fnuz", while
gfx950 (MI350) and CUDA use the OCP "fn" variant. Making that selection
arch-aware requires the TBE kernels to accept an fn-labeled weight tensor on
gfx950, which is what this diff builds.

## Why the obvious approach does not work

The device-side encoding is already arch-correct: all FP8 device load/store
paths reinterpret through the __nv_fp8_e4m3 alias in utils/float.cuh, which the
HIP headers bind to the arch's physical type per device-compile pass. The fn and
fnuz overloads in vec4.cuh and weight_row.cuh are identical and both cast to
that alias, so a single fnuz kernel instantiation emits correct machine code on
both archs. The at::Float8_e4m3fn vs fnuz C++ type is only a dispatch and
tensor-dtype label.

But the label is not free-floating: the template parameter emb_t must EQUAL the
tensor's scalar type. Two places enforce that:

  - TensorAccessorBuilder::checkTensorConstraints, for every
    PackedTensorAccessor*<emb_t, ...> built over an embedding weight
  - PyTorch core, at::TensorBase::data_ptr<T>() -> check_type(), which FBGEMM
    cannot relax

So merely adding an at::ScalarType::Float8_e4m3fn dispatch case that routes to
the fnuz instantiation fails at runtime on gfx950 with

  RuntimeError: Expected tensor 'dev_weights' to have scalar type
  Float8_e4m3fnuz, but found Float8_e4m3fn instead!

and, once the FBGEMM-side accessor check is relaxed, one layer deeper inside
PyTorch.

Instantiating both FP8 kernel variants resolves the coupling but costs +28.8%
.text and +33.2% device code in the TBE training library, which is not
acceptable for large linked binaries. Linker ICF was evaluated as a way to fold
the duplicates and rejected: -Wl,--icf=all recovers only 0.4% of the .text
growth, because the duplicate host stubs relocate against distinct fatbin kernel
descriptors and most of the growth is in the fatbin, which ICF does not touch.

## What this adds

A host-boundary relabel. embedding_common.h gains:

  relabel_nfp8_for_dispatch(t) -> t.view(at::kFloat8_e4m3fnuz) when t is
  Float8_e4m3fn under USE_ROCM, else t unchanged

To be explicit, since the name can be read the wrong way: this does NOT change
the FP8 encoding and does NOT force fnuz numerics. It rewrites only the host
tensor's dtype tag, on a view, so the type system lets the tensor reach the
single instantiated kernel. The encoding is still chosen per-arch inside device
code by the __nv_fp8_e4m3 alias, so a gfx950 kernel does OCP fn math either way.
It is metadata-only: no copy, no kernel launch, ~400 ns and independent of
tensor size.

Applied at the host dispatch boundaries:

  codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp  (fwd, bwd)
  codegen/training/backward/embedding_backward_split_host_template.cpp (fwd, bwd)
  codegen/training/optimizer/embedding_optimizer_split_template.cu
  src/split_embeddings_cache/lfu_cache_populate.cu
  src/split_embeddings_cache/lru_cache_populate.cu
  src/split_embeddings_cache/lxu_cache.cu
  src/split_embeddings_cache/reset_weight_momentum.cu

Deliberately not covered, with reasons:

  - lxu_cache_weights and all momentum / prev_iter / row_counter / grad_output
    tensors: cache_t and grad_t never include FP8, and NFP8 TBE pins the cache
    to fp16.
  - SSD TBE: tbe/ssd/training.py asserts weights_precision in (FP32, FP16) and
    has no NFP8 support.
  - The op-level forward / backward / indice_weights templates: every reachable
    caller flows through a relabeling host wrapper.

Note this cannot be done in Python. TBE's forward is torch.jit.script-ed and
TorchScript rejects every form of the dtype view: t.view(dtype) silently
resolves to the view(int[] size) overload (treating the dtype enum as a shape),
t.view(dtype=...) finds no such variant, and torch.ops.aten.view.dtype fails
attribute lookup. It has to be C++.

## Making the mechanism trackable

A reviewer's fair criticism of an earlier revision was that a relabel spread
across host boundaries is hard for a developer to follow. Three things address
that:

  - embedding_common.h opens with a four-step "NFP8 dtype flow" block covering
    allocation, host boundary, dispatch and device, plus a stated INVARIANT:
    every host entry point that hands NFP8 weights to a TBE kernel must call
    relabel_nfp8_for_dispatch() first, and must not let the relabeled view
    escape back to Python. Phrased as a rule rather than a list of sites so it
    does not rot.
  - dispatch_emb_cache_types() no longer silently routes an fn-labeled tensor
    into the fnuz instantiation. It rejects it and names the helper. Previously
    a host path that missed the relabel sailed through dispatch and died further
    downstream in TensorAccessorBuilder with a bare scalar-type mismatch that
    pointed at the symptom rather than the omission. That backstop provided no
    working path -- the accessor rejected the tensor moments later either way --
    so this only changes which error you get, and makes it actionable.
  - test/utils/dispatch_macros_test.cu pins that guardrail: an un-relabeled fn
    tensor must be rejected, the error must name the helper, and the fnuz label
    must still dispatch.

## Also here

  - embedding_common.h adds getNFP8ScalarType(), which resolves the FP8 scalar
    type from the runtime device through the ATen CUDA hooks. It replaces a
    compile-time HIP_FP8_TYPE_OCP branch that was undefined at the point of use
    and silently forced fnuz on every ROCm arch. Being a runtime query, it is
    correct for multi-arch fat binaries. It currently has no live caller and
    ships as documentation and future use; the Python side is what labels the
    weight buffer today.
  - dispatch_macros.h adds the Float8_e4m3fn case to
    FBGEMM_DISPATCH_FLOAT_HALF_AND_FP8_CASE.
  - A static_assert in embedding_backward_split_template.cu pinning FP8 out of
    the ROCm optimized backward. Unlike the generic path, that one converts
    emb_t through the c10 FP8 types, which are label-bound (exponent bias 8 vs
    7), so admitting FP8 there would be silently wrong on gfx950.

## Why this diff is inert on its own

  - On ROCm, SparseType.NFP8.as_dtype() still returns fnuz everywhere -- the
    arch-aware selection is in the follow-up -- so no fn-labeled NFP8 tensor
    exists and relabel_nfp8_for_dispatch() never fires.
  - The new dispatch rejection is therefore unreachable in production; only the
    gtest drives it.
  - getNFP8ScalarType() has no live caller (see above).
  - The ROCm NFP8 TBE tests remain skipped; they are re-enabled in the follow-up.
  - On CUDA every USE_ROCM block compiles out.

One genuine non-no-op to disclose: several host templates change `const auto&`
to `const auto` for the weight bindings, turning a lifetime-extended const-ref
into a by-value Tensor -- one atomic refcount increment per TBE call, on all
archs including CUDA.

Reviewed By: henrylhtsang

Differential Revision: D114094367


