### PR TITLE
Mask the column-scale load in _kernel_scale_fp8_row

### DIFF
--- a/fbgemm_gpu/experimental/gemm/test/fp8_gemm_test.py
+++ b/fbgemm_gpu/experimental/gemm/test/fp8_gemm_test.py
@@ -434,6 +434,10 @@ class TestFp8Matmul(unittest.TestCase):
 
         _test_scale_fp8_row((2, 3), torch.device("cuda"))
         _test_scale_fp8_row((2, 3), torch.device("cpu"))
+        # Shapes whose last block of columns is partial, including ones that
+        # take more than one iteration of the kernel's column loop.
+        for shape in [(4, 513), (3, 1000), (2, 1025)]:
+            _test_scale_fp8_row(shape, torch.device("cuda"))
 
     def test_matmul_fp8_row(self) -> None:
         def _test_matmul_fp8_row(

--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
@@ -3073,7 +3073,7 @@ def _kernel_scale_fp8_row(
         a = tl.load(
             A + pid * stride_am + n_offset * stride_an, mask=n_offset < N, other=0.0
         )
-        col_scale = tl.load(w_scale + n_offset)
+        col_scale = tl.load(w_scale + n_offset, mask=n_offset < N, other=0.0)
         scaled_a = a * row_scale * col_scale
         tl.store(
             scaled_out + pid * stride_om + n_offset * stride_on,


### PR DESCRIPTION
## Description

Fixes #6157

The column loop in `_kernel_scale_fp8_row` masks its activation load and its store with `n_offset < N`, but loads `w_scale` unmasked. `w_scale` holds exactly `N` elements, so the kernel reads past its end on the final iteration whenever `N` is not a multiple of `BLOCK_SIZE` — and since the smallest autotune block is 512, on every call with `N < 512`.

## Verification

Under `compute-sanitizer --tool memcheck` with `PYTORCH_NO_CUDA_MEMORY_CACHING=1`, on `test_scale_fp8_row` as extended by this PR:

| kernel | result |
|---|---|
| before | ERROR SUMMARY: 192 errors — `Invalid __global__ read` at `fp8_gemm.py:3076`, test fails when the overrun kills the context |
| after | ERROR SUMMARY: 0 errors, test passes |



## Environment

- NVIDIA B200 (sm_100), driver 595.71.05
- torch 2.13.0+cu130, triton 3.7.1
- compute-sanitizer 2025.4.1 (CUDA 13.1)
