### PR TITLE
Demote GCC `-Wmaybe-uninitialized`

### DIFF
--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -59,7 +59,8 @@ function(fbgemm_get_warning_flags)
     list(APPEND _cc
       -Wno-error=unused-but-set-parameter
       -Wno-error=unused-but-set-variable
-      -Wno-error=array-bounds)
+      -Wno-error=array-bounds
+      -Wno-error=maybe-uninitialized)
   endif()
 
   set(${ARG_MSVC_FLAGS_VAR} ${_msvc} PARENT_SCOPE)


### PR DESCRIPTION
Summary:
OSS GCC 13 builds can diagnose false-positive `maybe-uninitialized` paths in PyTorch headers while compiling generated TBE host C++. Because FBGEMM enables `-Werror`, these diagnostics currently fail the build.

Add `-Wno-error=maybe-uninitialized` to the GNU-only CMake warning flags in both mirrored modules. This keeps the diagnostic visible while preventing it from becoming fatal, without changing Clang, NVCC, or HIPCC flags.

Differential Revision: D115937458


