### PR TITLE
Move giant Zipf overflow repro out of CI

### DIFF
--- a/fbgemm_gpu/bench/zipf_large_n_benchmark.py
+++ b/fbgemm_gpu/bench/zipf_large_n_benchmark.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Manual large-grid overflow reproduction for ``fbgemm.zipf_cuda``."""
+
+import logging
+
+import click
+import fbgemm_gpu.sparse_ops  # noqa: F401
+import torch
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option("--alpha", default=1.5, show_default=True, type=float)
+@click.option("--n", default=(1 << 32) + 1, show_default=True, type=int)
+@click.option("--seed", default=0, show_default=True, type=int)
+def main(alpha: float, n: int, seed: int) -> None:
+    """Run the allocation-heavy grid-overflow reproduction once."""
+    if not torch.cuda.is_available():
+        raise RuntimeError("zipf_cuda requires a CUDA or ROCm accelerator")
+    if n <= 1 << 32:
+        raise ValueError("n must exceed 2**32 to reproduce the grid-overflow case")
+
+    logger.warning(
+        "Allocating an int64 output with %d elements (approximately %.1f GiB)",
+        n,
+        n * 8 / (1 << 30),
+    )
+    output = torch.ops.fbgemm.zipf_cuda(alpha, n, seed)
+
+    if output.shape != (n,) or output.dtype is not torch.int64:
+        raise RuntimeError(
+            f"unexpected output contract: shape={output.shape}, dtype={output.dtype}"
+        )
+
+    # Citrine C3: create sentinel indices directly on the output device.
+    indices = torch.tensor([0, n // 2, n - 1], device=output.device)
+    if not bool(torch.all(output[indices] >= 0)):
+        raise RuntimeError("zipf_cuda left a sampled output position uninitialized")
+
+    logger.info("Large-grid reproduction completed successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/fbgemm_gpu/test/sparse/cumsum_test.py
+++ b/fbgemm_gpu/test/sparse/cumsum_test.py
@@ -60,8 +60,11 @@ class CumSumTest(unittest.TestCase):
         ):
             return
 
+        # Citrine C3: create random input directly on the target device.
         # pyre-ignore-errors[16]
-        x = torch.randint(low=0, high=100, size=(n,)).type(pt_index_dtype).to(device)
+        x = torch.randint(low=0, high=100, size=(n,), device=device).type(
+            pt_index_dtype
+        )
         ze = torch.ops.fbgemm.asynchronous_exclusive_cumsum(x)
         zi = torch.ops.fbgemm.asynchronous_inclusive_cumsum(x)
         zc = torch.ops.fbgemm.asynchronous_complete_cumsum(x)
@@ -84,8 +87,11 @@ class CumSumTest(unittest.TestCase):
         )
 
         # meta tests
+        # Citrine C3: create random input directly on the meta device.
         # pyre-ignore-errors[16]
-        mx = torch.randint(low=0, high=100, size=(n,)).type(pt_index_dtype).to("meta")
+        mx = torch.randint(low=0, high=100, size=(n,), device="meta").type(
+            pt_index_dtype
+        )
 
         mze = torch.ops.fbgemm.asynchronous_exclusive_cumsum(mx)
         self.assertEqual(ze.size(), mze.size())
@@ -127,8 +133,11 @@ class CumSumTest(unittest.TestCase):
         ):
             return
 
+        # Citrine C3: create random input directly on the target device.
         # pyre-ignore-errors[16]
-        x = torch.randint(low=0, high=100, size=(b, n)).type(pt_index_dtype).to(device)
+        x = torch.randint(low=0, high=100, size=(b, n), device=device).type(
+            pt_index_dtype
+        )
 
         zc = torch.ops.fbgemm.asynchronous_complete_cumsum(x)
         zeros = torch.zeros(b, 1)
@@ -159,18 +168,17 @@ class CumSumTest(unittest.TestCase):
         dtype: torch.dtype,
         device: torch.device,
     ) -> None:
-        def cumsum_base(values: torch.Tensor) -> torch.Tensor:
-            out = [
-                torch.ops.fbgemm.asynchronous_complete_cumsum(values[i])
-                for i in range(values.shape[0])
-            ]
-            return torch.stack(out, dim=0)
-
         values = torch.randint(
             0, 1000, (batch_size, max_len), device=device, dtype=dtype
         )
         out = torch.ops.fbgemm.asynchronous_batched_complete_cumsum(values)
-        out2 = cumsum_base(values)
+        out2 = torch.cat(
+            [
+                torch.zeros_like(values[:, :1]),
+                torch.cumsum(values, dim=1, dtype=values.dtype),
+            ],
+            dim=1,
+        )
         torch.testing.assert_close(out, out2)
 
     @unittest.skipIf(*gpu_unavailable)

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -12,12 +12,7 @@
         "status": "xfail"
       }
     },
-    "fbgemm::asynchronous_batched_complete_cumsum": {
-      "CumSumTest.test_aot_dispatch_dynamic__test_batched_complete_cumsum": {
-        "comment": "Test builds output via a dynamic Python loop + torch.stack; incompatible with aot_dispatch_dynamic. Under aot_dispatch_dynamic it recompiles per example and exceeds the 600s tpx timeout (xfail does not catch a timeout), so skip. C++ symbolic meta is correct; eager + faketensor variants still cover the op. T191384137",
-        "status": "skip"
-      }
-    },
+    "fbgemm::asynchronous_batched_complete_cumsum": {},
     "fbgemm::asynchronous_complete_cumsum": {},
     "fbgemm::asynchronous_exclusive_cumsum": {},
     "fbgemm::asynchronous_inclusive_cumsum": {},

--- a/fbgemm_gpu/test/sparse/zipf_test.py
+++ b/fbgemm_gpu/test/sparse/zipf_test.py
@@ -17,98 +17,33 @@ from .common import extend_test_class, open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_memory_lt_gb, gpu_unavailable, optests
+    from test_utils import gpu_unavailable, optests
 else:
     import fbgemm_gpu.sparse_ops  # noqa: F401, E402
-    from fbgemm_gpu.test.test_utils import gpu_memory_lt_gb, gpu_unavailable, optests
+    from fbgemm_gpu.test.test_utils import gpu_unavailable, optests
 
 
 class ZipfTest(unittest.TestCase):
-    @unittest.skip(
-        "CUDA-only large-grid stress repro allocates ~32 GiB and exceeds the 600s "
-        "tpx timeout when it runs on a large-HBM GPU; it cannot run reliably in CI. "
-        "Kept in-tree as a manual repro. T191384137"
-    )
     @unittest.skipIf(*gpu_unavailable)
-    # Skip on GPUs with insufficient HBM. The test allocates int64[n] for
-    # n = 2**32 + 1 (~32 GiB), so it needs a large-HBM GPU. Gate at 64 GiB to
-    # avoid OOM/timeouts on 36-42 GiB CI GPUs (it only needs to run somewhere).
-    @unittest.skipIf(*gpu_memory_lt_gb(64))
-    # large-grid CUDA-only stress repro (allocates ~32 GiB); the generated
-    # opcheck variants add no op-schema coverage and only produce FAILURE/
-    # SKIPPING test-health records on CPU/small-GPU runs (T191384137).
     @optests.dontGenerateOpCheckTests(
-        "large-grid CUDA-only stress repro; opcheck variants add no coverage (T191384137)"
+        "zipf_cuda has no FakeTensor/meta dispatch; this test validates its CUDA "
+        "contract directly"
     )
-    def test_zipf_large_n_grid(self) -> None:
-        """
-        Reproduces the HIP grid-overflow bug in zipf_cuda and validates
-        the kernel's output via Tier-C structural invariants (no CPU
-        dispatch exists for ``zipf_cuda`` — the op is registered as a
-        single CUDA-only function pointer via ``DISPATCH_TO_ALL`` and a
-        Python reference cannot match the kernel's draws because the
-        kernel uses cuRAND with a per-thread sub-sequence stride).
+    def test_zipf_grid_stride_smoke(self) -> None:
+        n = 1024
+        output = torch.ops.fbgemm.zipf_cuda(1.5, n, 0)
 
-        With kMaxThreads=1024, the launch grid is
-        cuda_calc_xblock_count(n, 1024). For n > 2**32, total threads
-        exceed the HIP 2**32 limit, causing FBGEMM_LAUNCH_KERNEL ->
-        KernelLauncher::checkThreadCountNotExceeded to TORCH_CHECK-fail
-        on ROCm. zipf_kernel already grid-strides over the output index,
-        so the post-fix capped grid still covers all n elements.
+        self.assertEqual(output.shape, (n,))
+        self.assertEqual(output.dtype, torch.int64)
+        self.assertGreaterEqual(int(output.min().item()), 0)
+        self.assertTrue(torch.isfinite(output.to(torch.float64)).all().item())
 
-        Tier-C invariants checked: shape, dtype, plus an O(1) sentinel
-        check on the large output (start / middle / end positions are
-        non-negative). Heavier invariants (full non-negativity,
-        finiteness, seed-determinism, uniqueness) are validated at a
-        small scale to keep the opcheck-amplified cost bounded — each
-        opcheck variant (test_schema, test_faketensor,
-        test_aot_dispatch_dynamic) re-runs this test body, so any
-        full-scale reduction is multiplied 4×.
+        repeated_output = torch.ops.fbgemm.zipf_cuda(1.5, n, 0)
+        torch.testing.assert_close(output, repeated_output)
 
-        Note: This test allocates int64[n] (~32 GiB at the chosen n), so
-        it is skipped on GPUs without ~36 GiB of free HBM.
-        """
-
-        # Choose n so that total threads strictly exceeds 2**32:
-        # cuda_calc_xblock_count(n, 1024) * 1024 ~= n; need n > 2**32.
-        n = (1 << 32) + 1
-
-        # Large-scale invocation — trips the HIP grid cap pre-fix.
-        y = torch.ops.fbgemm.zipf_cuda(1.5, n, 0)
-
-        # Shape and dtype.
-        self.assertEqual(y.shape, (n,))
-        self.assertEqual(y.dtype, torch.int64)
-
-        # O(1) sentinel non-negativity check at start / middle / end.
-        # Avoids a full reduction over the 32 GiB tensor (which under
-        # opcheck would run 4× and dominate wall time).
-        sentinels = y[torch.tensor([0, n // 2, n - 1], device=y.device)]
-        self.assertTrue(torch.all(sentinels >= 0).item())
-
-        # Release the 32 GiB tensor before subsequent allocations.
-        del y
-
-        # Small-scale invariants — cheap under opcheck.
-        n_small = 1024
-        y_small = torch.ops.fbgemm.zipf_cuda(1.5, n_small, 0)
-
-        # Non-negativity (full reduction at small scale is free).
-        self.assertGreaterEqual(int(y_small.min().item()), 0)
-
-        # Finiteness: cast to float64 because ``isfinite`` on integer
-        # dtypes is not defined on all backends (notably ROCm).
-        self.assertTrue(torch.isfinite(y_small.to(torch.float64)).all().item())
-
-        # Seed-determinism: same seed must produce identical output.
-        y_small2 = torch.ops.fbgemm.zipf_cuda(1.5, n_small, 0)
-        torch.testing.assert_close(y_small, y_small2)
-
-        # Uniqueness sanity: the kernel must produce more than one
-        # distinct value at this scale.
-        unique_count = torch.unique(y_small).numel()
+        unique_count = torch.unique(output).numel()
         self.assertGreaterEqual(unique_count, 2)
-        self.assertLessEqual(unique_count, n_small)
+        self.assertLessEqual(unique_count, n)
 
 
 extend_test_class(ZipfTest)


### PR DESCRIPTION
Summary: Replace the permanently skipped 32 GiB `test_zipf_large_n_grid` leaf with a bounded CUDA correctness smoke test. Preserve the greater-than-`2**32` overflow reproduction as the manually invoked `zipf_large_n_benchmark` target so it no longer creates an unhealable OMH failure record.

Differential Revision: D115376129


