### PR TITLE
Fix over-strict GPU memory gate on opt_search_large_grid test

### DIFF
--- a/fbgemm_gpu/test/jagged/dense_dense_elementwise_add_test.py
+++ b/fbgemm_gpu/test/jagged/dense_dense_elementwise_add_test.py
@@ -380,7 +380,7 @@ class DenseDenseElementwiseAddTest(unittest.TestCase):
         torch.testing.assert_close(small_output_gpu[0].cpu(), small_output_cpu[0])
 
     @unittest.skipIf(*gpu_unavailable)
-    @unittest.skipIf(*gpu_memory_lt_gb(40))
+    @unittest.skipIf(*gpu_memory_lt_gb(4))
     def test_jagged_dense_dense_elementwise_add_jagged_output_opt_search_large_grid(
         self,
     ) -> None:

--- a/fbgemm_gpu/test/test_utils.py
+++ b/fbgemm_gpu/test/test_utils.py
@@ -283,7 +283,7 @@ def gpu_memory_lt_gb(x: int) -> tuple[bool, str]:
     return (
         torch.cuda.is_available()
         and (torch.cuda.get_device_properties(0).total_memory / (1024**3)) < x,
-        "GPU memory < 40GB",
+        f"GPU memory < {x}GB",
     )
 
 


### PR DESCRIPTION
Summary:
`test_jagged_dense_dense_elementwise_add_jagged_output_opt_search_large_grid`
was gated behind `unittest.skipIf(*gpu_memory_lt_gb(40))`. CI runs this
target on `fbcode.nvcc_arch=a100,h100a`; an A100-40GB reports
`total_memory` ~= 39.5 GiB, so the predicate is always true there and the
test (plus its four generated opcheck variants) skipped on every run.
That produced the perpetual SKIPPING test issue tracked by T283188244.

The 40 GiB figure comes from the original plan in D105203391, which
estimated the repro needed ~64 GiB HBM. The test as actually landed uses
a much smaller shape -- `nnz = 2**22 + 1`, `D = 16`, `float16` -- so the
gate was never recomputed against the real footprint. Measured peak on
device is 544 MiB allocated / 558 MiB reserved, matching the arithmetic
(4 tensors x 128 MiB = 512 MiB). Lowering the gate to 4 GiB keeps ~7.5x
headroom and lets the test run on every GPU lane CI schedules.

Also fixes `gpu_memory_lt_gb()` in test_utils.py, which hardcoded the
skip reason "GPU memory < 40GB" regardless of the threshold passed. It
now interpolates the actual value, so e.g. `gpu_memory_lt_gb(4)` no
longer reports "< 40GB". This is what made the original skip message
misleading during triage.

Differential Revision: D115328175


