### PR TITLE
Avoid FP64 in the MX4 Triton dequantize kernel (GB300 sm_103)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/triton/quantize.py
+++ b/fbgemm_gpu/fbgemm_gpu/triton/quantize.py
@@ -570,9 +570,22 @@ def _kernel_dequantize_mx4(
         exp = exp.to(tl.int16) - FP32_EXP_BIAS
 
         # Convert exponent to scale and apply to input.
-        # Requires higher precision to avoid rounding out small values.
-        # This might be slow so we should consider just letting them round away.
-        scale = tl.exp2(exp.to(tl.float64)).to(tl.float32)
+        # Same exact FP32 bit construction the quantize kernel uses, rather than a
+        # per-element FP64 exp2. exp is an integer in [-127, 125] (written by
+        # _kernel_quantize_mx4 as exp + FP32_EXP_BIAS in a uint8); for e >= -126,
+        # 2^e is a normal fp32 (zero mantissa) so the exponent field can be set
+        # directly. e == -127 -> 2^-127 is subnormal and cannot be built that way,
+        # so it is special-cased.
+        #
+        # This matters far more here than in the quantizer: exp is loaded at the
+        # packed-byte width (each group exponent repeated across its GROUP_SIZE/2
+        # bytes), so the FP64 tile was 16x wider than the quantizer's per-group one.
+        exp_int = exp.to(tl.int32)
+        scale = tl.where(
+            exp_int >= -126,
+            ((exp_int + 127) << 23).to(tl.float32, bitcast=True),
+            2.0**-127,
+        )
         scaled_low_fp32 = scale * low_fp32
         scaled_high_fp32 = scale * high_fp32
 


### PR DESCRIPTION
Summary:
Follow-up to the FP32 scale construction already landed in _kernel_quantize_mx4:
apply the same treatment to _kernel_dequantize_mx4, which still computes

  scale = tl.exp2(exp.to(tl.float64)).to(tl.float32)

GB300 (sm_103) reduced FP64 throughput to ~1/28th of GB200, and ptxas silently
emits an emulation sequence rather than failing, so this presents as an
unexplained slowdown. See "Knowledge Sharing: Avoid FP64 on GB300":
https://fb.workplace.com/groups/420659799592399/permalink/1337503244574712/

The dequantizer is by far the larger of the two. Measured from 64-rank Kineto
traces of ig_organic_feed_mtml, normalized by grid size so this is not a
launch-config artifact:

  kernel                    B200 sm_100    GB300 sm_103    regression
  _kernel_dequantize_mx4     26.6 ns/blk    511.1 ns/blk       19.2x
  _kernel_quantize_mx4       39.8 ns/blk    134.2 ns/blk        3.4x   (already fixed)

The asymmetry is structural: in the dequantizer `exp` is loaded at the packed-byte
vector width, because each group exponent is repeated across the GROUP_SIZE/2
bytes of its group. Its FP64 tile is therefore 16x wider than the quantizer's
per-group one. Fixing only the quantizer leaves ~72% of the original MX4 cost on
the table.

This uses the identical idiom already in _kernel_quantize_mx4, including the
subnormal special case at exp == -127, so it is bit-identical to the FP64 path
and NE-neutral.

Measured with both kernels fixed, GB300 64-GPU ig_organic_feed_mtml:

  kernel, per-block         before      after     change
  dequantize_mx4          511.1 ns    19.1 ns     -96.3%
  quantize_mx4            134.2 ns    49.7 ns     -63.0%
  MX4 total per rank       179.5 ms    22.7 ms     -87.4%

  end-to-end per-GPU QPS (p50, steady state, steps > 2000)
    baseline   3369
    with fix   3515    (+4.35%)

Dequantize ends up faster than B200 (19.1 vs 26.6 ns/block), and the 26.7x
speedup closely tracks the documented 28x FP64 deficit.

Differential Revision: D115890160


