### PR TITLE
Pass third-party include dirs as SYSTEM includes (#6127)

### DIFF
--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -91,7 +91,8 @@ function(cpp_library)
         CC_FLAGS        # General compilation flags applicable to all build variants
         MSVC_FLAGS      # Compilation flags specific to MSVC
         DEFINITIONS     # Preprocessor definitions
-        INCLUDE_DIRS    # Include directories for compilation
+        INCLUDE_DIRS    # First-party include directories for compilation
+        SYSTEM_INCLUDE_DIRS # Third-party include directories, passed as SYSTEM to suppress their warnings
         DEPS            # Target dependencies, i.e. built STATIC targets
     )
 
@@ -177,6 +178,11 @@ function(cpp_library)
     target_include_directories(${lib_name} PUBLIC
         ${args_INCLUDE_DIRS})
 
+    # Third-party include directories are marked SYSTEM so their diagnostics do
+    # not surface in this target.
+    target_include_directories(${lib_name} SYSTEM PUBLIC
+        ${args_SYSTEM_INCLUDE_DIRS})
+
     # Link against the external libraries as needed
     target_link_libraries(${lib_name} PUBLIC ${args_DEPS})
 
@@ -256,6 +262,9 @@ function(cpp_library)
         " "
         "INCLUDE_DIRS:"
         "${args_INCLUDE_DIRS}"
+        " "
+        "SYSTEM_INCLUDE_DIRS:"
+        "${args_SYSTEM_INCLUDE_DIRS}"
         " "
         "Library Dependencies:"
         "${args_DEPS}"

--- a/cmake/modules/GpuCppLibrary.cmake
+++ b/cmake/modules/GpuCppLibrary.cmake
@@ -168,7 +168,8 @@ function(gpu_cpp_library)
         CC_FLAGS            # General compilation flags applicable to all build variants
         NVCC_FLAGS          # Compilation flags specific to NVCC
         HIPCC_FLAGS         # Compilation flags specific to HIPCC
-        INCLUDE_DIRS        # Include directories for compilation
+        INCLUDE_DIRS        # First-party include directories for compilation
+        SYSTEM_INCLUDE_DIRS # Third-party include directories, passed as SYSTEM to suppress their warnings
         DEPS                # Target dependencies, i.e. built STATIC targets
         TORCH_LIBS          # PyTorch libraries to link against. Note that we provide the TORCH_LIBS automatically - this is for PyTorch build.
     )
@@ -184,6 +185,12 @@ function(gpu_cpp_library)
 
     # Take all the sources, and filter them into CPU and GPU buckets depending
     # on the source type and build mode
+    # NOTE: Only first-party include dirs are set as source file properties here.
+    # Third-party dirs are attached at the target level as SYSTEM includes; see
+    # gpu_cpp_library() below.  They must NOT also appear as plain `-I` entries:
+    # clang de-duplicates header search paths keeping the first occurrence, so a
+    # directory listed under both `-I` and `-isystem` stays non-system and its
+    # warnings are NOT suppressed.
     prepare_target_sources(
         PREFIX ${args_PREFIX}
         CPU_SRCS ${args_CPU_SRCS}
@@ -233,20 +240,37 @@ function(gpu_cpp_library)
                 HIP_SOURCE_PROPERTY_FORMAT 1)
         endif()
 
-        # Set the include directories for HIP
+        # Set the include directories for HIP.  First-party only: the legacy
+        # FindHIP `hip_include_directories()` has no SYSTEM variant and emits
+        # plain `-I`, so third-party dirs are passed separately as `-isystem`
+        # entries in HIPCC_OPTIONS below.
         hip_include_directories("${args_INCLUDE_DIRS}")
+
+        # Build `-isystem` flags for the third-party include dirs.  hipcc is
+        # clang, and clang de-duplicates header search paths keeping the first
+        # occurrence, so these directories must appear ONLY here and never in
+        # `hip_include_directories()` -- otherwise the `-I` entry wins and the
+        # directory is not treated as a system header path.
+        set(lib_hipcc_system_includes "")
+        foreach(include_dir IN LISTS args_SYSTEM_INCLUDE_DIRS)
+            list(APPEND lib_hipcc_system_includes "-isystem${include_dir}")
+        endforeach()
 
         # Create the HIP library
         hip_add_library(${lib_name} ${args_TYPE}
             ${lib_sources_hipified}
             ${args_OTHER_SRCS}
             ${FBGEMM_HIP_HCC_LIBRARIES}
-            HIPCC_OPTIONS ${HIP_HCC_FLAGS} ${args_HIPCC_FLAGS})
+            HIPCC_OPTIONS ${HIP_HCC_FLAGS} ${lib_hipcc_system_includes} ${args_HIPCC_FLAGS})
 
         # Append ROCM includes
         target_include_directories(${lib_name} PUBLIC
-            ${FBGEMM_HIP_INCLUDE}
             ${args_INCLUDE_DIRS})
+
+        # ROCm toolchain and third-party headers are system headers
+        target_include_directories(${lib_name} SYSTEM PUBLIC
+            ${FBGEMM_HIP_INCLUDE}
+            ${args_SYSTEM_INCLUDE_DIRS})
 
     else()
         # Create the CPU-only / CUDA library
@@ -289,10 +313,11 @@ function(gpu_cpp_library)
     # Library Includes and Linking
     ############################################################################
 
-    # Add external include directories
-    target_include_directories(${lib_name} PRIVATE
-        ${TORCH_INCLUDE_DIRS}
-        ${NCCL_INCLUDE_DIRS})
+    # Add external include directories.  These are third-party (PyTorch, NCCL,
+    # CUTLASS, CK, asmjit, ...) and are marked SYSTEM so their diagnostics do not
+    # surface in FBGEMM targets that consume them.
+    target_include_directories(${lib_name} SYSTEM PRIVATE
+        ${args_SYSTEM_INCLUDE_DIRS})
 
     # Set additional target properties
     if(NOT args_KEEP_PREFIX)
@@ -427,6 +452,9 @@ function(gpu_cpp_library)
         " "
         "INCLUDE_DIRS:"
         "${args_INCLUDE_DIRS}"
+        " "
+        "SYSTEM_INCLUDE_DIRS:"
+        "${args_SYSTEM_INCLUDE_DIRS}"
         " "
         "Selected Source Files:"
         "${lib_sources}"

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -141,13 +141,24 @@ endif()
 # Source Includes
 ################################################################################
 
+# First-party include directories.  Warnings MUST apply to code found here.
 set(fbgemm_sources_include_directories
   # FBGEMM
   ${FBGEMM}/include
   # FBGEMM_GPU
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/../include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+
+# Third-party include directories.  These are passed to targets as SYSTEM
+# includes (`-isystem`) so that diagnostics originating inside them are
+# suppressed wholesale.  Without this, enabling a high-volume warning flag
+# produces a wall of unfixable third-party output, and the natural response is a
+# blanket `-Wno-*` that also disables the flag for our own code.
+#
+# Do NOT add first-party paths to this list: doing so silently disables all
+# warnings for that code.
+set(fbgemm_thirdparty_include_directories
   # PyTorch
   ${TORCH_INCLUDE_DIRS}
   # Third-party

--- a/fbgemm_gpu/FbgemmGpu.cmake
+++ b/fbgemm_gpu/FbgemmGpu.cmake
@@ -148,6 +148,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     src/embedding_inplace_ops/embedding_inplace_update_cpu.cpp
   GPU_SRCS
@@ -190,6 +192,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${fbgemm_gpu_sources_cpu_static}
   GPU_SRCS

--- a/fbgemm_gpu/cmake/Asmjit.cmake
+++ b/fbgemm_gpu/cmake/Asmjit.cmake
@@ -23,6 +23,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   OTHER_SRCS
     ${asmjit_sources}
   DESTINATION

--- a/fbgemm_gpu/cmake/Fbgemm.cmake
+++ b/fbgemm_gpu/cmake/Fbgemm.cmake
@@ -74,6 +74,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   OTHER_SRCS
     ${fbgemm_sources}
   DEPS

--- a/fbgemm_gpu/cmake/TbeInference.cmake
+++ b/fbgemm_gpu/cmake/TbeInference.cmake
@@ -16,6 +16,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${FBGEMM_GPU}/src/split_embeddings_cache/lfu_cache_populate_byte.cpp
     ${FBGEMM_GPU}/src/split_embeddings_cache/linearize_cache_indices.cpp
@@ -58,6 +60,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${static_cpu_files_inference}
     ${gen_cpu_files_inference}

--- a/fbgemm_gpu/cmake/TbeTraining.cmake
+++ b/fbgemm_gpu/cmake/TbeTraining.cmake
@@ -73,6 +73,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     src/config/feature_gates.cpp
     src/config/feature_gates_torch_op.cpp
@@ -86,6 +88,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     src/split_embeddings_utils/split_embeddings_utils_cpu.cpp
     src/split_embeddings_utils/split_embeddings_utils_meta.cpp
@@ -105,6 +109,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     src/sparse_ops/sparse_async_cumsum.cpp
   GPU_SRCS
@@ -121,6 +127,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${static_cpu_files_common}
   GPU_SRCS
@@ -140,6 +148,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   GPU_SRCS
     ${gen_defused_optim_src_files}
   NVCC_FLAGS
@@ -154,6 +164,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${gen_cpu_files_forward_split}
   GPU_SRCS
@@ -172,6 +184,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${gen_cpu_files_training_pt2}
   GPU_SRCS
@@ -195,6 +209,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${static_cpu_files_training}
     ${gen_cpu_files_training}
@@ -221,6 +237,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   GPU_SRCS
     ${gen_gpu_files_training_gwd}
   NVCC_FLAGS
@@ -237,6 +255,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   GPU_SRCS
     ${gen_gpu_files_training_vbe}
   NVCC_FLAGS
@@ -253,6 +273,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   GPU_SRCS
     ${gen_gpu_files_training_dense}
   NVCC_FLAGS
@@ -270,6 +292,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   GPU_SRCS
     ${gen_gpu_files_training_split_host}
   NVCC_FLAGS
@@ -287,6 +311,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${static_cpu_files_index_select}
   GPU_SRCS

--- a/fbgemm_gpu/experimental/example/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/example/CMakeLists.txt
@@ -35,6 +35,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   GPU_SRCS
     ${experimental_example_cpp_source_files})
 

--- a/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
@@ -137,12 +137,18 @@ gpu_cpp_library(
     ${KEEP_PREFIX}
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/attention/cuda/cutlass_blackwell_fmha
     ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize
     ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize/include
     ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize/common/include
     ${CMAKE_CURRENT_SOURCE_DIR}/src/kv_cache
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
+    # Vendored upstream CUTLASS example code -- treated as third-party so that
+    # upstream re-syncs stay clean.
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/attention/cuda/cutlass_blackwell_fmha
+    # Injected externally when building as part of PyTorch; points at
+    # PyTorch-side paths.
     ${FBGEMM_GENAI_INCLUDE_DIRS}
   CPU_SRCS
     ${experimental_gen_ai_cpp_source_files_cpu}

--- a/fbgemm_gpu/experimental/hstu/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/hstu/CMakeLists.txt
@@ -158,6 +158,8 @@ gpu_cpp_library(
     ${fbgemm_sources_include_directories}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/hstu_ampere
     ${CMAKE_CURRENT_SOURCE_DIR}/src/hstu_hopper
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${hstu_cpp_source_files}
   GPU_SRCS


### PR DESCRIPTION
Summary:

Prerequisite for the compiler warning flag rollout (T169200065).

FBGEMM_GPU consumes several third-party header libraries we cannot modify:
PyTorch/ATen, CUTLASS, Composable Kernel, asmjit, cpuinfo, and nlohmann/json.
Today they are passed as ordinary `-I` includes, so any warning flag we enable
also reports diagnostics from inside them. The codebase already carries several
hand-rolled escapes for exactly this (`-Wno-strict-aliasing  # for CUTLASS`,
`-Wno-header-hygiene` for CK), and each such escape also disables the flag for
our own code in that target.

This change splits `fbgemm_sources_include_directories` into a first-party list
and a new `fbgemm_thirdparty_include_directories`, and adds a
`SYSTEM_INCLUDE_DIRS` parameter to `cpp_library()` and `gpu_cpp_library()` that
emits the latter as SYSTEM (`-isystem`) includes. Compilers suppress warnings
originating in system headers, so third-party diagnostics disappear wholesale
without touching our own coverage.

Notes:
- The two lists are kept strictly disjoint. clang de-duplicates header search
  paths keeping the first occurrence, so a directory listed under both `-I` and
  `-isystem` stays non-system and its warnings are NOT suppressed.
- The ROCm path needs special handling: the legacy FindHIP
  `hip_include_directories()` has no SYSTEM variant, so third-party dirs are
  passed to hipcc as explicit `-isystem` entries in HIPCC_OPTIONS instead.
- `TORCH_INCLUDE_DIRS` / `NCCL_INCLUDE_DIRS` were previously added
  unconditionally inside `gpu_cpp_library()`; they are now members of
  `fbgemm_thirdparty_include_directories` and arrive via SYSTEM_INCLUDE_DIRS.
  All 22 `gpu_cpp_library()` call sites were updated accordingly.
- In-tree vendored GPU code (`cutlass_blackwell_fmha`) is classified as
  third-party so that upstream re-syncs stay clean.
- Both `BLOCK_PRINT` debug summaries now print SYSTEM_INCLUDE_DIRS. Since the
  OSS build cannot be built inside fbsource, this configure-time output is the
  only way to verify the split from a CI log.

No functional change: the same directories are searched, only their system-ness
changes.

Differential Revision: D115393659


