### PR TITLE
Drop CUDA 13.4 (cu134) from all Linux wheel build matrices

### DIFF
--- a/.github/workflows/build_wheels_genai_linux_aarch64.yml
+++ b/.github/workflows/build_wheels_genai_linux_aarch64.yml
@@ -50,13 +50,14 @@ jobs:
         MAT: ${{ needs.generate-matrix.outputs.matrix }}
       # Nova Coordinate Filters:
       # cuda/13.0-aarch64: Not supported in FBGEMM CI yet
-      # cuda 13.2 (cu132): not supported by FBGEMM yet; validate step fails with
-      #   "Unknown distribution". Drop until 13.2 is supported.
+      # cuda 13.2 (cu132), 13.4 (cu134): not supported by FBGEMM yet; validate step
+      #   fails with "Unknown distribution". 13.4 is still on toolkit 13.4.0rc1
+      #   (not GA). Drop until each is supported.
       run: |
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_version:13.2' )"
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_version:13.2,13.4' )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/build_wheels_genai_linux_x86.yml
+++ b/.github/workflows/build_wheels_genai_linux_x86.yml
@@ -52,14 +52,15 @@ jobs:
       # Nova Coordinate Filters:
       # cuda/11.8: No longer supported in FBGEMM
       # cuda/12.9: No longer supported in PyTorch
-      # cuda 13.2 (cu132): not supported by FBGEMM yet; validate step fails with
-      #   "Unknown distribution". Drop until 13.2 is supported.
+      # cuda 13.2 (cu132), 13.4 (cu134): not supported by FBGEMM yet; validate step
+      #   fails with "Unknown distribution". 13.4 is still on toolkit 13.4.0rc1
+      #   (not GA). Drop until each is supported.
       # rocm/3.13t: causes segfaults at runtime
       run: |
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter gpu_arch_version:11.8 --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2' )"
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter gpu_arch_version:11.8 --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2,13.4' )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/build_wheels_linux_aarch64.yml
+++ b/.github/workflows/build_wheels_linux_aarch64.yml
@@ -49,13 +49,14 @@ jobs:
         MAT: ${{ needs.generate-matrix.outputs.matrix }}
       # Nova Coordinate Filters:
       # rocm/3.13t: causes segfaults at runtime
-      # cuda 13.2 (cu132): not supported by FBGEMM yet; validate step fails with
-      #   "Unknown distribution". Drop until 13.2 is supported.
+      # cuda 13.2 (cu132), 13.4 (cu134): not supported by FBGEMM yet; validate step
+      #   fails with "Unknown distribution". 13.4 is still on toolkit 13.4.0rc1
+      #   (not GA). Drop until each is supported.
       run: |
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2' )"
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2,13.4' )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/build_wheels_linux_x86.yml
+++ b/.github/workflows/build_wheels_linux_x86.yml
@@ -51,13 +51,14 @@ jobs:
         MAT: ${{ needs.generate-matrix.outputs.matrix }}
       # Nova Coordinate Filters:
       # rocm/3.13t: causes segfaults at runtime
-      # cuda 13.2 (cu132): not supported by FBGEMM yet; test-infra emits it and the
-      #   validate step fails with "Unknown distribution". Drop until 13.2 is supported.
+      # cuda 13.2 (cu132), 13.4 (cu134): not supported by FBGEMM yet; test-infra
+      #   emits them and the validate step fails with "Unknown distribution".
+      #   13.4 is still on toolkit 13.4.0rc1 (not GA). Drop until each is supported.
       run: |
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2' )"
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2,13.4' )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3040

PyTorch added CUDA 13.4rc1 to its nightly binary matrix on 2026-08-07
(pytorch/pytorch #192256 / internal D115257402, "Add CUDA 13.4rc1 x86 and sbsa
binaries", approved by atalman). Because the Nova build workflows generate their
matrix from pytorch/test-infra@main at build time, 13.4 immediately started
flowing into FBGEMM's wheel matrices and failing the validate step with
"Unknown distribution" — the same failure mode we already handle for 13.2.

13.4 is not supported by FBGEMM yet, and upstream it is still pinned to CUDA
toolkit 13.4.0rc1 (not GA); its wheels are not on the download.pytorch.org
index. Stable remains 13.0. Drop cu134 from all four Linux wheel build matrices
(x86 + aarch64, TBE + GenAI) alongside the existing 13.2 drop, until 13.4 is
supported. Revisit onboarding once the toolkit goes GA.

Differential Revision: D115490149


