### PR TITLE
Treat asmjit and cpuinfo headers as system headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,6 +450,10 @@ if(NOT TARGET asmjit)
   endif()
 endif()
 
+# asmjit is third-party code we do not modify; treat its headers as system
+# headers so its diagnostics do not surface in FBGEMM targets.
+fbgemm_mark_target_includes_system(asmjit)
+
 ################################################################################
 # Cpuinfo Target
 ################################################################################
@@ -469,6 +473,10 @@ if(NOT TARGET cpuinfo)
   add_subdirectory("${CPUINFO_SOURCE_DIR}" "${FBGEMM_BINARY_DIR}/cpuinfo")
   set_property(TARGET cpuinfo PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
+
+# cpuinfo is third-party code we do not modify; treat its headers as system
+# headers so its diagnostics do not surface in FBGEMM targets.
+fbgemm_mark_target_includes_system(cpuinfo)
 
 ################################################################################
 # Optional Targets

--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -91,7 +91,8 @@ function(cpp_library)
         CC_FLAGS        # General compilation flags applicable to all build variants
         MSVC_FLAGS      # Compilation flags specific to MSVC
         DEFINITIONS     # Preprocessor definitions
-        INCLUDE_DIRS    # Include directories for compilation
+        INCLUDE_DIRS    # First-party include directories for compilation
+        SYSTEM_INCLUDE_DIRS # Third-party include directories, passed as SYSTEM to suppress their warnings
         DEPS            # Target dependencies, i.e. built STATIC targets
     )
 
@@ -177,6 +178,11 @@ function(cpp_library)
     target_include_directories(${lib_name} PUBLIC
         ${args_INCLUDE_DIRS})
 
+    # Third-party include directories are marked SYSTEM so their diagnostics do
+    # not surface in this target.
+    target_include_directories(${lib_name} SYSTEM PUBLIC
+        ${args_SYSTEM_INCLUDE_DIRS})
+
     # Link against the external libraries as needed
     target_link_libraries(${lib_name} PUBLIC ${args_DEPS})
 
@@ -256,6 +262,9 @@ function(cpp_library)
         " "
         "INCLUDE_DIRS:"
         "${args_INCLUDE_DIRS}"
+        " "
+        "SYSTEM_INCLUDE_DIRS:"
+        "${args_SYSTEM_INCLUDE_DIRS}"
         " "
         "Library Dependencies:"
         "${args_DEPS}"

--- a/cmake/modules/GpuCppLibrary.cmake
+++ b/cmake/modules/GpuCppLibrary.cmake
@@ -168,7 +168,8 @@ function(gpu_cpp_library)
         CC_FLAGS            # General compilation flags applicable to all build variants
         NVCC_FLAGS          # Compilation flags specific to NVCC
         HIPCC_FLAGS         # Compilation flags specific to HIPCC
-        INCLUDE_DIRS        # Include directories for compilation
+        INCLUDE_DIRS        # First-party include directories for compilation
+        SYSTEM_INCLUDE_DIRS # Third-party include directories, passed as SYSTEM to suppress their warnings
         DEPS                # Target dependencies, i.e. built STATIC targets
         TORCH_LIBS          # PyTorch libraries to link against. Note that we provide the TORCH_LIBS automatically - this is for PyTorch build.
     )
@@ -184,6 +185,12 @@ function(gpu_cpp_library)
 
     # Take all the sources, and filter them into CPU and GPU buckets depending
     # on the source type and build mode
+    # NOTE: Only first-party include dirs are set as source file properties here.
+    # Third-party dirs are attached at the target level as SYSTEM includes; see
+    # gpu_cpp_library() below.  They must NOT also appear as plain `-I` entries:
+    # clang de-duplicates header search paths keeping the first occurrence, so a
+    # directory listed under both `-I` and `-isystem` stays non-system and its
+    # warnings are NOT suppressed.
     prepare_target_sources(
         PREFIX ${args_PREFIX}
         CPU_SRCS ${args_CPU_SRCS}
@@ -233,20 +240,37 @@ function(gpu_cpp_library)
                 HIP_SOURCE_PROPERTY_FORMAT 1)
         endif()
 
-        # Set the include directories for HIP
+        # Set the include directories for HIP.  First-party only: the legacy
+        # FindHIP `hip_include_directories()` has no SYSTEM variant and emits
+        # plain `-I`, so third-party dirs are passed separately as `-isystem`
+        # entries in HIPCC_OPTIONS below.
         hip_include_directories("${args_INCLUDE_DIRS}")
+
+        # Build `-isystem` flags for the third-party include dirs.  hipcc is
+        # clang, and clang de-duplicates header search paths keeping the first
+        # occurrence, so these directories must appear ONLY here and never in
+        # `hip_include_directories()` -- otherwise the `-I` entry wins and the
+        # directory is not treated as a system header path.
+        set(lib_hipcc_system_includes "")
+        foreach(include_dir IN LISTS args_SYSTEM_INCLUDE_DIRS)
+            list(APPEND lib_hipcc_system_includes "-isystem${include_dir}")
+        endforeach()
 
         # Create the HIP library
         hip_add_library(${lib_name} ${args_TYPE}
             ${lib_sources_hipified}
             ${args_OTHER_SRCS}
             ${FBGEMM_HIP_HCC_LIBRARIES}
-            HIPCC_OPTIONS ${HIP_HCC_FLAGS} ${args_HIPCC_FLAGS})
+            HIPCC_OPTIONS ${HIP_HCC_FLAGS} ${lib_hipcc_system_includes} ${args_HIPCC_FLAGS})
 
         # Append ROCM includes
         target_include_directories(${lib_name} PUBLIC
-            ${FBGEMM_HIP_INCLUDE}
             ${args_INCLUDE_DIRS})
+
+        # ROCm toolchain and third-party headers are system headers
+        target_include_directories(${lib_name} SYSTEM PUBLIC
+            ${FBGEMM_HIP_INCLUDE}
+            ${args_SYSTEM_INCLUDE_DIRS})
 
     else()
         # Create the CPU-only / CUDA library
@@ -289,10 +313,11 @@ function(gpu_cpp_library)
     # Library Includes and Linking
     ############################################################################
 
-    # Add external include directories
-    target_include_directories(${lib_name} PRIVATE
-        ${TORCH_INCLUDE_DIRS}
-        ${NCCL_INCLUDE_DIRS})
+    # Add external include directories.  These are third-party (PyTorch, NCCL,
+    # CUTLASS, CK, asmjit, ...) and are marked SYSTEM so their diagnostics do not
+    # surface in FBGEMM targets that consume them.
+    target_include_directories(${lib_name} SYSTEM PRIVATE
+        ${args_SYSTEM_INCLUDE_DIRS})
 
     # Set additional target properties
     if(NOT args_KEEP_PREFIX)
@@ -427,6 +452,9 @@ function(gpu_cpp_library)
         " "
         "INCLUDE_DIRS:"
         "${args_INCLUDE_DIRS}"
+        " "
+        "SYSTEM_INCLUDE_DIRS:"
+        "${args_SYSTEM_INCLUDE_DIRS}"
         " "
         "Selected Source Files:"
         "${lib_sources}"

--- a/cmake/modules/Utilities.cmake
+++ b/cmake/modules/Utilities.cmake
@@ -23,6 +23,29 @@ macro(handle_genfiles variable)
   list(TRANSFORM ${variable} PREPEND "${CMAKE_BINARY_DIR}/")
 endmacro()
 
+# Re-export a third-party target's public include directories as SYSTEM
+# includes, so that warnings originating inside its headers are suppressed in
+# every target that consumes it.
+#
+# This is needed for dependencies pulled in via `add_subdirectory()` (asmjit,
+# cpuinfo), whose INTERFACE_INCLUDE_DIRECTORIES propagate as plain `-I` and
+# therefore leak their diagnostics into FBGEMM targets.  We cannot fix those
+# projects, so we mark their headers system instead of blanket-disabling the
+# warning for our own code as well.
+function(fbgemm_mark_target_includes_system target_name)
+  if(NOT TARGET ${target_name})
+    return()
+  endif()
+
+  get_target_property(_includes ${target_name} INTERFACE_INCLUDE_DIRECTORIES)
+  # The property is `<name>-NOTFOUND` when unset; passing that through produces
+  # a confusing configure-time error.
+  if(_includes)
+    set_target_properties(${target_name} PROPERTIES
+      INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_includes}")
+  endif()
+endfunction()
+
 macro(handle_genfiles_rocm variable)
   if(FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM)
     handle_genfiles(${variable})

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -141,13 +141,24 @@ endif()
 # Source Includes
 ################################################################################
 
+# First-party include directories.  Warnings MUST apply to code found here.
 set(fbgemm_sources_include_directories
   # FBGEMM
   ${FBGEMM}/include
   # FBGEMM_GPU
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/../include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+
+# Third-party include directories.  These are passed to targets as SYSTEM
+# includes (`-isystem`) so that diagnostics originating inside them are
+# suppressed wholesale.  Without this, enabling a high-volume warning flag
+# produces a wall of unfixable third-party output, and the natural response is a
+# blanket `-Wno-*` that also disables the flag for our own code.
+#
+# Do NOT add first-party paths to this list: doing so silently disables all
+# warnings for that code.
+set(fbgemm_thirdparty_include_directories
   # PyTorch
   ${TORCH_INCLUDE_DIRS}
   # Third-party

--- a/fbgemm_gpu/FbgemmGpu.cmake
+++ b/fbgemm_gpu/FbgemmGpu.cmake
@@ -148,6 +148,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     src/embedding_inplace_ops/embedding_inplace_update_cpu.cpp
   GPU_SRCS
@@ -190,6 +192,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${fbgemm_gpu_sources_cpu_static}
   GPU_SRCS

--- a/fbgemm_gpu/cmake/Asmjit.cmake
+++ b/fbgemm_gpu/cmake/Asmjit.cmake
@@ -23,6 +23,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   OTHER_SRCS
     ${asmjit_sources}
   DESTINATION

--- a/fbgemm_gpu/cmake/Fbgemm.cmake
+++ b/fbgemm_gpu/cmake/Fbgemm.cmake
@@ -74,6 +74,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   OTHER_SRCS
     ${fbgemm_sources}
   DEPS

--- a/fbgemm_gpu/cmake/TbeInference.cmake
+++ b/fbgemm_gpu/cmake/TbeInference.cmake
@@ -16,6 +16,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${FBGEMM_GPU}/src/split_embeddings_cache/lfu_cache_populate_byte.cpp
     ${FBGEMM_GPU}/src/split_embeddings_cache/linearize_cache_indices.cpp
@@ -58,6 +60,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${static_cpu_files_inference}
     ${gen_cpu_files_inference}

--- a/fbgemm_gpu/cmake/TbeTraining.cmake
+++ b/fbgemm_gpu/cmake/TbeTraining.cmake
@@ -73,6 +73,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     src/config/feature_gates.cpp
     src/config/feature_gates_torch_op.cpp
@@ -86,6 +88,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     src/split_embeddings_utils/split_embeddings_utils_cpu.cpp
     src/split_embeddings_utils/split_embeddings_utils_meta.cpp
@@ -105,6 +109,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     src/sparse_ops/sparse_async_cumsum.cpp
   GPU_SRCS
@@ -121,6 +127,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${static_cpu_files_common}
   GPU_SRCS
@@ -140,6 +148,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   GPU_SRCS
     ${gen_defused_optim_src_files}
   NVCC_FLAGS
@@ -154,6 +164,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${gen_cpu_files_forward_split}
   GPU_SRCS
@@ -172,6 +184,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${gen_cpu_files_training_pt2}
   GPU_SRCS
@@ -195,6 +209,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${static_cpu_files_training}
     ${gen_cpu_files_training}
@@ -221,6 +237,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   GPU_SRCS
     ${gen_gpu_files_training_gwd}
   NVCC_FLAGS
@@ -237,6 +255,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   GPU_SRCS
     ${gen_gpu_files_training_vbe}
   NVCC_FLAGS
@@ -253,6 +273,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   GPU_SRCS
     ${gen_gpu_files_training_dense}
   NVCC_FLAGS
@@ -270,6 +292,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   GPU_SRCS
     ${gen_gpu_files_training_split_host}
   NVCC_FLAGS
@@ -287,6 +311,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${static_cpu_files_index_select}
   GPU_SRCS

--- a/fbgemm_gpu/experimental/example/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/example/CMakeLists.txt
@@ -35,6 +35,8 @@ gpu_cpp_library(
     SHARED
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   GPU_SRCS
     ${experimental_example_cpp_source_files})
 

--- a/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
@@ -137,12 +137,18 @@ gpu_cpp_library(
     ${KEEP_PREFIX}
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/attention/cuda/cutlass_blackwell_fmha
     ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize
     ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize/include
     ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize/common/include
     ${CMAKE_CURRENT_SOURCE_DIR}/src/kv_cache
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
+    # Vendored upstream CUTLASS example code -- treated as third-party so that
+    # upstream re-syncs stay clean.
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/attention/cuda/cutlass_blackwell_fmha
+    # Injected externally when building as part of PyTorch; points at
+    # PyTorch-side paths.
     ${FBGEMM_GENAI_INCLUDE_DIRS}
   CPU_SRCS
     ${experimental_gen_ai_cpp_source_files_cpu}

--- a/fbgemm_gpu/experimental/hstu/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/hstu/CMakeLists.txt
@@ -158,6 +158,8 @@ gpu_cpp_library(
     ${fbgemm_sources_include_directories}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/hstu_ampere
     ${CMAKE_CURRENT_SOURCE_DIR}/src/hstu_hopper
+  SYSTEM_INCLUDE_DIRS
+    ${fbgemm_thirdparty_include_directories}
   CPU_SRCS
     ${hstu_cpp_source_files}
   GPU_SRCS


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3031

Prerequisite for the compiler warning flag rollout (T169200065). Follow-up to
the previous diff, which handled FBGEMM_GPU; this one covers the CPU FBGEMM
library.

asmjit and cpuinfo are brought in via `add_subdirectory()`, and their headers
reach FBGEMM targets through `INTERFACE_INCLUDE_DIRECTORIES`, which propagates
as plain `-I`. That means any warning flag we enable also reports diagnostics
from inside those two projects, which we do not own and cannot fix.

Adds `fbgemm_mark_target_includes_system()` to Utilities.cmake, which copies a
target's `INTERFACE_INCLUDE_DIRECTORIES` into
`INTERFACE_SYSTEM_INCLUDE_DIRECTORIES` so consumers receive `-isystem` instead.
Applied to asmjit and cpuinfo.

The helper is a no-op when the target does not exist (so it is safe when the
target is supplied externally, e.g. by the PyTorch build) and when the target
has no interface includes -- the property reads back as `<name>-NOTFOUND`, and
passing that through would produce a confusing configure error.

The calls are placed outside the `if(NOT TARGET ...)` guards on purpose, so the
headers are marked system whether the target was built here or provided by a
parent project.

Note: the existing `target_compile_options(asmjit PRIVATE /wd5054)` is
deliberately left alone -- it applies when compiling asmjit's own sources, not
when consuming its headers.

Differential Revision: D115393660


