### PR TITLE
02c.2 -- HIP and nvcc reconnaissance: warnings on, -Werror off

### DIFF
--- a/cmake/modules/GpuCppLibrary.cmake
+++ b/cmake/modules/GpuCppLibrary.cmake
@@ -225,8 +225,9 @@ function(gpu_cpp_library)
     # Computed BEFORE the library is created, because `hip_add_library()` takes
     # HIPCC_OPTIONS as a creation-time argument (it is a legacy FindHIP concept,
     # not a target property that can be set afterwards), so the HIPCC list has to
-    # exist by then. A follow-up applies these lists; this block only computes
-    # them, and nothing consumes the NVCC/HIPCC ones yet.
+    # exist by then. Both lists are now consumed, and both minus `-Werror`:
+    # `_nvcc_warning_flags` by the CUDA genex near the bottom of this function,
+    # and `_hipcc_warning_flags` by `hip_add_library()` below.
     #
     # Only the flag computation moved here. The MSVC `target_compile_definitions`
     # that used to sit in the same block stays after library creation, because it
@@ -284,12 +285,36 @@ function(gpu_cpp_library)
             list(APPEND lib_hipcc_system_includes "-isystem${include_dir}")
         endforeach()
 
+        # RECONNAISSANCE: warnings ON, `-Werror` OFF.
+        #
+        # OSS HIP compilation has never had `-Wall`/`-Wextra` at all, and there is
+        # no local ROCm build to measure with, so this lands warn-only to size the
+        # fixup work from CI before it can break anyone. **This is temporary** --
+        # a follow-up deletes the two lines below and passes
+        # `_hipcc_warning_flags` directly, at which point ROCm CI becomes a real
+        # device-code gate.
+        #
+        # Strip every `-Werror*` entry, not just the bare token. `REMOVE_ITEM`
+        # with the literal would leave a targeted `-Werror=<name>` behind if the
+        # warning list ever grows one, and the surface would silently stop being
+        # warn-only. The `^-Werror` anchor deliberately does not match the
+        # `-Wno-error=<name>` entries -- those are inert once `-Werror` is gone,
+        # and removing them would be a behaviour change.
+        set(_hipcc_recon ${_hipcc_warning_flags})
+        list(FILTER _hipcc_recon EXCLUDE REGEX "^-Werror")
+
         # Create the HIP library
+        #
+        # Warning flags come FIRST, before HIP_HCC_FLAGS. The tail of
+        # HIP_HCC_FLAGS is the HIP-specific `-Wno-*` block appended by
+        # RocmSetup.cmake, and those suppressions must keep winning -- otherwise
+        # `-Wall` re-enables things HIP deliberately turned off, such as
+        # `-Wformat`. Do not reorder these two.
         hip_add_library(${lib_name} ${args_TYPE}
             ${lib_sources_hipified}
             ${args_OTHER_SRCS}
             ${FBGEMM_HIP_HCC_LIBRARIES}
-            HIPCC_OPTIONS ${HIP_HCC_FLAGS} ${lib_hipcc_system_includes} ${args_HIPCC_FLAGS})
+            HIPCC_OPTIONS ${_hipcc_recon} ${HIP_HCC_FLAGS} ${lib_hipcc_system_includes} ${args_HIPCC_FLAGS})
 
         # Append ROCM includes
         target_include_directories(${lib_name} PUBLIC
@@ -416,9 +441,27 @@ function(gpu_cpp_library)
     # `-Wno-strict-aliasing` and friends to cl.exe, which does not accept them.
     # The host CXX path already handles this by selecting `_msvc_flags` into
     # `lib_cc_flags`; there is no MSVC-shaped equivalent for the nvcc list today.
+    # RECONNAISSANCE: warnings ON, `-Werror` OFF -- the same treatment the HIPCC
+    # list gets above, for a different reason.
+    #
+    # nvcc hands its own generated stubs (`/tmp/tmpxft_*.cudafe1.stub.c`) to the
+    # host compiler, so `-Xcompiler=-Werror` lands on code this repo does not
+    # write and cannot annotate. Those stubs spell out template arguments as bare
+    # decimal literals, and an `int64_t` NTTP of `INT64_MIN` becomes
+    # `9223372036854775808` -- which does not fit a signed 64-bit type, so GCC
+    # emits `integer constant is so large that it is unsigned`. That diagnostic
+    # carries NO `-W<name>`, so unlike every other noisy warning here it cannot
+    # be demoted with `-Wno-error=<name>`; dropping `-Werror` is the only lever.
+    #
+    # Same anchor rationale as the HIPCC list: `^-Xcompiler=-Werror` strips bare
+    # `-Werror` and any future `-Werror=<name>`, and deliberately does not match
+    # `-Xcompiler=-Wno-error=<name>`, which is inert once `-Werror` is gone.
+    set(_nvcc_recon ${_nvcc_warning_flags})
+    list(FILTER _nvcc_recon EXCLUDE REGEX "^-Xcompiler=-Werror")
+
     if(NOT MSVC)
         target_compile_options(${lib_name} PRIVATE
-            $<$<COMPILE_LANGUAGE:CUDA>:${_nvcc_warning_flags}>)
+            $<$<COMPILE_LANGUAGE:CUDA>:${_nvcc_recon}>)
     endif()
 
     ############################################################################
@@ -487,11 +530,17 @@ function(gpu_cpp_library)
         "RESOLVED WARNING FLAGS (CC):"
         "${_cc_flags}"
         " "
-        "RESOLVED WARNING FLAGS (NVCC, produced not applied):"
+        "RESOLVED WARNING FLAGS (NVCC, full set):"
         "${_nvcc_warning_flags}"
         " "
-        "RESOLVED WARNING FLAGS (HIPCC, produced not applied):"
+        "RESOLVED WARNING FLAGS (NVCC, AS APPLIED -- recon strips -Werror*):"
+        "${_nvcc_recon}"
+        " "
+        "RESOLVED WARNING FLAGS (HIPCC, full set):"
         "${_hipcc_warning_flags}"
+        " "
+        "RESOLVED WARNING FLAGS (HIPCC, AS APPLIED -- recon strips -Werror*):"
+        "${_hipcc_recon}"
         " "
         "NVCC_FLAGS:"
         "${args_NVCC_FLAGS}"

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
@@ -59,9 +59,6 @@ constexpr uint32_t LXU_PARAMS_CNT = 2;
 #define SMEM_CACHE_WEIGHT_DATA(SMEM_IDX, WEIGHT_IDX) \
   (SMEM_PTR_BASE(const cache_vec_t**)[SMEM_IDX])[WEIGHT_IDX]
 
-// This avoid type conversion of denom in div_round_up
-#define DIV_ROUND_UP(numer, denom) ((numer + denom - 1) / denom)
-
 #define ACC_ADD_OR_FMA(WEIGHT, INDEX_WEIGHT) \
   {%- if weighted %}
   accumulator.fma(WEIGHT, INDEX_WEIGHT);

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_prelude.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_prelude.cuh
@@ -58,7 +58,7 @@ namespace fbgemm_gpu {
     assert(err == cudaError::cudaSuccess); \
   } while (0)
 
-#define DIV_ROUND_UP(a, b) (a + b - 1) / b
+#define DIV_ROUND_UP(a, b) (((a) + (b) - 1) / (b))
 
 // Warp size -- device-pass constant
 //


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3051

Subplan 02c chunk 02c.2 (T169200065), §4.3. Passes the warning set to
`hip_add_library()` with `-Werror` stripped, so ROCm CI reports diagnostics on HIP
**device** code without failing the build.

OSS HIP compilation has never had `-Wall`/`-Wextra` at all -- it received only
`-Wno-*`. This is the surface Richard's ask is actually about: hipcc is clang, so
unlike nvcc it warns device code.

```cmake
set(_hipcc_recon ${_hipcc_warning_flags})
list(REMOVE_ITEM _hipcc_recon -Werror)

hip_add_library(${lib_name} ${args_TYPE}
    ...
    HIPCC_OPTIONS ${_hipcc_recon} ${HIP_HCC_FLAGS} ${lib_hipcc_system_includes} ${args_HIPCC_FLAGS})
```

**Warn-only is the one deliberate exception to straight-to-`-Werror`** in this
project, and it is narrow: the surface has never been compiled with warnings, and
there is no local ROCm build to size the work with. 02c.4 deletes the two
`_hipcc_recon` lines and passes `_hipcc_warning_flags` directly. The comment says
so at the point of use, so the temporary form is not mistaken for the final one.

**Ordering is load-bearing.** The warning flags go *before* `HIP_HCC_FLAGS`,
because the tail of `HIP_HCC_FLAGS` is the HIP-specific `-Wno-*` block appended by
`RocmSetup.cmake` -- `-Wno-format`, `-Wno-cuda-compat`, `-Wno-unused-result` and
friends. If `-Wall` came after them it would re-enable exactly what HIP
deliberately turned off. There is a comment against reordering.

Note the call already carried `${lib_hipcc_system_includes}` from subplan 01, which
§4.3's snippet predates; it is preserved in position.

**Verified the §2 caveat before landing.** `Hip.cmake:96` pulls `${CMAKE_CXX_FLAGS}`
into HIP compilation, and the plan warns that a warning flag leaking in there would
arrive at HIP twice in different positions. Audited `setup.py`, which is what
populates it: `cxx_flags` contains include paths, `-stdlib=libstdc++`,
`-fopenmp=libgomp`, `-DROCM_VERSION=...` and similar -- **no `-W` flag anywhere**.
No double arrival.

**Addressed two review findings before export (V2).**

1. **The BLOCK_PRINT was lying about what HIP receives.** It still labelled both
   GPU lists "produced not applied" and printed `_hipcc_warning_flags`. As of this
   chunk the HIP branch applies `_hipcc_recon` (the same list minus `-Werror`), and
   as of 02c.1 the NVCC list is applied too. A reader of the configure-time output
   would have seen `-Werror` and concluded ROCm was error-gated when it is
   warn-only. That matters more here than anywhere else: the BLOCK_PRINT is the
   only instrument for reading what reached each surface from a CI log, so the
   census this chunk exists to produce would have been interpreted against the
   wrong flag list. Now prints three labelled entries -- NVCC as applied, the HIPCC
   full set, and the HIPCC set AS APPLIED -- so the withheld flag is visible rather
   than implied.

2. **`REMOVE_ITEM -Werror` only stripped the bare token.** The old comment claimed
   it "stays correct if the warning list is ever reshaped"; it does not. A targeted
   `-Werror=<name>` would survive and the surface would silently stop being
   warn-only. Replaced with `list(FILTER ... EXCLUDE REGEX "^-Werror")`, which
   deliberately does not match `-Wno-error=<name>` -- those are inert once
   `-Werror` is gone and removing them would be a behaviour change.

Also corrected a third stale comment ("nothing consumes the NVCC/HIPCC ones yet"),
which 02c.1 and this chunk both falsified.

**The filter change is behaviour-neutral today**, which matters because it must not
alter what the census measures:

```
list shape                        old REMOVE_ITEM        new FILTER
today                             n=6, no -Werror*       n=6, no -Werror*   (identical)
hypothetical + -Werror=shadow     n=7, SURVIVES  <-bug   n=6, removed
-Wno-error=* entries              preserved              preserved
```

---

**V3 -- also strips `-Werror` from the nvcc list, to fix the OSS CUDA CI break.**

02c.1 (D115805271, landed) began forwarding the host warning set to nvcc as
`-Xcompiler=<flag>`, `-Werror` included. That breaks the OSS CUDA build:

```
/tmp/tmpxft_00020cd7_00000000-6_jagged_unique_indices.compute_100f.cudafe1.stub.c:22:1107:
    error: integer constant is so large that it is unsigned [-Werror]
```

The failing translation unit is **nvcc's own generated stub**, not a file in this
repo. nvcc writes template arguments into the stub as bare decimal literals, and
`jagged_unique_indices.cu:624` instantiates

```cpp
compute_hash_size_kernel<index_t, std::numeric_limits<index_t>::min()>
```

which for `index_t = int64_t` puts `9223372036854775808` in the stub. That does not
fit a signed 64-bit type, so GCC warns, and `-Xcompiler=-Werror` promotes it.

**This warning cannot be demoted.** Every other noisy warning here is handled with
a targeted `-Wno-error=<name>`; this one has no `-W<name>` at all. Verified
directly:

```
$ gcc -c -Werror -Wno-error=overflow wtest.c
wtest.c:1:15: error: integer constant is so large that it is unsigned [-Werror]
```

Note the bare `[-Werror]` -- no option name in the brackets, and the demotion has
no effect. So the only lever is `-Werror` itself, and nvcc gets the same
reconnaissance treatment the HIPCC list already gets in this diff:

```cmake
set(_nvcc_recon ${_nvcc_warning_flags})
list(FILTER _nvcc_recon EXCLUDE REGEX "^-Xcompiler=-Werror")
```

The anchor is `^-Xcompiler=-Werror` rather than `^-Werror`, because the nvcc
entries are wrapped. Same rationale as the HIPCC filter otherwise: it catches a
future `-Werror=<name>` and deliberately does not match
`-Xcompiler=-Wno-error=<name>`, which is inert once `-Werror` is gone. The
BLOCK_PRINT now shows the NVCC full set and the NVCC as-applied set, matching the
treatment the HIPCC lists already got in V2.

**Not fixed here, deliberately.** The NTTP at `jagged_unique_indices.cu:577`
(`template <typename index_t, auto min_value>`) carries no information not already
derivable from `index_t` -- it is used once, at line 600, as `index_t t_max =
min_value`. Dropping it would shorten the mangled name and remove this particular
literal. But it would not make `-Werror` safe on nvcc in general: the constants
live in generated stubs across the whole CUDA surface, and the second diagnostic in
the same log is on a `PackedTensorAccessor32<double, ...>` typedef that this repo
does not parameterize. Sizing that is what the reconnaissance is for.

Reviewed By: cthi

Differential Revision: D115811780


