### PR TITLE
num_stages=0 -> 1 (pytorch/FBGEMM)

### DIFF
--- a/fbgemm_gpu/experimental/simplicial_attention/benchmarks/_proton/tlx_fwd_ws_pingpong_proton.py
+++ b/fbgemm_gpu/experimental/simplicial_attention/benchmarks/_proton/tlx_fwd_ws_pingpong_proton.py
@@ -55,7 +55,7 @@ def get_configs():
                 "BLOCK_SIZE_KV": BLOCK_SIZE_KV,
                 "NUM_BUFFERS": num_buffers,
             },
-            num_stages=0,
+            num_stages=1,
             num_warps=4,
             pre_hook=_host_descriptor_pre_hook,
         )

--- a/fbgemm_gpu/experimental/simplicial_attention/benchmarks/_proton/tlx_fwd_ws_proton.py
+++ b/fbgemm_gpu/experimental/simplicial_attention/benchmarks/_proton/tlx_fwd_ws_proton.py
@@ -54,7 +54,7 @@ def get_configs():
                 "BLOCK_SIZE_KV": BLOCK_SIZE_KV,
                 "NUM_BUFFERS": num_buffers,
             },
-            num_stages=0,
+            num_stages=1,
             num_warps=4,
             pre_hook=_host_descriptor_pre_hook,
         )

--- a/fbgemm_gpu/experimental/simplicial_attention/simplicial/ops/tlx/fwd_ws.py
+++ b/fbgemm_gpu/experimental/simplicial_attention/simplicial/ops/tlx/fwd_ws.py
@@ -53,7 +53,7 @@ def get_configs():
                 "BLOCK_SIZE_KV": BLOCK_SIZE_KV,
                 "NUM_BUFFERS": num_buffers,
             },
-            num_stages=0,
+            num_stages=1,
             num_warps=4,
             pre_hook=_host_descriptor_pre_hook,
         )

--- a/fbgemm_gpu/experimental/simplicial_attention/simplicial/ops/tlx/fwd_ws_pingpong.py
+++ b/fbgemm_gpu/experimental/simplicial_attention/simplicial/ops/tlx/fwd_ws_pingpong.py
@@ -53,7 +53,7 @@ def get_configs():
                 "BLOCK_SIZE_KV": BLOCK_SIZE_KV,
                 "NUM_BUFFERS": num_buffers,
             },
-            num_stages=0,
+            num_stages=1,
             num_warps=4,
             pre_hook=_host_descriptor_pre_hook,
         )

--- a/fbgemm_gpu/experimental/simplicial_attention/simplicial/ops/tlx/fwd_ws_pipelined.py
+++ b/fbgemm_gpu/experimental/simplicial_attention/simplicial/ops/tlx/fwd_ws_pipelined.py
@@ -53,7 +53,7 @@ def get_configs():
                 "BLOCK_SIZE_KV": BLOCK_SIZE_KV,
                 "NUM_BUFFERS": num_buffers,
             },
-            num_stages=0,
+            num_stages=1,
             num_warps=4,
             pre_hook=_host_descriptor_pre_hook,
         )


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3015

Simplicial attention TLX forward kernels (`fwd_ws`, `fwd_ws_pingpong`, `fwd_ws_pipelined`) and their proton benchmarks.

Split out of D114751669 so each GitHub export destination lands as its
own diff. `num_stages=0` has been removed from TLX (AMD included), so the
remaining uses move to `num_stages=1` -- covering the
`triton.Config(..., num_stages=0)` autotune param, the
`tl.range(..., num_stages=0)` loop attribute, and autotune sweeps that
generate a 0 (the 0 is dropped rather than duplicated to 1).

See D114751669 for the full sweep and rationale.

Reviewed By: jianyuh

Differential Revision: D114753270


