### PR TITLE
Avoid ATen reduction in masked jagged select (#6140)

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -12,6 +12,7 @@
 #include <torch/csrc/autograd/custom_function.h>
 #include <torch/library.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <functional>
 #include "ATen/Parallel.h"
@@ -1026,14 +1027,15 @@ std::tuple<Tensor, Tensor> masked_select_jagged_1d(
       lengths.scalar_type(), "mask_select_jagged_1d_kernel1", [&] {
         FBGEMM_DISPATCH_ALL_TYPES(
             values.scalar_type(), "mask_select_jagged_1d_kernel2", [&] {
-              const int32_t num_outputs = mask.sum().item<int32_t>();
+              const auto mask_ptr = mask_contiguous->const_data_ptr<bool>();
+              const int64_t num_outputs =
+                  std::count(mask_ptr, mask_ptr + mask.numel(), true);
               masked_values = at::empty({num_outputs}, values.options());
 
               const auto values_ptr =
                   values_contiguous->const_data_ptr<scalar_t>();
               const auto lengths_ptr =
                   lengths_contiguous->const_data_ptr<index_t>();
-              const auto mask_ptr = mask_contiguous->const_data_ptr<bool>();
 
               auto masked_values_ptr =
                   masked_values.mutable_data_ptr<scalar_t>();


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3041


Replace `mask.sum().item<int32_t>()` with `std::count` over the contiguous boolean mask, avoiding generic ATen dispatch, bool-to-int64 conversion, TensorIterator reduction, and temporary tensor allocation while preserving exact output sizing.

CPU benchmarks show an 8.7%-60.2% whole-operator reduction depending on mask size. 

Current cost of the whole function in the fleet is $2.456M/year

Reviewed By: bottler

Differential Revision: D115456015


