### PR TITLE
Add ROCm cap to pack_segments backward (unpack) launch

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_pack_segments_backward.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_pack_segments_backward.cu
@@ -7,6 +7,7 @@
  */
 
 #include "common.cuh"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 
 using Tensor = at::Tensor;
 
@@ -102,7 +103,10 @@ DLL_PUBLIC Tensor pack_segments_backward_cuda(
 
           FBGEMM_LAUNCH_KERNEL(
               (unpack_segments_cuda_kernel<index_t, scalar_t>),
-              cuda_calc_xblock_count(num_seq * max_length * cell_size, 128),
+              utils::cuda::cap_grid_dim_x_from_workload(
+                  num_seq * max_length * cell_size,
+                  128,
+                  at::cuda::getCurrentCUDAStream()),
               128,
               0,
               at::cuda::getCurrentCUDAStream(),


### PR DESCRIPTION
Summary:
unpack_segments_cuda_kernel already grid-strides via CUDA_KERNEL_LOOP, but its
launch grid = div_round_up(num_seq * max_length * cell_size, 128) was uncapped,
so on ROCm total threads can exceed the HIP 2^32 threads-per-launch limit for
large segment workloads. Cap-only fix: cap_grid_dim_x_from_workload(
num_seq * max_length * cell_size, 128, stream). Added the cuda_utilities.cuh
include. No-op on CUDA.

Differential Revision: D113380027


