### PR TITLE
Add ROCm cap to fused_nbit_rowwise dequant launch

### DIFF
--- a/fbgemm_gpu/src/quantize_ops/quantize_fused_nbit_rowwise.cu
+++ b/fbgemm_gpu/src/quantize_ops/quantize_fused_nbit_rowwise.cu
@@ -270,7 +270,10 @@ Tensor _fusednbitrowwise_to_float_gpu_t(
   const int blockDim_x = std::min(output_columns, threads_per_block);
   const dim3 blockDim(blockDim_x, threads_per_block / blockDim_x);
   const auto gridDim_x = cuda_calc_xblock_count(output_columns, blockDim.x);
-  const auto gridDim_y = cuda_calc_block_count(nrows, blockDim.y);
+  const auto gridDim_y = utils::cuda::cap_grid_dim_x(
+      cuda_calc_block_count(nrows, blockDim.y),
+      static_cast<int64_t>(gridDim_x) * threads_per_block,
+      at::cuda::getCurrentCUDAStream());
   const dim3 gridDim(gridDim_x, gridDim_y);
 
 #define DEQUANT_LAUNCH_NBIT(scale_bias_last)                               \


### PR DESCRIPTION
Summary:
_fusednbitrowwise_to_float_cuda_kernel launches a 2-D (row x col) grid and
already grid-strides over rows, but its grid.y was uncapped, so on ROCm the
total thread count (gridDim.x * gridDim.y * threads_per_block) can exceed the
HIP 2^32 threads-per-launch limit for large nrows * ncols. (The quantize path
_float_to_fusednbitrowwise is already capped and grid-strides.)

Cap grid.y by reusing cap_grid_dim_x with (gridDim_x * threads_per_block) as the
per-y-block thread count. OverflowOnly => no-op on CUDA; kernel unchanged.

Reviewed By: henrylhtsang

Differential Revision: D113375949


