### PR TITLE
Add fp8 corner case unit test (#6133)

### DIFF
--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -53,6 +53,7 @@ if open_source:
         is_nvidia_device,
         optests,
         running_in_oss,
+        skipIfNotRocm,
         TEST_WITH_ROCM,
     )
 else:
@@ -62,6 +63,7 @@ else:
         is_nvidia_device,
         optests,
         running_in_oss,
+        skipIfNotRocm,
         TEST_WITH_ROCM,
     )
 
@@ -875,6 +877,54 @@ class ForwardTest(unittest.TestCase):
             use_cpu,
             SparseType.FP32,
             use_experimental_tbe,
+        )
+
+    @optests.dontGenerateOpCheckTests("FP8 compute requires custom op support.")
+    @unittest.skipIf(*gpu_unavailable)
+    @skipIfNotRocm("NFP8 format-selection corner case is ROCm-specific")
+    def test_forward_gpu_nfp8_format_matches_host_decode(self) -> None:
+        # Pins that the device NFP8 decode matches a host decode through the same
+        # dtype. Fails when the arch-native FP8 format (OCP on gfx950) disagrees
+        # with the Python-selected fnuz storage dtype.
+        E, D = 64, 8
+        dev = torch.device("cuda:0")
+
+        cc = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (E, D, EmbeddingLocation.DEVICE, ComputeDevice.CUDA),
+            ],
+            weights_precision=SparseType.NFP8,
+            pooling_mode=PoolingMode.NONE,
+            output_dtype=SparseType.FP32,
+            device=dev,
+        )
+
+        # Finite values whose fnuz and OCP decodes differ.
+        ref = (
+            torch.arange(1, E * D + 1, dtype=torch.float32, device=dev).view(E, D)
+            * 0.05
+        )
+        stored = ref.to(fp8_dtype)
+        cc.split_embedding_weights()[0].data.copy_(stored)
+
+        indices = torch.arange(E, dtype=torch.int64, device=dev)
+        offsets = torch.arange(0, E + 1, dtype=torch.int64, device=dev)
+        out = cc(indices, offsets).detach().float()
+
+        host_decode = stored.view(torch.uint8).view(fp8_dtype).float()
+
+        arch = getattr(torch.cuda.get_device_properties(dev), "gcnArchName", "unknown")
+        max_err = (out - host_decode).abs().max().item()
+        torch.testing.assert_close(
+            out,
+            host_decode,
+            atol=1.0e-2,
+            rtol=1.0e-2,
+            msg=(
+                f"NFP8 TBE forward on {arch} decoded weights stored as "
+                f"{fp8_dtype} inconsistently with the host decode of the same "
+                f"dtype (max abs err {max_err:.4g})."
+            ),
         )
 
     @unittest.skipIf(*gpu_unavailable)


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3026


Test Plan:
## fbcode

Full `forward_test.py` suite on AMD/ROCm (required for the new test to actually run):

```bash
buck2 test fbcode//mode/opt-amd-gpu \
  -c fbcode.enable_gpu_sections=true \
  -c fbcode.rocm_arch=mi300 \
  -c fbcode.platform=platform010 \
  -m rocm70 \
  fbcode//deeplearning/fbgemm/fbgemm_gpu/test/tbe:forward
```

The new test only:

```bash
buck2 test fbcode//mode/opt-amd-gpu \
  -c fbcode.enable_gpu_sections=true \
  -c fbcode.rocm_arch=mi300 \
  -c fbcode.platform=platform010 \
  -m rocm70 \
  fbcode//deeplearning/fbgemm/fbgemm_gpu/test/tbe:forward \
  -- --regex 'test_forward_gpu_nfp8_format_matches_host_decode'
```

Swap `-c fbcode.rocm_arch=` for the target hardware (`mi250` / `mi300` / `mi350`).
`mi350` (gfx950) is the arch this test is designed to catch.

Skip-path / non-regression checks — the new test must skip cleanly and the rest
of the suite must be unaffected:

```bash
# CUDA (H100)
buck2 test fbcode//mode/opt \
  -c fbcode.enable_gpu_sections=true \
  -c fbcode.nvcc_arch=h100 \
  -m ovr_config//third-party/cuda/constraints:12.8 -m cuda128 \
  fbcode//deeplearning/fbgemm/fbgemm_gpu/test/tbe:forward

# CPU-only
buck2 test fbcode//mode/opt fbcode//deeplearning/fbgemm/fbgemm_gpu/test/tbe:forward
buck2 test fbcode//mode/opt fbcode//deeplearning/fbgemm/fbgemm_gpu/test/tbe:forward_backend_bc
```

## OSS

```bash
cd fbgemm_gpu/test
export FBGEMM_TEST_WITH_ROCM=1
python -m pytest -v -rsx -s -W ignore::pytest.PytestCollectionWarning \
  tbe/training/forward_test.py

# single test
python -m pytest -v -rsx -s \
  tbe/training/forward_test.py::ForwardTest::test_forward_gpu_nfp8_format_matches_host_decode
```

## Lint / format

```bash
arc f        # reformatted one over-long getattr() call
arc lint -a  # ok No lint issues.
```

Reviewed By: cthi

Differential Revision: D115263030

Pulled By: q10
