### PR TITLE
Docs: Add fbgemm-ascend to community ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ For contributions, please see the [`CONTRIBUTING`](./CONTRIBUTING.md) file for
 ways to help out.
 
 
+## Community Ports
+
+### Huawei Ascend NPU
+
+[fbgemm-ascend](https://gitcode.com/Ascend/fbgemm-ascend) provides
+community-maintained NPU implementations for selected FBGEMM_GPU operators.
+
+* **Prebuilt wheels:** Install from [PyPI](https://pypi.org/project/fbgemm-ascend/)
+  with `python -m pip install fbgemm-ascend`, or download a wheel from
+  [GitCode Releases](https://gitcode.com/Ascend/fbgemm-ascend/releases).
+
+* **Build from source:** See the
+  [fbgemm-ascend README](https://gitcode.com/Ascend/fbgemm-ascend) for source
+  build instructions.
+
+
 ## License
 
 FBGEMM is BSD licensed, as found in the [`LICENSE`](LICENSE) file.


### PR DESCRIPTION
## Summary

  This PR adds a new **Community Ports** section to the FBGEMM README and introduces [fbgemm-ascend](https://gitcode.com/Ascend/fbgemm-ascend), a community-maintained Ascend NPU implementation of FBGEMM_GPU operators.

  The new section provides:

  - The fbgemm-ascend repository and documentation
  - Prebuilt wheel links on GitCode Releases and PyPI
  - pip and local wheel installation commands
  - Source build instructions

  fbgemm-ascend is developed and maintained independently by the Ascend team.

  This PR follows the discussion in https://github.com/pytorch/FBGEMM/issues/6149.

  ## Testing

  Documentation-only change. Verified the Markdown formatting and links.