### PR TITLE
Fix new rocm version build: use __syncthreads() instead of removed hipcub::CTA_SYNC

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_async_batched_cumsum.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_async_batched_cumsum.cu
@@ -80,7 +80,7 @@ __global__ __launch_bounds__(kMaxThreads) void _batched_complete_cumsum_kernel(
       }
       BlockScan(temp_storage).InclusiveSum(data, data, prefix_op);
 
-#if CUDA_VERSION >= 13000
+#if defined(USE_ROCM) || CUDA_VERSION >= 13000
       __syncthreads();
 #else
       cub::CTA_SYNC();
@@ -93,7 +93,7 @@ __global__ __launch_bounds__(kMaxThreads) void _batched_complete_cumsum_kernel(
 
     // Ensure all threads finished using temp_storage before the next
     // outer-iteration's BlockScan overwrites it.
-#if CUDA_VERSION >= 13000
+#if defined(USE_ROCM) || CUDA_VERSION >= 13000
     __syncthreads();
 #else
     cub::CTA_SYNC();

--- a/fbgemm_gpu/test/sll/jagged_jagged_bmm_jagged_out_test.py
+++ b/fbgemm_gpu/test/sll/jagged_jagged_bmm_jagged_out_test.py
@@ -34,7 +34,7 @@ class JaggedJaggedBmmJaggedOutTest(unittest.TestCase):
     )
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
-    @settings(deadline=30000)
+    @settings(deadline=None)
     def test_triton_jagged_jagged_bmm_jagged_out(
         self,
         B: int,


### PR DESCRIPTION
Fixes the FBGEMM-GPU ROCm build on the upcoming ROCm version, which fails with:
  src/sparse_ops/sparse_async_batched_cumsum.hip:88:15: error: no member named 'CTA_SYNC' in namespace 'hipcub'

Root cause: sparse_async_batched_cumsum.cu guards a CUB barrier with
`#if CUDA_VERSION >= 13000` (CUB removed cub::CTA_SYNC in CUDA 13.0). hipify
rewrites CUDA_VERSION -> TORCH_HIP_VERSION and cub:: -> hipcub::. HIP versioning
is major*100+minor, so HIP 7.15 = 715 < 13000, selecting hipcub::CTA_SYNC() --
removed in ROCm 10 hipcub.

Fix: guard on defined(USE_ROCM) so ROCm always uses native __syncthreads() (what
CTA_SYNC maps to), preserving CUDA-13 behavior. Version-independent.

Also set deadline=None on test_triton_jagged_jagged_bmm_jagged_out (Triton
first-call JIT ~99s exceeded the 30s hypothesis deadline; subsequent runs ~2ms).

Tested on ROCm 10 (gfx942): full wheel build succeeds; sparse/cumsum_test.py
4 passed; sll/jagged_jagged_bmm_jagged_out_test.py 2 passed. CUDA path unchanged.