### PR TITLE
Create no-FBGEMM_FBCODE stub library to fix no-fbcode streamer test (#6105)

### DIFF
--- a/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
@@ -8,7 +8,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "deeplearning/fbgemm/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h" // @manual=//deeplearning/fbgemm/fbgemm_gpu/src/split_embeddings_cache:raw_embedding_streamer
+#include "fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h"
 #ifdef FBGEMM_FBCODE
 #include <folly/coro/GmockHelpers.h>
 #include "aiplatform/gmpp/experimental/training_ps/gen-cpp2/TrainingParameterServerService.h"
@@ -35,6 +35,11 @@ class MockTrainingParameterServerService
 };
 #endif
 
+// These object-constructing tests run in BOTH targets: the fbcode target links
+// the flag-on :raw_embedding_streamer, and the no-fbcode target links the
+// flag-off :raw_embedding_streamer_no_fbcode -- so each test's flag view of the
+// header layout matches its library, avoiding the sizeof mismatch (an all-off
+// test linked against the always-flag-on library would overrun the object).
 static std::unique_ptr<fbgemm_gpu::RawEmbeddingStreamer>
 getRawEmbeddingStreamer(
     const std::string& unique_id,


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3004

The no-fbcode streamer test compiled the header with FBGEMM_FBCODE off but linked the always-flag-on :raw_embedding_streamer, so the flag-on constructor overran the smaller flag-off object layout → ASan heap-buffer-overflow (pre-existing latent bug).

Fix: link the test against a new -UFBGEMM_FBCODE build, :raw_embedding_streamer_no_fbcode, so its header view matches the library layout; switch the test include to the short form so it resolves via fbgemm_gpu's include/ dir instead of the manual pin to the flag-on lib.

___

Differential Revision: D114193888
