### PR TITLE
Guard permute_2D_sparse_data against undersized permuted_indices (S683387)

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cstdlib>
+
 #include "common.cuh"
 
 using Tensor = at::Tensor;
@@ -18,7 +20,8 @@ template <
     bool has_weight,
     typename offsets_t,
     typename indices_t,
-    typename weights_t>
+    typename weights_t,
+    bool debug = false>
 __global__ __launch_bounds__(kMaxThreads) void permute_2D_data_kernel(
     int64_t len,
     int32_t T,
@@ -44,6 +47,21 @@ __global__ __launch_bounds__(kMaxThreads) void permute_2D_data_kernel(
       segment_length = output_offsets[b_t + 1] - output_offsets[b_t];
     }
     offsets_t input_start = input_offsets[permute[t] * B + b];
+    if constexpr (debug) {
+      const bool in_bounds = output_start >= 0 && segment_length >= 0 &&
+          static_cast<int64_t>(output_start) +
+                  static_cast<int64_t>(segment_length) <=
+              len;
+      CUDA_KERNEL_ASSERT_PRINTF(
+          in_bounds,
+          "permute_2D_data_kernel: output segment out of bounds of "
+          "permuted_indices (b_t=%d, output_start=%lld, segment_length=%lld, "
+          "len=%lld)",
+          b_t,
+          static_cast<long long>(output_start),
+          static_cast<long long>(segment_length),
+          static_cast<long long>(len));
+    }
     for (auto i = threadIdx.x; i < segment_length; i += blockDim.x) {
       permuted_indices[output_start + i] = indices[input_start + i];
       if (has_weight) {
@@ -111,7 +129,8 @@ template <
     bool has_weight,
     typename offsets_t,
     typename indices_t,
-    typename weights_t>
+    typename weights_t,
+    bool debug = false>
 __global__ __launch_bounds__(kMaxThreads) void permute_2D_data_kernel_vec(
     int64_t len,
     int32_t T,
@@ -137,6 +156,22 @@ __global__ __launch_bounds__(kMaxThreads) void permute_2D_data_kernel_vec(
     const int32_t segment_length =
         static_cast<int32_t>(output_end - output_start);
     const offsets_t input_start = input_offsets[permute[t] * B + b];
+
+    if constexpr (debug) {
+      // output_end wrapping negative (int32 offsets overflow) is caught by the
+      // output_end >= output_start term.
+      const bool in_bounds =
+          output_start >= 0 && output_end >= output_start && output_end <= len;
+      CUDA_KERNEL_ASSERT_PRINTF(
+          in_bounds,
+          "permute_2D_data_kernel_vec: output segment out of bounds of "
+          "permuted_indices (b_t=%d, output_start=%lld, output_end=%lld, "
+          "len=%lld)",
+          b_t,
+          static_cast<long long>(output_start),
+          static_cast<long long>(output_end),
+          static_cast<long long>(len));
+    }
 
     indices_t* __restrict__ indices_dst = permuted_indices + output_start;
     const indices_t* __restrict__ indices_src = indices + input_start;
@@ -213,6 +248,23 @@ __global__ __launch_bounds__(kMaxThreads) void permute_2D_lengths_kernel(
     permuted_lengths[b_t] = lengths[permute[t] * B + b];
   }
 }
+
+// Launch a permute kernel, picking the debug instantiation at runtime.
+// debug=false does not instantiate the bounds assert at all, which is what
+// keeps the fused two-stream copy optimizable (see is_debug_permute_enabled).
+#define FBGEMM_LAUNCH_PERMUTE_2D(                                       \
+    DEBUG, KERNEL, HAS_WEIGHT, OFFSETS_T, INDICES_T, WEIGHTS_T, ...)    \
+  do {                                                                  \
+    if (DEBUG) {                                                        \
+      FBGEMM_LAUNCH_KERNEL(                                             \
+          (KERNEL<HAS_WEIGHT, OFFSETS_T, INDICES_T, WEIGHTS_T, true>),  \
+          __VA_ARGS__);                                                 \
+    } else {                                                            \
+      FBGEMM_LAUNCH_KERNEL(                                             \
+          (KERNEL<HAS_WEIGHT, OFFSETS_T, INDICES_T, WEIGHTS_T, false>), \
+          __VA_ARGS__);                                                 \
+    }                                                                   \
+  } while (0)
 
 DLL_PUBLIC std::tuple<Tensor, Tensor, std::optional<Tensor>>
 permute_2D_sparse_preallocated_out_cuda(
@@ -305,6 +357,8 @@ permute_2D_sparse_preallocated_out_cuda(
   }
 
   // convert lengths to offsets
+  const bool debug_permute = is_debug_permute_enabled();
+
   const auto input_offsets = asynchronous_exclusive_cumsum_gpu(lengths_contig);
   const auto output_offsets =
       asynchronous_complete_cumsum_gpu(permuted_lengths.flatten());
@@ -314,9 +368,24 @@ permute_2D_sparse_preallocated_out_cuda(
         "permute_2D", output_offsets, debug_permuted_lengths_sum);
   }
 
+  // The hint only sizes permuted_indices; the kernels address writes via
+  // output_offsets, so a hint that disagrees causes out-of-bounds writes.
   int64_t permuted_indices_size = 0;
   if (permuted_lengths_sum.has_value()) {
     permuted_indices_size = permuted_lengths_sum.value();
+    if (debug_permute) {
+      const int64_t true_size = output_offsets[-1].item<int64_t>();
+      TORCH_CHECK(
+          permuted_indices_size == true_size,
+          "permute_2D_sparse_data: permuted_lengths_sum hint (",
+          permuted_indices_size,
+          ") != actual sum of permuted lengths (",
+          true_size,
+          "). The preallocated permuted_indices buffer is undersized and the "
+          "permute kernel would write out of bounds. This usually means the "
+          "caller's cached length metadata is stale relative to the GPU lengths "
+          "tensor.");
+    }
   } else {
     permuted_indices_size = output_offsets[-1].item<int64_t>();
   }
@@ -372,12 +441,13 @@ permute_2D_sparse_preallocated_out_cuda(
                     [&] {
                       using weights_t = scalar_t;
                       if (weights_columns == 1) {
-                        FBGEMM_LAUNCH_KERNEL(
-                            (permute_2D_data_kernel_vec<
-                                true,
-                                offsets_t,
-                                indices_t,
-                                weights_t>),
+                        FBGEMM_LAUNCH_PERMUTE_2D(
+                            debug_permute,
+                            permute_2D_data_kernel_vec,
+                            true,
+                            offsets_t,
+                            indices_t,
+                            weights_t,
                             blocks_2,
                             threads_2,
                             0,
@@ -393,12 +463,13 @@ permute_2D_sparse_preallocated_out_cuda(
                             permuted_indices.data_ptr<indices_t>(),
                             permuted_weights.data_ptr<weights_t>());
                       } else {
-                        FBGEMM_LAUNCH_KERNEL(
-                            (permute_2D_data_kernel<
-                                true,
-                                offsets_t,
-                                indices_t,
-                                weights_t>),
+                        FBGEMM_LAUNCH_PERMUTE_2D(
+                            debug_permute,
+                            permute_2D_data_kernel,
+                            true,
+                            offsets_t,
+                            indices_t,
+                            weights_t,
                             blocks_2,
                             threads_2,
                             0,
@@ -417,12 +488,13 @@ permute_2D_sparse_preallocated_out_cuda(
                       }
                     }); // for each weights_t
               } else {
-                FBGEMM_LAUNCH_KERNEL(
-                    (permute_2D_data_kernel_vec<
-                        false,
-                        offsets_t,
-                        indices_t,
-                        std::nullptr_t>),
+                FBGEMM_LAUNCH_PERMUTE_2D(
+                    debug_permute,
+                    permute_2D_data_kernel_vec,
+                    false,
+                    offsets_t,
+                    indices_t,
+                    std::nullptr_t,
                     blocks_2,
                     threads_2,
                     0,
@@ -440,8 +512,11 @@ permute_2D_sparse_preallocated_out_cuda(
               }
             }); // for each indices_t
       }); // for each offsets_t
+
   return {permuted_lengths, permuted_indices, permuted_weights};
 }
+
+#undef FBGEMM_LAUNCH_PERMUTE_2D
 
 // Functional (allocating) entry point. Delegates to the shared implementation
 // with no pre-allocated output buffers.


### PR DESCRIPTION
Summary:
S683387 is a non-deterministic CUDA illegal memory access in
permute_2D_data_kernel_vec (sparse_permute_2d.cu). The coredump (P2424369841)
shows the destination base pointer permuted_indices + output_start is out of
range while the source read is fine, faulting on a tail segment.

Root cause: permute_2D_sparse_preallocated_out_cuda sizes permuted_indices from
the caller-provided permuted_lengths_sum hint, but the kernel addresses writes
via output_offsets recomputed on-GPU from permuted_lengths. Nothing reconciles
the two. When the hint is smaller than the true sum (e.g. a stale cached
length_per_key from the torchrec KJT permute caller under the pipelined
input-dist), the tail segments write past the end of the buffer. This is
invisible under CUDA_LAUNCH_BLOCKING, matching the observed 1/30 flakiness.

## READ THIS FIRST: both guards are opt-in, production is unprotected

Everything this diff adds is behind FBGEMM_DEBUG_PERMUTE=1 and is OFF by
default. With the env var unset the behaviour is unchanged from before this
diff: a stale hint still corrupts silently and still surfaces as a
non-deterministic IMA. This diff makes S683387 *diagnosable in one run*, it does
not prevent it. Preventing it in production requires fixing the caller (have
torchrec pass None, or stop caching stale length metadata) -- see the RCA.

This is a deliberate reversal of the earlier "always-on guard" framing, forced
by measurement (below). aschhabra: your accept was "so we can create a hotfix",
which was predicated on the always-on device assert -- please re-confirm, since
that guard is now off by default.

## What the diff adds

- `bool debug = false` template parameter on permute_2D_data_kernel and
  permute_2D_data_kernel_vec. The bounds predicate and its
  CUDA_KERNEL_ASSERT_PRINTF both live inside `if constexpr (debug)`, so the
  default instantiation contains no check at all and is codegen-identical to
  the pre-guard kernel. The host picks the instantiation per launch.
- Host-side TORCH_CHECK validating permuted_lengths_sum against
  output_offsets[-1], as before. This is the check that fails fast AT the
  offending call and names both values, so it is the one to reach for first.
- One env var, FBGEMM_DEBUG_PERMUTE=1, enables both.

Note the host check runs before the launch, so on the stale-hint path it
preempts the device assert. The device assert covers what the host check
cannot: an out-of-bounds segment when the hint was absent or already validated.

Buffer sizing is unchanged: permuted_indices is sized from the hint when
provided, else from output_offsets[-1].

## Why the device assert is not always-on

An always-on CUDA_KERNEL_ASSERT_PRINTF costs +21.6% / +15.5% / +9.1%
(max_segment_length 8 / 32 / 128) on the weighted + int32-indices + fp32-weights
specialization -- even though it never fires. That is the only specialization
taking the fused two-stream uint4 copy, which the in-file comment already flags
as needing to be emitted contiguously to reach peak bandwidth. The other 21 of
24 configs in the matrix are within +/-1.3%.

Isolated by elimination. Each variant built and A/B'd interleaved with rotating
arm order on a pinned B200, 5 reps, n=5500 per arm per config, weighted+int32:

  variant                                  maxseg 8   32       128    recovers
  CUDA_KERNEL_ASSERT_PRINTF (baseline)     +21.6%   +15.5%   +9.1%    --
  plain CUDA_KERNEL_ASSERT (0-byte frame)  +21.7%   +13.4%   +8.8%     0%
  check hoisted above the segment loop     +23.7%   +13.9%   +8.9%     0%
  __trap() instead of __assert_fail        +21.6%   +16.0%   +8.4%     1%
  error flag + continue (falls through)     +1.4%    +0.7%   -1.3%    94%
  THIS DIFF (debug=false)                   -0.2%    -0.1%   -0.4%   101%

So it is not the printf buffer (ptxas -v: 64-byte frame, 0 spills; removing it
changes nothing), not register pressure (plain assert restores REG 30 == parent
and still costs 21%), not occupancy (-2.3%), not instruction count (the
non-regressing control gains MORE), and not the external call (__trap() is a
single instruction and still costs 21%). ncu shows zero local-memory traffic --
the frame is never touched -- with memory throughput -16.5% and long-scoreboard
stalls +12.3%, on the weighted path only.

The discriminator is that any TERMINATING failure path in the loop blocks
optimization of the fused copy. `if constexpr (debug)` sidesteps this by not
instantiating the path at all, rather than trying to make it cheap.
torch/headeronly/macros/Macros.h already carries a ROCm-specific workaround for
the same effect ("non-negligible performance impact even if the assert condition
is never triggered").

The error-flag + continue variant in the previous version of this diff was fast
but reported a bare boolean with no b_t/offsets/len, and only on the NEXT call
-- so a violation on a job's last call was never reported at all. Dropped.

## Review feedback

supadchaya: renamed per your comment --
permute_2D_check_output_size_enabled() -> is_debug_permute_enabled(), and
FBGEMM_PERMUTE_2D_CHECK_OUTPUT_SIZE -> FBGEMM_DEBUG_PERMUTE. The same knob now
also selects the debug kernel instantiation, which suits the generic name. One
limitation worth knowing: you cannot enable the device asserts without also
enabling the host check, and the host check's .item() forces a D2H sync that
perturbs timing -- not ideal when reproducing a non-deterministic race. Happy to
split the knob if that bites.

Also removes the unconditional TORCH_WARN of the hint value added in an earlier
version: it was TORCH_WARN, not TORCH_WARN_ONCE, so it fired on every call that
passes a hint -- i.e. every torchrec production call.

Full analysis: fbcode/ai_codesign/nonprod/bensonma415/sevs/S683387/root_cause_analysis.md
(updated: the guard section described the assert as always-on and named the old
env var.)

Reviewed By: aschhabra

Differential Revision: D112586847


