### PR TITLE
Gate permute_1D lengths device assert at compile time

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/common.cuh
+++ b/fbgemm_gpu/src/sparse_ops/common.cuh
@@ -58,6 +58,34 @@ namespace fbgemm_gpu {
 
 constexpr int MAX_ELEMENTS_PER_THREAD = 4;
 
+// Whether the sparse permute kernels instantiate their device-side bounds
+// asserts. This is a COMPILE-time switch, not a runtime one. Selecting it at
+// runtime forces the compiler to emit both the debug and the non-debug
+// specialization of every kernel in the dispatch matrix. For the permute_2D
+// data kernels that is offsets(2) x indices(5) x weights(6) = 60 for each of
+// the two weighted launches, plus offsets(2) x indices(5) = 10 for the
+// unweighted one, so 130 kernels become 260 -- and that doubling pushed large
+// PyTorch test binaries past the 2 GiB PC-relative relocation limit
+// (T283951345).
+//
+// The lengths kernels have much smaller matrices (permute_2D: indices(2),
+// permute_1D: permute(2) x indices(2)), so their doubling is not what blew the
+// limit. They share this constant anyway so that every device assert in the
+// sparse permute ops is toggled by one mechanism rather than each growing its
+// own runtime-selected launch macro.
+//
+// Build with -DFBGEMM_DEBUG_PERMUTE_DEVICE_ASSERT to instantiate the asserts;
+// leaving it out keeps the fused two-stream copy optimizable. The host-side
+// checks stay runtime-gated on FBGEMM_DEBUG_PERMUTE=1 (see
+// is_debug_permute_enabled below) and cost no instantiations -- they are the
+// checks to reach for first, since they fail fast at the offending call and
+// name both values.
+#ifdef FBGEMM_DEBUG_PERMUTE_DEVICE_ASSERT
+inline constexpr bool kPermuteDeviceAssert = true;
+#else
+inline constexpr bool kPermuteDeviceAssert = false;
+#endif
+
 // Opt-in host-side validation for the sparse permute ops. Every check below
 // performs a D2H sync, so it is gated behind an env var which is off by
 // default. Enable with FBGEMM_DEBUG_PERMUTE=1 for additional debugging with a

--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_1d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_1d.cu
@@ -12,28 +12,17 @@ using Tensor = at::Tensor;
 
 namespace fbgemm_gpu {
 
-// Launch permute_1D_lengths_kernel, picking the debug instantiation at runtime.
-// debug=false does not instantiate the bounds asserts at all, so the default
-// kernel carries no terminating path.
-#define FBGEMM_LAUNCH_PERMUTE_1D_LENGTHS(DEBUG, INDEX_T, PERMUTE_T, ...)       \
-  do {                                                                         \
-    if (DEBUG) {                                                               \
-      FBGEMM_LAUNCH_KERNEL(                                                    \
-          (permute_1D_lengths_kernel<INDEX_T, PERMUTE_T, true>), __VA_ARGS__); \
-    } else {                                                                   \
-      FBGEMM_LAUNCH_KERNEL(                                                    \
-          (permute_1D_lengths_kernel<INDEX_T, PERMUTE_T, false>),              \
-          __VA_ARGS__);                                                        \
-    }                                                                          \
-  } while (0)
-
 // Kernel for permuting 1D lengths. Used for permutation of sparse features.
 //
-// The bounds checks are compiled in only for debug=true (selected at launch
-// from FBGEMM_DEBUG_PERMUTE): a terminating failure path costs on the healthy
-// path even when it never fires, so the default instantiation carries no check.
-// See permute_2D_data_kernel_vec for the measurement.
-template <typename index_t, typename permute_t = int32_t, bool debug = false>
+// The bounds checks are compiled in only for debug=true, which defaults to the
+// compile-time kPermuteDeviceAssert (see common.cuh): a terminating failure
+// path costs on the healthy path even when it never fires, so the default
+// instantiation carries no check. See permute_2D_data_kernel_vec for the
+// measurement.
+template <
+    typename index_t,
+    typename permute_t = int32_t,
+    bool debug = kPermuteDeviceAssert>
 __global__ __launch_bounds__(kMaxThreads) void permute_1D_lengths_kernel(
     const index_t* __restrict__ lengths,
     int32_t permuted_lengths_size,
@@ -314,16 +303,13 @@ permute_1D_sparse_data_cuda(
   // See: https://github.com/ROCm/hip/issues/2253
   const auto blocks_1 = utils::cuda::cap_grid_dim_x_from_workload(
       permuted_lengths_size, threads_1, at::cuda::getCurrentCUDAStream());
-  const bool debug_permute = is_debug_permute_enabled();
   AT_DISPATCH_INDEX_TYPES(
       permute.scalar_type(), "permute_1D_lengths_permute_type", [&] {
         using permute_t = index_t;
         AT_DISPATCH_INDEX_TYPES(
             lengths.scalar_type(), "permute_1D_lengths_kernel", [&] {
-              FBGEMM_LAUNCH_PERMUTE_1D_LENGTHS(
-                  debug_permute,
-                  index_t,
-                  permute_t,
+              FBGEMM_LAUNCH_KERNEL(
+                  (permute_1D_lengths_kernel<index_t, permute_t>),
                   blocks_1,
                   threads_1,
                   0,
@@ -471,8 +457,6 @@ permute_1D_sparse_data_cuda(
 
   return {permuted_lengths, permuted_indices, permuted_weights};
 }
-
-#undef FBGEMM_LAUNCH_PERMUTE_1D_LENGTHS
 
 } // namespace fbgemm_gpu
 

--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
@@ -14,6 +14,31 @@ using Tensor = at::Tensor;
 
 namespace fbgemm_gpu {
 
+// Whether the permute_2D kernels instantiate their device-side bounds asserts.
+// This is a COMPILE-time switch, not a runtime one. Selecting it at runtime
+// forces the compiler to emit both the debug and non-debug specialization of
+// every kernel in the dispatch matrix -- offsets(2) x indices(5) x weights(6)
+// = 60 for each of the two weighted data launches, plus offsets(2) x
+// indices(5) = 10 for the unweighted one, so 130 kernels become 260. That
+// doubling pushed large PyTorch test binaries past the 2 GiB PC-relative
+// relocation limit (T283951345).
+//
+// permute_2D_lengths_kernel hangs off the same constant. Its own matrix is just
+// indices(2), so its doubling is not what blew the limit, but keeping a second
+// runtime-selected switch beside this one would reintroduce the same pattern
+// and leave the two asserts toggled by different mechanisms.
+//
+// Build with -DFBGEMM_DEBUG_PERMUTE_DEVICE_ASSERT to instantiate the asserts;
+// leaving it out keeps the fused two-stream copy optimizable. The host-side
+// TORCH_CHECK stays runtime-gated on FBGEMM_DEBUG_PERMUTE=1 and costs no
+// instantiations -- it is the check to reach for first, since it fails fast at
+// the offending call and names both values.
+#ifdef FBGEMM_DEBUG_PERMUTE_DEVICE_ASSERT
+inline constexpr bool kPermuteDeviceAssert = true;
+#else
+inline constexpr bool kPermuteDeviceAssert = false;
+#endif
+
 // Kernel for permuting the indices and weights. Used for permutation of sparse
 // data
 template <
@@ -21,7 +46,7 @@ template <
     typename offsets_t,
     typename indices_t,
     typename weights_t,
-    bool debug = false>
+    bool debug = kPermuteDeviceAssert>
 __global__ __launch_bounds__(kMaxThreads) void permute_2D_data_kernel(
     int64_t len,
     int32_t T,
@@ -130,7 +155,7 @@ template <
     typename offsets_t,
     typename indices_t,
     typename weights_t,
-    bool debug = false>
+    bool debug = kPermuteDeviceAssert>
 __global__ __launch_bounds__(kMaxThreads) void permute_2D_data_kernel_vec(
     int64_t len,
     int32_t T,
@@ -234,24 +259,11 @@ __global__ __launch_bounds__(kMaxThreads) void permute_2D_data_kernel_vec(
   }
 }
 
-// Launch permute_2D_lengths_kernel, picking the debug instantiation at runtime.
-// See FBGEMM_LAUNCH_PERMUTE_1D_LENGTHS in sparse_permute_1d.cu.
-#define FBGEMM_LAUNCH_PERMUTE_2D_LENGTHS(DEBUG, INDEX_T, ...)        \
-  do {                                                               \
-    if (DEBUG) {                                                     \
-      FBGEMM_LAUNCH_KERNEL(                                          \
-          (permute_2D_lengths_kernel<INDEX_T, true>), __VA_ARGS__);  \
-    } else {                                                         \
-      FBGEMM_LAUNCH_KERNEL(                                          \
-          (permute_2D_lengths_kernel<INDEX_T, false>), __VA_ARGS__); \
-    }                                                                \
-  } while (0)
-
 // Kernel for permuting the lengths. Used for permutation of sparse features.
 //
-// The bounds checks are compiled in only for debug=true (selected at launch
-// from FBGEMM_DEBUG_PERMUTE); see permute_1D_lengths_kernel.
-template <typename index_t, bool debug = false>
+// The bounds checks are compiled in only for debug=true, which defaults to the
+// compile-time kPermuteDeviceAssert above.
+template <typename index_t, bool debug = kPermuteDeviceAssert>
 __global__ __launch_bounds__(kMaxThreads) void permute_2D_lengths_kernel(
     int32_t T,
     int32_t B,
@@ -305,23 +317,6 @@ __global__ __launch_bounds__(kMaxThreads) void permute_2D_lengths_kernel(
   }
 }
 
-// Launch a permute kernel, picking the debug instantiation at runtime.
-// debug=false does not instantiate the bounds assert at all, which is what
-// keeps the fused two-stream copy optimizable (see is_debug_permute_enabled).
-#define FBGEMM_LAUNCH_PERMUTE_2D(                                       \
-    DEBUG, KERNEL, HAS_WEIGHT, OFFSETS_T, INDICES_T, WEIGHTS_T, ...)    \
-  do {                                                                  \
-    if (DEBUG) {                                                        \
-      FBGEMM_LAUNCH_KERNEL(                                             \
-          (KERNEL<HAS_WEIGHT, OFFSETS_T, INDICES_T, WEIGHTS_T, true>),  \
-          __VA_ARGS__);                                                 \
-    } else {                                                            \
-      FBGEMM_LAUNCH_KERNEL(                                             \
-          (KERNEL<HAS_WEIGHT, OFFSETS_T, INDICES_T, WEIGHTS_T, false>), \
-          __VA_ARGS__);                                                 \
-    }                                                                   \
-  } while (0)
-
 DLL_PUBLIC std::tuple<Tensor, Tensor, std::optional<Tensor>>
 permute_2D_sparse_preallocated_out_cuda(
     const Tensor& permute,
@@ -336,8 +331,6 @@ permute_2D_sparse_preallocated_out_cuda(
   TORCH_CHECK(lengths.dim() == 2);
 
   CUDA_DEVICE_GUARD(indices);
-
-  const bool debug_permute = is_debug_permute_enabled();
 
   const auto permute_contig = permute.contiguous();
   const auto lengths_contig = lengths.contiguous();
@@ -396,9 +389,8 @@ permute_2D_sparse_preallocated_out_cuda(
       B * T, threads_1, at::cuda::getCurrentCUDAStream());
   AT_DISPATCH_INDEX_TYPES(
       lengths.scalar_type(), "permute_2D_lengths_kernel", [&] {
-        FBGEMM_LAUNCH_PERMUTE_2D_LENGTHS(
-            debug_permute,
-            index_t,
+        FBGEMM_LAUNCH_KERNEL(
+            (permute_2D_lengths_kernel<index_t>),
             blocks_1,
             threads_1,
             0,
@@ -432,7 +424,7 @@ permute_2D_sparse_preallocated_out_cuda(
   int64_t permuted_indices_size = 0;
   if (permuted_lengths_sum.has_value()) {
     permuted_indices_size = permuted_lengths_sum.value();
-    if (debug_permute) {
+    if (is_debug_permute_enabled()) {
       const int64_t true_size = output_offsets[-1].item<int64_t>();
       TORCH_CHECK(
           permuted_indices_size == true_size,
@@ -500,13 +492,12 @@ permute_2D_sparse_preallocated_out_cuda(
                     [&] {
                       using weights_t = scalar_t;
                       if (weights_columns == 1) {
-                        FBGEMM_LAUNCH_PERMUTE_2D(
-                            debug_permute,
-                            permute_2D_data_kernel_vec,
-                            true,
-                            offsets_t,
-                            indices_t,
-                            weights_t,
+                        FBGEMM_LAUNCH_KERNEL(
+                            (permute_2D_data_kernel_vec<
+                                true,
+                                offsets_t,
+                                indices_t,
+                                weights_t>),
                             blocks_2,
                             threads_2,
                             0,
@@ -522,13 +513,12 @@ permute_2D_sparse_preallocated_out_cuda(
                             permuted_indices.data_ptr<indices_t>(),
                             permuted_weights.data_ptr<weights_t>());
                       } else {
-                        FBGEMM_LAUNCH_PERMUTE_2D(
-                            debug_permute,
-                            permute_2D_data_kernel,
-                            true,
-                            offsets_t,
-                            indices_t,
-                            weights_t,
+                        FBGEMM_LAUNCH_KERNEL(
+                            (permute_2D_data_kernel<
+                                true,
+                                offsets_t,
+                                indices_t,
+                                weights_t>),
                             blocks_2,
                             threads_2,
                             0,
@@ -547,13 +537,12 @@ permute_2D_sparse_preallocated_out_cuda(
                       }
                     }); // for each weights_t
               } else {
-                FBGEMM_LAUNCH_PERMUTE_2D(
-                    debug_permute,
-                    permute_2D_data_kernel_vec,
-                    false,
-                    offsets_t,
-                    indices_t,
-                    std::nullptr_t,
+                FBGEMM_LAUNCH_KERNEL(
+                    (permute_2D_data_kernel_vec<
+                        false,
+                        offsets_t,
+                        indices_t,
+                        std::nullptr_t>),
                     blocks_2,
                     threads_2,
                     0,
@@ -574,9 +563,6 @@ permute_2D_sparse_preallocated_out_cuda(
 
   return {permuted_lengths, permuted_indices, permuted_weights};
 }
-
-#undef FBGEMM_LAUNCH_PERMUTE_2D
-#undef FBGEMM_LAUNCH_PERMUTE_2D_LENGTHS
 
 // Functional (allocating) entry point. Delegates to the shared implementation
 // with no pre-allocated output buffers.

--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
@@ -14,31 +14,6 @@ using Tensor = at::Tensor;
 
 namespace fbgemm_gpu {
 
-// Whether the permute_2D kernels instantiate their device-side bounds asserts.
-// This is a COMPILE-time switch, not a runtime one. Selecting it at runtime
-// forces the compiler to emit both the debug and non-debug specialization of
-// every kernel in the dispatch matrix -- offsets(2) x indices(5) x weights(6)
-// = 60 for each of the two weighted data launches, plus offsets(2) x
-// indices(5) = 10 for the unweighted one, so 130 kernels become 260. That
-// doubling pushed large PyTorch test binaries past the 2 GiB PC-relative
-// relocation limit (T283951345).
-//
-// permute_2D_lengths_kernel hangs off the same constant. Its own matrix is just
-// indices(2), so its doubling is not what blew the limit, but keeping a second
-// runtime-selected switch beside this one would reintroduce the same pattern
-// and leave the two asserts toggled by different mechanisms.
-//
-// Build with -DFBGEMM_DEBUG_PERMUTE_DEVICE_ASSERT to instantiate the asserts;
-// leaving it out keeps the fused two-stream copy optimizable. The host-side
-// TORCH_CHECK stays runtime-gated on FBGEMM_DEBUG_PERMUTE=1 and costs no
-// instantiations -- it is the check to reach for first, since it fails fast at
-// the offending call and names both values.
-#ifdef FBGEMM_DEBUG_PERMUTE_DEVICE_ASSERT
-inline constexpr bool kPermuteDeviceAssert = true;
-#else
-inline constexpr bool kPermuteDeviceAssert = false;
-#endif
-
 // Kernel for permuting the indices and weights. Used for permutation of sparse
 // data
 template <
@@ -262,7 +237,7 @@ __global__ __launch_bounds__(kMaxThreads) void permute_2D_data_kernel_vec(
 // Kernel for permuting the lengths. Used for permutation of sparse features.
 //
 // The bounds checks are compiled in only for debug=true, which defaults to the
-// compile-time kPermuteDeviceAssert above.
+// compile-time kPermuteDeviceAssert (see common.cuh).
 template <typename index_t, bool debug = kPermuteDeviceAssert>
 __global__ __launch_bounds__(kMaxThreads) void permute_2D_lengths_kernel(
     int32_t T,


### PR DESCRIPTION
Summary:
Follow-up to D115324727, which moved the permute_2D device asserts off a
runtime selector and onto the compile-time kPermuteDeviceAssert constant.
sparse_permute_1d.cu still selected its `debug` template argument at runtime
via FBGEMM_LAUNCH_PERMUTE_1D_LENGTHS, so after that diff the two files
disagreed: FBGEMM_DEBUG_PERMUTE=1 flipped the 1D lengths assert but not the 2D
one, and the last runtime-selected launch macro in the sparse permute ops was
still alive to be copied by the next person adding a device assert.

- Hoist kPermuteDeviceAssert out of sparse_permute_2d.cu into common.cuh, next
  to is_debug_permute_enabled(). Both .cu files already include it, and a
  duplicated `#ifdef` pair would have to be kept in sync by hand.
- permute_1D_lengths_kernel's `debug` parameter now defaults to
  kPermuteDeviceAssert, and FBGEMM_LAUNCH_PERMUTE_1D_LENGTHS plus its #undef
  are deleted. The single launch site goes back to calling
  FBGEMM_LAUNCH_KERNEL directly.
- Drops the now-unused `debug_permute` local; the three host-side checks in
  this function already call is_debug_permute_enabled() directly.

Every device-side assert in the sparse permute ops is now on one switch:
-DFBGEMM_DEBUG_PERMUTE_DEVICE_ASSERT. The host-side checks are unchanged and
still runtime-gated on FBGEMM_DEBUG_PERMUTE=1.

Behavior change, same tradeoff D115324727 already took for permute_2D: the 1D
lengths assert can no longer be enabled with an env var on an already-running
job, and now needs a build flag. The host-side checks remain the ones to reach
for first on a repro.

Differential Revision: D115468380


