### PR TITLE
Add ROCm cap to invert_permute launch (#6134)

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_invert_permute.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_invert_permute.cu
@@ -7,6 +7,7 @@
  */
 
 #include "common.cuh"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 
 using Tensor = at::Tensor;
 
@@ -35,7 +36,8 @@ DLL_PUBLIC Tensor invert_permute_cuda(const Tensor& permute) {
   }
 
   constexpr int32_t threads_1 = kMaxThreads;
-  const auto blocks_1 = cuda_calc_xblock_count(permute_size, threads_1);
+  const auto blocks_1 = utils::cuda::cap_grid_dim_x_from_workload(
+      permute_size, threads_1, at::cuda::getCurrentCUDAStream());
   AT_DISPATCH_INDEX_TYPES(permute.scalar_type(), "invert_permute_kernel", [&] {
     FBGEMM_LAUNCH_KERNEL(
         (invert_permute_kernel<index_t>),


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3034


invert_permute_kernel already grid-strides via CUDA_KERNEL_LOOP, but its launch
grid = div_round_up(permute_size, kMaxThreads) was uncapped, so on ROCm total
threads ~= permute_size can exceed the HIP 2^32 threads-per-launch limit for very
large permutations. Cap-only fix: cap_grid_dim_x_from_workload(permute_size,
kMaxThreads, stream). Added the cuda_utilities.cuh include. No-op on CUDA.

Differential Revision: D113380026


