### PR TITLE
Apply the last k scale block in _kernel_matmul_fp8_block_fastacc

### DIFF
--- a/fbgemm_gpu/experimental/gemm/test/fp8_gemm_test.py
+++ b/fbgemm_gpu/experimental/gemm/test/fp8_gemm_test.py
@@ -741,3 +741,9 @@ class TestFp8Matmul(unittest.TestCase):
         _test_matmul_fp8_block((3, 4, 5), (256, 256, 256), False)
         _test_matmul_fp8_block((3, 4, 5), (256, 256, 256), True, device="cpu")
         _test_matmul_fp8_block((1024, 2048, 4096), (256, 512, 1024), True, device="cpu")
+        # K values that leave a partial trailing scale block while still being a
+        # multiple of the tile BLOCK_K. The K=5 shapes above are not a multiple of
+        # any BLOCK_K, so they exercise a different path through the scale guard.
+        _test_matmul_fp8_block((256, 256, 640), (256, 256, 256), True)
+        _test_matmul_fp8_block((256, 256, 64), (128, 128, 128), True)
+        _test_matmul_fp8_block((256, 256, 192), (128, 128, 128), True)

--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
@@ -1851,7 +1851,7 @@ def _kernel_matmul_fp8_block_fastacc(
         # And have s_k+1 be 1.
         # Scale_i = pid_i * BLOCK_I / scale_block_i
         pid_k = k * SPLIT_K + pid_z
-        if ((pid_k + 1) % k_multiple == 0) or (k_remaining < BLOCK_K * SPLIT_K):
+        if ((pid_k + 1) % k_multiple == 0) or (k + 1 == tl.cdiv(K, BLOCK_K * SPLIT_K)):
             # Note: Due to split_k access "pid_k" = k * SPLIT_K + pid_z
             # Access a_scale[pid_m, k * SPLIT_K + pid_z]
             # and b_scale[k * SPLIT_K + pid_z, pid_n]


### PR DESCRIPTION
## Description

Fixes #6159

The scale-application guard in `_kernel_matmul_fp8_block_fastacc` escapes with `(k_remaining < BLOCK_K * SPLIT_K)`, which is false on the final k iteration whenever `K` is an exact multiple of `BLOCK_K * SPLIT_K`. When `K` is also not a multiple of `scale_block_k`, the modulo clause is false as well and the trailing scale block is never applied, so the output is off by a multiplicative per-block scale.

## Verification

Relative error of `matmul_fp8_block(..., fp8_fast_accum=True)` against `a @ b.T`, M = N = 256 (~0.04 is fp8 quantization noise):

| scale blocks | K | before | after |
|---|---|---|---|
| 256 | 640 | 10411.09 | 0.0372 |
| 256 | 896 | 11432.38 | 0.0377 |
| 256 | 1152 | 11753.16 | 0.0375 |
| 128 | 64 | 12574.35 | 0.0372 |
| 128 | 192 | 13013.62 | 0.0378 |
| 128 | 320 | 13258.18 | 0.0376 |
| 256 | 256, 512, 300 | 0.0375 | 0.0375 |
| 128 | 128, 256 | 0.0375 | 0.0375 |

## Environment

- NVIDIA B200 (sm_100), driver 595.71.05
- torch 2.13.0+cu130, triton 3.7.1
