### PR TITLE
Move get_maybe_uvm_scalar under FBGEMM_FBCODE for OSS build

### DIFF
--- a/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
@@ -61,8 +61,6 @@ get_res_client(int64_t res_server_port) {
       "realtime.delta.publish.esr", params);
 }
 
-#endif
-
 /// Read a scalar value from a tensor that is maybe a UVM tensor
 /// Note that `tensor.item<type>()` is not allowed on a UVM tensor in
 /// PyTorch
@@ -71,6 +69,8 @@ inline int64_t get_maybe_uvm_scalar(const at::Tensor& tensor) {
       ? *(tensor.const_data_ptr<int64_t>())
       : *(tensor.const_data_ptr<int32_t>());
 }
+
+#endif
 
 } // namespace
 


### PR DESCRIPTION
Summary:
Fixes the OSS -Werror break on pytorch/FBGEMM main:
```
  raw_embedding_streamer.cpp:69:16: error: unused function
  'get_maybe_uvm_scalar' [-Werror,-Wunused-function]
```

Root cause is D113594180. It rewrote tensor_copy into tensor_copy_chunk(..., start_row, end_row), which derives n = end_row - start_row instead of calling get_maybe_uvm_scalar(count). tensor_copy lived outside #ifdef FBGEMM_FBCODE, so that was the helper's last OSS-visible caller; the only remaining one, chunked_copy_and_enqueue, is inside the ifdef.

This diff simply moves the function inside the `ifdef`

Reviewed By: hirenapatel1109

Differential Revision: D115616471


