### PR TITLE
Disable prefetch pipeline for embedding cache

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -599,6 +599,17 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         self.last_flush_step = -1
 
         # Set prefetch pipeline
+        # Prefetch pipelining is not supported in embedding cache mode: the TBE
+        # forward runs under no_grad (see ZeroCollisionEmbeddingCache), so the
+        # backward hooks that drain ssd_location_update_data and unlock cache
+        # lines never fire, and their UVA scratch pads leak one per iteration.
+        if self._enrichment_enabled:
+            if prefetch_pipeline:
+                logging.warning(
+                    "prefetch_pipeline is not supported in embedding_cache_mode; "
+                    "disabling it"
+                )
+            prefetch_pipeline = False
         self.prefetch_pipeline: bool = prefetch_pipeline
         self.prefetch_stream: torch.cuda.Stream | None = None
 


### PR DESCRIPTION
Summary:
f1122133724 was killed by OOMD after ~40 minutes: a ~160 MiB UVA scratch pad
leaked per training step in the KVZCH embedding-cache TBE.

Prefetch pipelining appends to ssd_location_update_data on every _prefetch,
guarded only by self.training, and drains it only in a backward pre-hook.
ZeroCollisionEmbeddingEnrichmentCache.forward() runs under torch.no_grad(),
since embedding-cache rows are written externally and never learned, so the
hook never fires and every entry pins a scratch pad forever. The same missing
hook also leaves lxu_cache_locking_counter never decremented, saturating L1
cache ways. The design assumes training mode implies a backward will follow;
embedding-cache mode is an unmodelled third state, training but no backward.

Fix: force prefetch_pipeline = False for embedding-cache TBEs. Scratch-pad
forwarding, cache-line locking and pointer fix-up all exist only to protect
the forward/backward overlap, so with no backward they are pure cost plus the
leak.

Diagnosis: RssAnon and RssShmem were flat while RssFile grew linearly, and
MemAvailable tracked MemFree down, pointing at unreclaimable /dev/nvidia-uvm
mappings rather than heap growth. FREE_MEM eviction fired at its threshold and
evicted zero blocks, ruling out the DRAM KV store.

Future work: enable the prefetch pipeline for embedding cache

Differential Revision: D115116344


