### PR TITLE
Bound block-bucketize stress generation

### DIFF
--- a/fbgemm_gpu/test/sparse/block_bucketize_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_test.py
@@ -14,7 +14,7 @@ import unittest
 
 import hypothesis.strategies as st
 import torch
-from hypothesis import given, settings, Verbosity
+from hypothesis import example, given, settings, Verbosity
 
 from .common import extend_test_class, open_source
 
@@ -1850,7 +1850,17 @@ class BlockBucketizeTest(unittest.TestCase):
         sequence=st.booleans(),
         my_size=st.sampled_from([3, 194, 256, 1024]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=32, deadline=None)
+    @example(
+        index_type=torch.long,
+        has_weight=True,
+        bucketize_pos=True,
+        sequence=True,
+        my_size=1024,
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    @optests.dontGenerateOpCheckTests(
+        "large randomized workload is covered directly without recompiling every example"
+    )
     def test_block_bucketize_sparse_features_large(
         self,
         index_type: type[torch.dtype],

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -18,16 +18,7 @@
     "fbgemm::asynchronous_inclusive_cumsum": {},
     "fbgemm::batch_index_select_dim0": {},
     "fbgemm::batch_index_select_dim0_tensor": {},
-    "fbgemm::block_bucketize_sparse_features": {
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_large": {
-        "comment": "max_examples=32 with my_size up to 1024 (~2048 items) recompiles per hypothesis example under aot_dispatch_dynamic and exceeds the 600s tpx timeout (flaky ~10%). Eager + faketensor variants still cover the op. T191384137",
-        "status": "skip"
-      },
-      "BlockBucketizeTest.test_schema__test_block_bucketize_sparse_features_large": {
-        "comment": "Same large-shape recompile as the aot_dispatch variant; test_schema also exceeds the 600s tpx timeout. Eager + faketensor variants still cover the op schema. T191384137",
-        "status": "skip"
-      }
-    },
+    "fbgemm::block_bucketize_sparse_features": {},
     "fbgemm::block_bucketize_sparse_features_2d_weights": {},
     "fbgemm::block_bucketize_sparse_features_inference": {},
     "fbgemm::bottom_k_per_row": {


### PR DESCRIPTION
Summary: Keep the large CPU/GPU regression while preventing generated opcheck duplication. Run eight randomized examples plus an explicit maximum-grid example, and remove the permanent generated-test skips.

Differential Revision: D115378483


