### PR TITLE
mx4 dequantize: scale via FP32 bit-construction, not FP64 exp2 (#6148)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/triton/quantize.py
+++ b/fbgemm_gpu/fbgemm_gpu/triton/quantize.py
@@ -567,12 +567,17 @@ def _kernel_dequantize_mx4(
             other=0.0,
         )
         # Remove fp32 exponent bias.
-        exp = exp.to(tl.int16) - FP32_EXP_BIAS
+        exp = exp.to(tl.int32) - FP32_EXP_BIAS
 
-        # Convert exponent to scale and apply to input.
-        # Requires higher precision to avoid rounding out small values.
-        # This might be slow so we should consider just letting them round away.
-        scale = tl.exp2(exp.to(tl.float64)).to(tl.float32)
+        # Compute scale = 2^exp exactly via FP32 bit construction instead of a slow
+        # FP64 exp2. exp is an integer in [-127, 125]; for e >= -126, 2^e is a normal
+        # fp32 (zero mantissa) so we set the exponent field directly. e == -127 ->
+        # 2^-127 is subnormal and cannot be built that way, so special-case it.
+        scale = tl.where(
+            exp >= -126,
+            ((exp + 127) << 23).to(tl.float32, bitcast=True),
+            2.0**-127,
+        )
         scaled_low_fp32 = scale * low_fp32
         scaled_high_fp32 = scale * high_fp32
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3046

`_kernel_dequantize_mx4` computes the group scale as `scale = tl.exp2(exp.to(tl.float64)).to(tl.float32)` — the same FP64 transcendental that D107485047 removed from `_kernel_quantize_mx4`. FP64 throughput on datacenter GPUs (including Blackwell / GB300) is a small fraction of FP32, and here it dominates completely: before this change the kernel sustains ~270 GB/s on a GB300, roughly 3% of HBM bandwidth, so it is FP64-bound rather than memory-bound as a dequantize kernel should be.

`exp` is the stored shared exponent minus the FP32 bias, an integer in `[-127, 125]`, so `2^exp` is always an exact power of two. For `exp >= -126` the result is a normal FP32 with zero mantissa, which we build directly by setting the exponent field: `((exp + 127) << 23)` bitcast to FP32. `exp == -127` corresponds to the subnormal `2^-127` and is handled with a constant. The intermediate also widens from `int16` to `int32`, which is what the shift requires; the packed tensor is `uint8`, so the widening is zero-extending and the value range is unchanged.

This is bit-identical to the previous behavior: both the old `exp2(fp64) -> fp32` path and the new bit-construction produce the exact FP32 value of `2^exp` for every `exp` in `[-127, 125]`, including the `2^-127` subnormal edge.

Measured on a GB300 (sm_103, CUDA 13.0) at the eight MX4 dequantize call sites of a production APS training job (`aps-short_ebf_0L_only_pinet_32_ac_0-1_GB300_128t`, rank 1), fp32 output:

```
  out numel      group  before     after    speedup  after GB/s
  1,272,824,832  16     21.80 ms   1.08 ms  20.2x    5378
  1,236,671,488  16     21.00 ms   1.05 ms  19.9x    5354
  1,203,738,624  16     20.75 ms   1.01 ms  20.5x    5418
    680,656,896  16     11.52 ms   0.59 ms  19.6x    5298
  1,054,586,880   8     17.98 ms   0.96 ms  18.7x    5081
    984,307,712   8     16.77 ms   0.90 ms  18.6x    5052
    814,034,944   8     13.87 ms   0.71 ms  19.7x    5338
    677,183,488   8     11.60 ms   0.62 ms  18.6x    5022
```

Summed over those sites, 135.29 ms -> 6.92 ms (19.5x). In that job the rank-1 per-iteration dequantize cost drops from 62.8 ms/iter to ~3.2 ms/iter. The kernel moves from ~270 GB/s to ~5,000-5,400 GB/s, i.e. it becomes memory-bound, which is the expected ceiling.

An additional change was evaluated and deliberately left out: hoisting the shared-exponent load and scale computation from per-packed-byte to per-group (the kernel currently evaluates both on `GROUP_LOAD * GROUP_SIZE / 2` lanes when only `GROUP_LOAD` distinct values exist). Ablation showed that hoist is worth 1.00x on its own, and only 1.00-1.14x when stacked on top of this change — 1.137x at group_size=16 with fp32 output and ~1.00x at every other measured (group_size, dtype) pair. It is not worth the extra `tl.reshape` broadcast in the kernel body and can be revisited separately.

Reviewed By: jwfromm

Differential Revision: D115468226


