### PR TITLE
Bounds-assert permute index in permute_1D/2D_lengths_kernel (S683387)

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_1d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_1d.cu
@@ -12,15 +12,70 @@ using Tensor = at::Tensor;
 
 namespace fbgemm_gpu {
 
+// Launch permute_1D_lengths_kernel, picking the debug instantiation at runtime.
+// debug=false does not instantiate the bounds asserts at all, so the default
+// kernel carries no terminating path.
+#define FBGEMM_LAUNCH_PERMUTE_1D_LENGTHS(DEBUG, INDEX_T, PERMUTE_T, ...)       \
+  do {                                                                         \
+    if (DEBUG) {                                                               \
+      FBGEMM_LAUNCH_KERNEL(                                                    \
+          (permute_1D_lengths_kernel<INDEX_T, PERMUTE_T, true>), __VA_ARGS__); \
+    } else {                                                                   \
+      FBGEMM_LAUNCH_KERNEL(                                                    \
+          (permute_1D_lengths_kernel<INDEX_T, PERMUTE_T, false>),              \
+          __VA_ARGS__);                                                        \
+    }                                                                          \
+  } while (0)
+
 // Kernel for permuting 1D lengths. Used for permutation of sparse features.
-template <typename index_t, typename permute_t = int32_t>
+//
+// The bounds checks are compiled in only for debug=true (selected at launch
+// from FBGEMM_DEBUG_PERMUTE): a terminating failure path costs on the healthy
+// path even when it never fires, so the default instantiation carries no check.
+// See permute_2D_data_kernel_vec for the measurement.
+template <typename index_t, typename permute_t = int32_t, bool debug = false>
 __global__ __launch_bounds__(kMaxThreads) void permute_1D_lengths_kernel(
     const index_t* __restrict__ lengths,
     int32_t permuted_lengths_size,
     const permute_t* __restrict__ permute,
+    int64_t lengths_size,
+    int64_t indices_size,
     index_t* __restrict__ permuted_lengths) {
   CUDA_KERNEL_LOOP(i, permuted_lengths_size) {
-    permuted_lengths[i] = lengths[permute[i]];
+    const auto permute_idx = permute[i];
+    if constexpr (debug) {
+      // An out-of-range permute index makes lengths[permute[i]] read out of
+      // bounds and silently poisons permuted_lengths; the corruption only
+      // surfaces much later as a non-deterministic CUDA illegal memory access
+      // in the data kernel. Asserting at the read site localizes the fault to
+      // its true origin.
+      CUDA_KERNEL_ASSERT_PRINTF(
+          permute_idx >= 0 && static_cast<int64_t>(permute_idx) < lengths_size,
+          "permute_1D_lengths_kernel: permute index out of bounds "
+          "(i=%d, permute[i]=%lld, lengths_size=%lld)",
+          i,
+          static_cast<long long>(permute_idx),
+          static_cast<long long>(lengths_size));
+    }
+    const index_t length = lengths[permute_idx];
+    if constexpr (debug) {
+      // A corrupt length *value* even when the index is in range: a valid
+      // per-feature length is in [0, indices_size], since one feature cannot
+      // own more elements than the total input indices. Out of that range means
+      // the lengths contents were poisoned (e.g. a concurrent write/free),
+      // which otherwise surfaces only as a garbage output_offsets sum. Firing
+      // here rather than the index assert distinguishes the two causes.
+      CUDA_KERNEL_ASSERT_PRINTF(
+          static_cast<int64_t>(length) >= 0 &&
+              static_cast<int64_t>(length) <= indices_size,
+          "permute_1D_lengths_kernel: length value out of range "
+          "(i=%d, permute[i]=%lld, length=%lld, indices_size=%lld)",
+          i,
+          static_cast<long long>(permute_idx),
+          static_cast<long long>(length),
+          static_cast<long long>(indices_size));
+    }
+    permuted_lengths[i] = length;
   }
 }
 
@@ -259,13 +314,16 @@ permute_1D_sparse_data_cuda(
   // See: https://github.com/ROCm/hip/issues/2253
   const auto blocks_1 = utils::cuda::cap_grid_dim_x_from_workload(
       permuted_lengths_size, threads_1, at::cuda::getCurrentCUDAStream());
+  const bool debug_permute = is_debug_permute_enabled();
   AT_DISPATCH_INDEX_TYPES(
       permute.scalar_type(), "permute_1D_lengths_permute_type", [&] {
         using permute_t = index_t;
         AT_DISPATCH_INDEX_TYPES(
             lengths.scalar_type(), "permute_1D_lengths_kernel", [&] {
-              FBGEMM_LAUNCH_KERNEL(
-                  (permute_1D_lengths_kernel<index_t, permute_t>),
+              FBGEMM_LAUNCH_PERMUTE_1D_LENGTHS(
+                  debug_permute,
+                  index_t,
+                  permute_t,
                   blocks_1,
                   threads_1,
                   0,
@@ -273,6 +331,8 @@ permute_1D_sparse_data_cuda(
                   lengths_contig.data_ptr<index_t>(),
                   permuted_lengths_size,
                   permute_contig.data_ptr<permute_t>(),
+                  lengths_size,
+                  indices_contig.numel(),
                   permuted_lengths.data_ptr<index_t>());
             });
       });
@@ -411,6 +471,8 @@ permute_1D_sparse_data_cuda(
 
   return {permuted_lengths, permuted_indices, permuted_weights};
 }
+
+#undef FBGEMM_LAUNCH_PERMUTE_1D_LENGTHS
 
 } // namespace fbgemm_gpu
 

--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
@@ -234,18 +234,74 @@ __global__ __launch_bounds__(kMaxThreads) void permute_2D_data_kernel_vec(
   }
 }
 
+// Launch permute_2D_lengths_kernel, picking the debug instantiation at runtime.
+// See FBGEMM_LAUNCH_PERMUTE_1D_LENGTHS in sparse_permute_1d.cu.
+#define FBGEMM_LAUNCH_PERMUTE_2D_LENGTHS(DEBUG, INDEX_T, ...)        \
+  do {                                                               \
+    if (DEBUG) {                                                     \
+      FBGEMM_LAUNCH_KERNEL(                                          \
+          (permute_2D_lengths_kernel<INDEX_T, true>), __VA_ARGS__);  \
+    } else {                                                         \
+      FBGEMM_LAUNCH_KERNEL(                                          \
+          (permute_2D_lengths_kernel<INDEX_T, false>), __VA_ARGS__); \
+    }                                                                \
+  } while (0)
+
 // Kernel for permuting the lengths. Used for permutation of sparse features.
-template <typename index_t>
+//
+// The bounds checks are compiled in only for debug=true (selected at launch
+// from FBGEMM_DEBUG_PERMUTE); see permute_1D_lengths_kernel.
+template <typename index_t, bool debug = false>
 __global__ __launch_bounds__(kMaxThreads) void permute_2D_lengths_kernel(
     int32_t T,
     int32_t B,
     const index_t* __restrict__ lengths,
     const int32_t* __restrict__ permute,
+    int64_t lengths_size,
+    int64_t indices_size,
     index_t* __restrict__ permuted_lengths) {
   CUDA_KERNEL_LOOP(b_t, B * T) {
     int32_t b = b_t % B;
     int32_t t = b_t / B;
-    permuted_lengths[b_t] = lengths[permute[t] * B + b];
+    const int64_t input_idx = static_cast<int64_t>(permute[t]) * B + b;
+    if constexpr (debug) {
+      // An out-of-range permute index makes lengths[permute[t] * B + b] read
+      // out of bounds and poisons permuted_lengths with garbage that only
+      // surfaces later as a non-deterministic CUDA illegal memory access.
+      // Asserting here localizes the fault to its origin.
+      CUDA_KERNEL_ASSERT_PRINTF(
+          input_idx >= 0 && input_idx < lengths_size,
+          "permute_2D_lengths_kernel: input index out of bounds "
+          "(b_t=%d, t=%d, b=%d, permute[t]=%d, input_idx=%lld, "
+          "lengths_size=%lld)",
+          b_t,
+          t,
+          b,
+          permute[t],
+          static_cast<long long>(input_idx),
+          static_cast<long long>(lengths_size));
+    }
+    const index_t length = lengths[input_idx];
+    if constexpr (debug) {
+      // A corrupt length *value* even when the index is in range: a valid
+      // per-(feature, batch) length is in [0, indices_size]. Out of that range
+      // means the lengths contents were poisoned (e.g. a concurrent
+      // write/free), which otherwise surfaces only as a garbage output_offsets
+      // sum. Firing here rather than the index assert distinguishes the two.
+      CUDA_KERNEL_ASSERT_PRINTF(
+          static_cast<int64_t>(length) >= 0 &&
+              static_cast<int64_t>(length) <= indices_size,
+          "permute_2D_lengths_kernel: length value out of range "
+          "(b_t=%d, t=%d, b=%d, input_idx=%lld, length=%lld, "
+          "indices_size=%lld)",
+          b_t,
+          t,
+          b,
+          static_cast<long long>(input_idx),
+          static_cast<long long>(length),
+          static_cast<long long>(indices_size));
+    }
+    permuted_lengths[b_t] = length;
   }
 }
 
@@ -280,6 +336,8 @@ permute_2D_sparse_preallocated_out_cuda(
   TORCH_CHECK(lengths.dim() == 2);
 
   CUDA_DEVICE_GUARD(indices);
+
+  const bool debug_permute = is_debug_permute_enabled();
 
   const auto permute_contig = permute.contiguous();
   const auto lengths_contig = lengths.contiguous();
@@ -338,8 +396,9 @@ permute_2D_sparse_preallocated_out_cuda(
       B * T, threads_1, at::cuda::getCurrentCUDAStream());
   AT_DISPATCH_INDEX_TYPES(
       lengths.scalar_type(), "permute_2D_lengths_kernel", [&] {
-        FBGEMM_LAUNCH_KERNEL(
-            (permute_2D_lengths_kernel<index_t>),
+        FBGEMM_LAUNCH_PERMUTE_2D_LENGTHS(
+            debug_permute,
+            index_t,
             blocks_1,
             threads_1,
             0,
@@ -348,6 +407,8 @@ permute_2D_sparse_preallocated_out_cuda(
             B,
             lengths_contig.data_ptr<index_t>(),
             permute_contig.data_ptr<int32_t>(),
+            lengths_contig.numel(),
+            indices_contig.numel(),
             permuted_lengths.data_ptr<index_t>());
       });
 
@@ -357,8 +418,6 @@ permute_2D_sparse_preallocated_out_cuda(
   }
 
   // convert lengths to offsets
-  const bool debug_permute = is_debug_permute_enabled();
-
   const auto input_offsets = asynchronous_exclusive_cumsum_gpu(lengths_contig);
   const auto output_offsets =
       asynchronous_complete_cumsum_gpu(permuted_lengths.flatten());
@@ -517,6 +576,7 @@ permute_2D_sparse_preallocated_out_cuda(
 }
 
 #undef FBGEMM_LAUNCH_PERMUTE_2D
+#undef FBGEMM_LAUNCH_PERMUTE_2D_LENGTHS
 
 // Functional (allocating) entry point. Delegates to the shared implementation
 // with no pre-allocated output buffers.
@@ -638,6 +698,8 @@ permute_sparse_features_cuda(
             B,
             lengths_contig.data_ptr<index_t>(),
             permute.data_ptr<int32_t>(),
+            lengths_contig.numel(),
+            indices_contig.numel(),
             permuted_lengths.data_ptr<index_t>());
       });
 


### PR DESCRIPTION
Summary:
Add device-side bounds asserts to the CUDA sparse permute lengths kernels
(permute_1D_lengths_kernel and permute_2D_lengths_kernel) to localize the
source of the non-deterministic CUDA illegal memory access in S683387.

Background: the DSA/host guards on the data path (D112586847 for 2D, D113797969
for 1D) fire on an already-poisoned output_offsets whose sum is a garbage int64
(e.g. 0x52573E0A1E4D7555 ~= 5.9e18) vs a legit caller hint (~76054). That sum is
sum(permuted_lengths), so permuted_lengths is corrupt before the data kernel
runs. permuted_lengths[i] = lengths[permute[i]], so the corruption is either the
permute index or the length value.

This diff adds two asserts at that read site:
1. Index guard: 0 <= permute[i] < lengths_size (permute[t]*B + b < lengths_size
   for 2D).
2. Value guard: 0 <= lengths[permute[i]] <= indices_size. A single segment
   cannot own more elements than the total number of input indices, so a value
   outside this range (in particular the 5.9e18 garbage) is definitively a
   poisoned length value even when the index is in range.

Together they disambiguate the root cause:
- Index assert fires  -> out-of-range permute tensor.
- Value assert fires  -> lengths *contents* corrupt at read time (e.g. a
  concurrent write/free of the lengths buffer).
- Neither fires but the data-path/host guard still fires -> permuted_lengths was
  clobbered *after* our kernel wrote it (cross-stream output-buffer race).

Empirical result so far (repro with the index guard + D113808890's int32
overflow guards): neither the index guard nor the overflow guards fired, yet the
original data-path DSA still did, and CUDA_LAUNCH_BLOCKING makes it disappear.
That rules out an out-of-range permute index and int32 size overflow and points
at a memory race on tensor contents. The value guard added here is the next
probe to split 'corrupt lengths input' from 'clobbered permuted_lengths output'.

This is a debug backstop to localize the fault, not the caller-side forward fix.
All guards are additive; valid in-range inputs are unaffected.

Differential Revision: D113803946


