### PR TITLE
Downgrade -Werror=maybe-uninitialized on GCC to unblock nightly wheel build (#6147)

### DIFF
--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -59,7 +59,8 @@ function(fbgemm_get_warning_flags)
     list(APPEND _cc
       -Wno-error=unused-but-set-parameter
       -Wno-error=unused-but-set-variable
-      -Wno-error=array-bounds)
+      -Wno-error=array-bounds
+      -Wno-error=maybe-uninitialized)
   endif()
 
   set(${ARG_MSVC_FLAGS_VAR} ${_msvc} PARENT_SCOPE)


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3045


The nightly x86 wheel build (build_wheels_linux_x86, gcc-toolset-13 / GCC 13,
`-std=c++20 -Wall -Wextra -Werror`) fails compiling gen_embedding_backward_split_sgd.cpp:

  c10/util/intrusive_ptr.h:507: error: '...target_' may be used uninitialized
  [-Werror=maybe-uninitialized]

GCC 13 reports a spurious maybe-uninitialized through the move-construction of a
`std::optional<at::Tensor>` on the return path of the codegen forward op call. It
is a known GCC false-positive (same family as -Warray-bounds, which is already
downgraded here) surfaced by a recent torch nightly header change. Because the
build uses -Werror the warning is fatal, ninja stops, and the wheel is never
produced -- every downstream `No module named 'fbgemm_gpu'` test error is fallout.

Downgrade maybe-uninitialized from error to warning on GNU, mirroring the existing
-Wno-error=array-bounds treatment.

Differential Revision: D115776478


