### PR TITLE
Reduce TBE backward arg count — pack weights + aux tensors into TensorLists (#6132)

### DIFF
--- a/fbgemm_gpu/codegen/genscript/generate_backward_split.py
+++ b/fbgemm_gpu/codegen/genscript/generate_backward_split.py
@@ -417,7 +417,7 @@ class BackwardSplitGenerator:
             "actions_count",
         ]
 
-        aux_names = ["aux_tensor", "aux_int", "aux_float", "aux_bool"]
+        aux_names = ["aux_tensor", "aux_tensor_bwd", "aux_int", "aux_float", "aux_bool"]
         # This is a dict of auxilary arguments used in TBE PT2 interface where the aux
         # arguments of a type are packed into a list for that type. This dict maintains the
         # order of the arguments of each type.
@@ -430,6 +430,16 @@ class BackwardSplitGenerator:
                 "uvm_cache_stats",  # 4
                 "prev_iter_dev",  # 5
                 "vbe_output_offsets",  # 6
+            ],
+            # Slot 0 is always packed; slots 1-4 are VBE-only. The `bwd_` prefix is
+            # required: these enumerators share namespace fbgemm_gpu with the
+            # forward `aux_tensor` ones above.
+            "aux_tensor_bwd": [
+                "bwd_lxu_cache_locations",  # 0 (ssd_row_addrs for SSD)
+                "bwd_B_offsets",  # 1
+                "bwd_vbe_row_output_offsets",  # 2
+                "bwd_vbe_b_t_map",  # 3
+                "bwd_vbe_B_offsets_rank_per_feature",  # 4
             ],
             "aux_int": [
                 "iter",  # 0

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -229,12 +229,11 @@ enum SSDTensor {
             .findSchemaOrThrow("fbgemm::{{ backward_op }}", "")
             .typed<Tensor(
                 const Tensor& /*grad_output*/,
-                const Tensor& /*weights_host*/,
-                const Tensor& /*weights_dev*/,
-                const Tensor& /*weights_uvm*/,
-                const Tensor& /*lxu_cache_weight*/,
-                const Tensor& /*weights_placements*/,
-                const Tensor& /*weights_offsets*/,
+                {%- if dense %}
+                const Tensor& /*dev_weights*/,
+                {%- else %}
+                const at::TensorList /*weights*/,
+                {%- endif %}
                 {%- if nobag %}
                 const c10::SymInt /*D*/,
                 {%- else %}
@@ -250,27 +249,25 @@ enum SSDTensor {
                 const int64_t /*pooling_mode*/,
                 const Tensor& /*indice_weights*/, // currently supports no bag with unweighted
                 {%- endif %}
-                {%- if ssd %}
-                const Tensor& /*ssd_row_addrs*/,
-                {%- else %}
-                const Tensor& /*lxu_cache_locations*/,
+                {%- if not dense %}
+                const at::TensorList /*aux_tensor_bwd*/,
                 {%- endif %}
                 const int64_t /*BT_block_size*/,
                 const int64_t /*max_segment_length_per_warp*/,
+                {%- if not dense %}
                 {%- if optimizer != "none" %}
                 const bool /*stochastic_rounding*/,
                 {%- endif %}
                 const int64_t /*info_B_num_bits*/,
                 const int64_t /*info_B_mask_int64*/,
+                {%- endif %}
                 {%- if vbe %}
-                const Tensor& /*B_offsets*/,
-                const Tensor& /*vbe_row_output_offsets*/,
-                const Tensor& /*vbe_b_t_map*/,
-                const Tensor& /*vbe_B_offsets_rank_per_feature*/, // for reshaping vbe cpu offsets and grad output
                 const c10::SymInt /*max_B*/, // for reshaping vbe cpu offsets
                 {%- endif %}
+                {%- if not dense %}
                 const bool /*use_uniq_cache_locations_bwd*/,
                 const bool /*use_homogeneous_placements*/,
+                {%- endif %}
                 {%- if ssd %}
                 const bool /*enable_optimizer_offloading*/,
                 {%- endif %}
@@ -283,25 +280,51 @@ enum SSDTensor {
                 {%- endif %}
                 const double /*gwd_lower_bound*/,
                 {%- endif %} {# /* if is_gwd */ #}
+                {%- if dense %}
+                const int64_t /*unused*/
+                {%- else %}
                 {%- for arg_type in args_pt2.split_function_args %}
                 {{ arg_type.split(' ')[0]}}{%- if not loop.last %}{{ "," }}{%- endif %}
                 {%- endfor %}
+                {%- endif %}
                 {%- if not nobag %}
                 , const int64_t /*output_dtype*/
                 {%- endif %}
             )>();
 
+    {%- if not dense %}
+    // Mirrors the `weights` layout unpack_tensorlist() consumes in forward.
+    // MTIA-with-UVM takes the 5-slot layout but puts host_weights in slot 0.
+    const bool use_cpu_weights_layout = !weights_dev.defined() &&
+        !weights_uvm.defined() && !weights_lxu_cache.defined();
+    TORCH_CHECK(
+        !use_cpu_weights_layout || weights_host.defined(),
+        "weights_host must be defined when none of weights_dev/weights_uvm/weights_lxu_cache are");
+    const std::vector<Tensor> weights = use_cpu_weights_layout
+        ? std::vector<Tensor>{weights_host, weights_placements, weights_offsets}
+        : std::vector<Tensor>{
+            weights_dev.defined() ? weights_dev : weights_host, // CUDA, or MTIA with UVM
+            weights_placements,
+            weights_offsets,
+            weights_uvm,
+            weights_lxu_cache};
+    // Owned std::vector -- a TensorList over the brace temporary would dangle.
+    const std::vector<Tensor> aux_tensor_bwd = {
+        {{ "ssd_row_addrs" if ssd else "lxu_cache_locations" }}
+        {%- if vbe %}
+        , B_offsets,
+        vbe_row_output_offsets,
+        vbe_b_t_map,
+        vbe_B_offsets_rank_per_feature
+        {%- endif %}
+    };
+    {%- endif %}
     grad_weights_dev = embedding_codegen{{ wdesc }}_backward_op.call(
           grad_output,
           {% if dense %}
           dev_weights,
           {% else %}
-          weights_host,
-          weights_dev,
-          weights_uvm,
-          weights_lxu_cache,
-          weights_placements,
-          weights_offsets,
+          weights,
           {% endif %}
           {% if nobag %}
           D,
@@ -318,10 +341,8 @@ enum SSDTensor {
           pooling_mode,
           indice_weights,
           {%- endif %} {# /* if not nobag */ #}
-          {%- if ssd %}
-          ssd_row_addrs,
-          {%- elif not dense %}
-          lxu_cache_locations,
+          {%- if not dense %}
+          aux_tensor_bwd,
           {%- endif %}
           BT_block_size,
           max_segment_length_per_warp,
@@ -333,10 +354,6 @@ enum SSDTensor {
           info_B_mask_int64,
           {%- endif %} {# /* if not dense */ #}
           {%- if vbe %}
-          B_offsets,
-          vbe_row_output_offsets,
-          vbe_b_t_map,
-          vbe_B_offsets_rank_per_feature, // for reshaping vbe cpu offsets and grad output
           max_B, // for reshaping vbe cpu offsets
           {%- endif %} {# /* if vbe */ #}
           {%- if not dense %}
@@ -566,21 +583,51 @@ enum SSDTensor {
 
 /* This macro generates a code blob for creating tensor that is unpacked from list of optional tensors*/
 {%- macro get_optional_optim_tensor(name, suffix, idx, options) %}
-  auto {{ name }}_{{ suffix }} = GET_OPTIONAL_TENSOR_VALUE(optim_tensor[{{ idx }}], at::empty({0}, {{ options }}));
+  {{ name }}_{{ suffix }} = GET_OPTIONAL_TENSOR_VALUE(optim_tensor[{{ idx }}], at::empty({0}, {{ options }}));
+{%- endmacro %}
+
+/* This macro sets a dummy (empty) tensor. Used for backward compatibility when the
+   frontend package does not supply the optional optimizer tensors (see below). */
+{%- macro set_dummy_tensor(name, suffix, options) %}
+  {{ name }}_{{ suffix }} = at::empty({0}, {{ options }});
 {%- endmacro %}
 
 /* This macro generates a code blob for unpacking a list of optional tensors
     We cannot do list of optional tensorlist. We need to pack optimizer optional tensors in a flatten manner.
     For readability and programmability, we pass all unified args (i.e., 5 items), as opposed to passing per device (like above)
     which needs to be determined at runtime.
+    The 5 tensors are declared up front (so they stay in scope for the backward op
+    call below) and assigned conditionally: when the frontend supplies this optimizer's
+    optional tensors we unpack them, otherwise we fall back to dummy empty tensors for
+    backward compatibility with old frontend packages that predate these args.
 */
 {%- macro unpack_tensorlist_optional(name, arg_index) %}
+  at::Tensor {{ name }}_host, {{ name }}_dev, {{ name }}_uvm, {{ name }}_placements, {{ name }}_offsets;
+  if (optim_tensor.size() >= {{ arg_index * 5 + 5 }}) {
   {{ get_optional_optim_tensor(name, "host", arg_index * 5, "options") }}
   {{ get_optional_optim_tensor(name, "dev", arg_index * 5 + 1, "options") }}
   // optional optimizer states will be on HOST/DEVICE and not UVM.
   {{ get_optional_optim_tensor(name, "uvm", arg_index * 5 + 2, "options") }}
   {{ get_optional_optim_tensor(name, "placements", arg_index * 5 + 3, "weights_placements.options()") }}
   {{ get_optional_optim_tensor(name, "offsets", arg_index * 5 + 4, "weights_offsets.options()") }}
+  } else {
+  // Backward compat: frontend package lacks these optional tensors. Warn once so
+  // version skew is visible rather than silently dropping optional optimizer state.
+  TORCH_WARN_ONCE(
+      "TBE backward: frontend package did not supply optional optimizer tensors for '{{ name }}' "
+      "(optim_tensor.size() = ",
+      optim_tensor.size(),
+      ", expected at least ",
+      {{ arg_index * 5 + 5 }},
+      "). Falling back to empty tensors for backward compatibility; update the frontend "
+      "package to clear this warning.");
+  {{ set_dummy_tensor(name, "host", "options") }}
+  {{ set_dummy_tensor(name, "dev", "options") }}
+  // optional optimizer states will be on HOST/DEVICE and not UVM.
+  {{ set_dummy_tensor(name, "uvm", "options") }}
+  {{ set_dummy_tensor(name, "placements", "weights_placements.options()") }}
+  {{ set_dummy_tensor(name, "offsets", "weights_offsets.options()") }}
+  }
 {%- endmacro %}
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
@@ -26,6 +26,15 @@
 #include "fbgemm_gpu/utils/ops_utils.h"
 #include "fbgemm_gpu/utils/dispatch_macros.h"
 #include "fbgemm_gpu/embedding_common.h"
+{#-/* pt2_arg_utils*.h is emitted by generate_backward_split.py, so it is on the
+      include path only for the backward render of this shared template. */#}
+{%- if not is_forward %}
+{%- if ssd %}
+#include "pt2_arg_utils_ssd.h"
+{%- else %}
+#include "pt2_arg_utils.h"
+{%- endif %}
+{%- endif %}
 // #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
 #include <ATen/TensorUtils.h>
@@ -247,12 +256,7 @@ Tensor split_embedding{{ ndesc }}_codegen_forward_{{ wdesc }}{{ vdesc }}_pt2_cpu
 {#-/* PT2 wrapper function for backward CPU */#}
 Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_pt2_cpu_wrapper(
     const Tensor& grad_output,
-    const Tensor& host_weights,
-    const Tensor& /*dev_weights*/,
-    const Tensor& /*uvm_weights*/,
-    const Tensor& /*lxu_cache_weights*/,
-    const Tensor& weights_placements,
-    const Tensor& weights_offsets,
+    const at::TensorList weights,
     {%- if nobag %}
     const c10::SymInt D,
     {%- else %}
@@ -268,17 +272,13 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{
     const int64_t pooling_mode,
     const Tensor& indice_weights,
     {%- endif %}
-    const Tensor& /*lxu_cache_locations*/,
+    const at::TensorList aux_tensor_bwd,
     const int64_t /*BT_block_size*/,
     const int64_t /*max_segment_length_per_warp*/,
     const bool stochastic_rounding,
     const int64_t info_B_num_bits,
     const int64_t info_B_mask_int64,
     {%- if vbe %}
-    const Tensor& B_offsets,
-    const Tensor& vbe_row_output_offsets,
-    const Tensor& vbe_b_t_map,
-    const Tensor& vbe_B_offsets_rank_per_feature,
     const c10::SymInt max_B,
     {%- endif %}
     const bool /*use_uniq_cache_locations*/,
@@ -288,7 +288,40 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{
     , const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)
     {%- endif %})
     {
+        // Accept the MTIA CPU-fallback 5-slot device layout too. Slots 3/4 are
+        // unused here; assert they are empty so device state isn't silently dropped.
+        TORCH_CHECK(
+            weights.size() == 3 || weights.size() == 5,
+            "CPU weights must be size 3 [host, placements, offsets] or 5 "
+            "[dev-or-host, placements, offsets, uvm, lxu_cache], got ", weights.size());
+        if (weights.size() == 5) {
+            TORCH_CHECK(
+                !weights[3].defined() || weights[3].numel() == 0,
+                "CPU backward does not support UVM weights, but weights[3] (uvm) has ",
+                weights[3].numel(), ". If this is a CPU fallback for MTIA, please "
+                "ensure all weights are on host.");
+            TORCH_CHECK(
+                !weights[4].defined() || weights[4].numel() == 0,
+                "CPU backward does not support an LXU cache. Expect LXU cache weights "
+                "to be undefined or empty, but found the size to be ", weights[4].numel());
+        }
+        const auto& host_weights = weights[0];
+        const auto& weights_placements = weights[1];
+        const auto& weights_offsets = weights[2];
+        {%- if not vbe %}
+        // Non-VBE packs only lxu_cache_locations, so aux_tensor_bwd holds 1 tensor.
+        {%- endif %}
+        TORCH_CHECK(
+            aux_tensor_bwd.size() == {{ "AUX_TENSOR_BWD_SIZE" if vbe else "1" }},
+            "aux_tensor_bwd must contain {{ "AUX_TENSOR_BWD_SIZE" if vbe else "1" }} tensor(s), got ",
+            aux_tensor_bwd.size());
         {%- if vbe %}
+        TORCH_CHECK(
+            aux_tensor_bwd[IDX_BWD_VBE_B_OFFSETS_RANK_PER_FEATURE].defined(),
+            "aux_tensor_bwd[", IDX_BWD_VBE_B_OFFSETS_RANK_PER_FEATURE, "] must be defined. "
+            "It is expected to contain vbe_B_offsets_rank_per_feature for VBE reshape in CPU.");
+        const auto& vbe_B_offsets_rank_per_feature =
+            aux_tensor_bwd[IDX_BWD_VBE_B_OFFSETS_RANK_PER_FEATURE];
         const int64_t max_B_int = max_B.guard_int(__FILE__, __LINE__);
         Tensor offsets_;
         AT_DISPATCH_INDEX_TYPES(offsets.scalar_type(), "reshape_vbe_offsets_cpu_backward", [&]() {
@@ -437,12 +470,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
     if (!utils::torch::schemaExists("fbgemm::{{ embedding_codegen_backward_op }}_wrapper")) {
     m.def("{{ embedding_codegen_backward_op }}_wrapper("
         "    Tensor grad_output, "
-        "    Tensor{{ schema_annotation['weights_host'] }} host_weights, "
-        "    Tensor{{ schema_annotation['weights_dev'] }} dev_weights, "
-        "    Tensor{{ schema_annotation['weights_uvm'] }} uvm_weights, "
-        "    Tensor{{ schema_annotation['weights_lxu_cache'] }} lxu_cache_weights, "
-        "    Tensor weights_placements, "
-        "    Tensor weights_offsets, "
+        "    Tensor[]{{ schema_annotation['weights'] }} weights, "
         {%- if nobag %}
         "    SymInt D, "
         {%- else %}
@@ -458,7 +486,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         "    int pooling_mode, "
         "    Tensor indice_weights, "
         {%- endif %}
-        "    Tensor lxu_cache_locations, "
+        "    Tensor[] aux_tensor_bwd, "
         "    int BT_block_size, "
         "    int max_segment_length_per_warp, "
         {%- if optimizer != "none" %}
@@ -467,10 +495,6 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         "    int info_B_num_bits, "
         "    int info_B_mask_int64, "
         {%- if vbe %}
-        "    Tensor B_offsets, "
-        "    Tensor vbe_row_output_offsets, "
-        "    Tensor vbe_b_t_map, "
-        "    Tensor vbe_B_offsets_rank_per_feature, "
         "    SymInt max_B, "
         {%- endif %}
         "    bool use_uniq_cache_locations, "

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
@@ -27,6 +27,15 @@
 #include "fbgemm_gpu/utils/dispatch_macros.h"
 #include "fbgemm_gpu/embedding_common.h"
 #include "fbgemm_gpu/utils/torch_library.h"
+{#-/* pt2_arg_utils*.h is emitted by generate_backward_split.py, so it is on the
+      include path only for the backward render of this shared template. */#}
+{%- if not is_forward %}
+{%- if ssd %}
+#include "pt2_arg_utils_ssd.h"
+{%- else %}
+#include "pt2_arg_utils.h"
+{%- endif %}
+{%- endif %}
 
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
@@ -224,12 +233,7 @@ Tensor {{ fwd_mdesc }}_embedding{{ ndesc }}_codegen_forward_{{ desc_suffix }}_pt
 {#-/* PT2 wrapper function for backward CUDA */#}
 Tensor {{ bwd_mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ desc_suffix }}_pt2_{{ dispatch_type }}_wrapper(
     const Tensor& grad_output,
-    const Tensor& /*host_weights*/,
-    const Tensor& dev_weights,
-    const Tensor& uvm_weights,
-    const Tensor& lxu_cache_weights,
-    const Tensor& weights_placements,
-    const Tensor& weights_offsets,
+    const at::TensorList weights,
     {%- if nobag %}
     const c10::SymInt D,
     {%- else %}
@@ -245,11 +249,7 @@ Tensor {{ bwd_mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ 
     const int64_t pooling_mode,
     const Tensor& indice_weights, // currently supports no bag with unweighted
     {%- endif %}
-    {%- if ssd %}
-    const Tensor& ssd_row_addrs,
-    {%- elif not dense %}
-    const Tensor& lxu_cache_locations,
-    {%- endif %}
+    const at::TensorList aux_tensor_bwd,
     const int64_t BT_block_size,
     const int64_t max_segment_length_per_warp,
     {%- if optimizer != "none" %}
@@ -258,10 +258,6 @@ Tensor {{ bwd_mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ 
     const int64_t info_B_num_bits,
     const int64_t info_B_mask_int64,
     {%- if vbe %}
-    const Tensor& B_offsets,
-    const Tensor& vbe_row_output_offsets,
-    const Tensor& vbe_b_t_map,
-    const Tensor& vbe_B_offsets_rank_per_feature,
     const c10::SymInt max_B,
     {%- endif %}
     const bool use_uniq_cache_locations,
@@ -282,6 +278,33 @@ Tensor {{ bwd_mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ 
     {%- if not nobag %}
     , const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)
     {%- endif %}){
+        TORCH_CHECK(
+            weights.size() == 5,
+            "CUDA weights must contain dev, placements, offsets, uvm, lxu_cache");
+        const auto& dev_weights = weights[0];
+        const auto& weights_placements = weights[1];
+        const auto& weights_offsets = weights[2];
+        const auto& uvm_weights = weights[3];
+        const auto& lxu_cache_weights = weights[4];
+        // IDX_BWD_VBE_B_OFFSETS_RANK_PER_FEATURE is packed for the CPU reshape
+        // and is unused here.
+        {%- if not vbe %}
+        // Non-VBE packs only lxu_cache_locations, so aux_tensor_bwd holds 1 tensor.
+        {%- endif %}
+        TORCH_CHECK(
+            aux_tensor_bwd.size() == {{ "AUX_TENSOR_BWD_SIZE" if vbe else "1" }},
+            "aux_tensor_bwd must contain {{ "AUX_TENSOR_BWD_SIZE" if vbe else "1" }} tensor(s), got ",
+            aux_tensor_bwd.size());
+        {%- if ssd %}
+        const auto& ssd_row_addrs = aux_tensor_bwd[IDX_BWD_LXU_CACHE_LOCATIONS];
+        {%- else %}
+        const auto& lxu_cache_locations = aux_tensor_bwd[IDX_BWD_LXU_CACHE_LOCATIONS];
+        {%- endif %}
+        {%- if vbe %}
+        const auto& B_offsets = aux_tensor_bwd[IDX_BWD_B_OFFSETS];
+        const auto& vbe_row_output_offsets = aux_tensor_bwd[IDX_BWD_VBE_ROW_OUTPUT_OFFSETS];
+        const auto& vbe_b_t_map = aux_tensor_bwd[IDX_BWD_VBE_B_T_MAP];
+        {%- endif %}
         {%- set backward_op = "{}_embedding{}_backward_codegen_{}_{}_exact_cuda".format(
                 bwd_mdesc, ndesc, optimizer, desc_suffix
             )
@@ -607,12 +630,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
     if (!utils::torch::schemaExists("fbgemm::{{ embedding_codegen_backward_op }}_wrapper")) {
     m.def("{{ embedding_codegen_backward_op }}_wrapper("
         "    Tensor grad_output, "
-        "    Tensor{{ schema_annotation['weights_host'] }} host_weights, "
-        "    Tensor{{ schema_annotation['weights_dev'] }} dev_weights, "
-        "    Tensor{{ schema_annotation['weights_uvm'] }} uvm_weights, "
-        "    Tensor{{ schema_annotation['weights_lxu_cache'] }} lxu_cache_weights, "
-        "    Tensor weights_placements, "
-        "    Tensor weights_offsets, "
+        "    Tensor[]{{ schema_annotation['weights'] }} weights, "
         {%- if nobag %}
         "    SymInt D, "
         {%- else %}
@@ -628,11 +646,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         "    int pooling_mode, "
         "    Tensor indice_weights, "
         {%- endif %}
-        {%- if ssd %}
-        "    Tensor ssd_row_addrs, "
-        {%- else %}
-        "    Tensor lxu_cache_locations, "
-        {%- endif %}
+        "    Tensor[] aux_tensor_bwd, "
         "    int BT_block_size, "
         "    int max_segment_length_per_warp, "
         {%- if optimizer != "none" %}
@@ -641,10 +655,6 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         "    int info_B_num_bits, "
         "    int info_B_mask_int64, "
         {%- if vbe %}
-        "    Tensor B_offsets, "
-        "    Tensor vbe_row_output_offsets, "
-        "    Tensor vbe_b_t_map, "
-        "    Tensor vbe_B_offsets_rank_per_feature, "
         "    SymInt max_B, "
         {%- endif %}
         "    bool use_uniq_cache_locations, "


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3032

Packs the TBE backward wrapper arguments into two at::TensorLists to stay under the
64-arg Torch dispatcher limit, freeing headroom for additional optimizer state.
Implements the plan in "Reduce number of arguments in TBE backward".

- weights: device-conditional, mirroring the forward `weights` list — CPU 3
  [host, placements, offsets], GPU/MTIA 5 [dev, placements, offsets, uvm, lxu_cache].
  Slots 0/1/2 (weight payload, placements, offsets) are shared across all device
  types; GPU/MTIA append uvm at [3] and lxu_cache at [4]. This shared layout lets
  the unpack paths hoist the common slots and branch only on the device-specific tail.
- aux_tensor_bwd: fixed 7-slot [lxu_cache_locations, uvm_cache_stats, B_offsets,
  vbe_row_output_offsets, vbe_b_t_map, vbe_B_offsets_rank_per_feature, vbe_output_offsets];
  absent slots filled with at::empty({0}) so it stays a mandatory TensorList with no None.

Applied across the PT2 autograd + CPU/CUDA/META wrappers and their m.def schemas;
save_for_backward extended for uvm_cache_stats / vbe_output_offsets. max_B and
ssd_row_addrs stay separate. Forward + grad_indice_weights wrappers unchanged.

Differential Revision: D113869217


