### PR TITLE
Validate NFP8 device labels and expand coverage (#6165)

### DIFF
--- a/fbgemm_gpu/bench/tbe/nfp8_relabel_overhead_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/nfp8_relabel_overhead_benchmark.py
@@ -1,0 +1,134 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Measure the host-side cost of the NFP8 fn->fnuz boundary relabel on ROCm.
+
+Two measurements:
+  1. Isolated cost of Tensor.view(dtype) at TBE weight-buffer scale. This is an
+     UPPER BOUND on the C++ relabel_nfp8_for_dispatch() cost, since the Python
+     call additionally pays pybind/dispatch overhead the C++ path does not.
+  2. End-to-end TBE NFP8 forward wall time, for context. Run this file against
+     both the relabel build and a forced-fnuz-label build to A/B the delta.
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from collections.abc import Sequence
+
+import torch
+from fbgemm_gpu.split_embedding_configs import nfp8_dtype, SparseType
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+    ComputeDevice,
+    EmbeddingLocation,
+)
+from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+    SplitTableBatchedEmbeddingBagsCodegen,
+)
+
+T = 8
+E = 100_000
+D = 256
+B = 1024
+L = 32
+WARMUP = 50
+ITERS = 500
+
+
+def _pct(vals: Sequence[float], p: float) -> float:
+    s = sorted(vals)
+    return s[min(int(len(s) * p), len(s) - 1)]
+
+
+def bench_view(numel: int) -> None:
+    src = torch.empty(
+        numel, dtype=torch.float8_e4m3fn, device=torch.accelerator.current_accelerator()
+    )
+    for _ in range(1000):
+        src.view(dtype=torch.float8_e4m3fnuz)
+
+    samples = []
+    for _ in range(ITERS):
+        t0 = time.perf_counter_ns()
+        for _ in range(100):
+            src.view(dtype=torch.float8_e4m3fnuz)
+        samples.append((time.perf_counter_ns() - t0) / 100.0)
+
+    print(
+        f"  view(dtype) on {numel:>12,} elems: "
+        f"p50={statistics.median(samples):7.1f} ns  "
+        f"p90={_pct(samples, 0.90):7.1f} ns  "
+        f"min={min(samples):7.1f} ns"
+    )
+
+
+def bench_tbe_forward() -> tuple[float, int, int]:
+    tbe = SplitTableBatchedEmbeddingBagsCodegen(
+        [(E, D, EmbeddingLocation.DEVICE, ComputeDevice.CUDA)] * T,
+        weights_precision=SparseType.NFP8,
+        output_dtype=SparseType.FP32,
+        device=torch.cuda.current_device(),
+    )
+    weights = tbe.split_embedding_weights()[0]
+    total_numel = sum(w.numel() for w in tbe.split_embedding_weights())
+
+    indices = torch.randint(
+        0,
+        E,
+        (B * T * L,),
+        device=torch.accelerator.current_accelerator(),
+        dtype=torch.int64,
+    )
+    offsets = torch.arange(
+        0,
+        B * T * L + 1,
+        L,
+        device=torch.accelerator.current_accelerator(),
+        dtype=torch.int64,
+    )
+
+    for _ in range(WARMUP):
+        tbe(indices, offsets)
+    torch.cuda.synchronize()
+
+    samples = []
+    for _ in range(ITERS):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter_ns()
+        tbe(indices, offsets)
+        torch.cuda.synchronize()
+        samples.append(time.perf_counter_ns() - t0)
+
+    p50 = statistics.median(samples)
+    print(
+        f"  TBE NFP8 forward           : "
+        f"p50={p50 / 1000.0:9.1f} us  "
+        f"p90={_pct(samples, 0.90) / 1000.0:9.1f} us  "
+        f"min={min(samples) / 1000.0:9.1f} us"
+    )
+    return p50, weights.numel(), total_numel
+
+
+def main() -> None:
+    arch = torch.cuda.get_device_properties(torch.cuda.current_device()).gcnArchName
+    print(f"arch        = {arch}")
+    print(f"nfp8_dtype  = {nfp8_dtype()}")
+    print(f"relabel active on this build = {nfp8_dtype() is torch.float8_e4m3fn}")
+    print(f"config      = T={T} E={E:,} D={D} B={B} L={L} iters={ITERS}\n")
+
+    p50_fwd, per_table, total = bench_tbe_forward()
+    print()
+    bench_view(per_table)
+    bench_view(total)
+
+    print(f"\n  forward p50 = {p50_fwd / 1000.0:.1f} us")
+    print("  NOTE: forward does 2 relabels (dev_weights, uvm_weights);")
+    print("        uvm_weights is empty here, so only 1 is a real view.")
+
+
+if __name__ == "__main__":
+    main()

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -20,6 +20,38 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
 )
 
 
+@torch.jit.ignore
+def _nfp8_is_fnuz() -> bool:
+    """
+    Whether the current runtime device uses the FP8 "fnuz" e4m3 encoding.
+
+    The FP8 e4m3 encoding is hardware specific on AMD GPUs: the gfx94x family
+    (gfx940/941/942, MI300) and gfx90a use the "fnuz" encoding, while gfx950 and
+    CUDA use the OCP "fn" encoding. A single ROCm build can be a fat binary
+    spanning multiple archs, so this must be resolved at runtime from the actual
+    device in use, mirroring the C++ getNFP8ScalarType() helper in
+    embedding_common.h. Keep the arch to encoding mapping identical between the
+    two.
+
+    Marked @torch.jit.ignore because the arch query is not TorchScript-able;
+    scripted callers get the eager result at runtime.
+    """
+    if torch.version.hip is not None and torch.cuda.is_available():
+        arch = torch.cuda.get_device_properties(torch.cuda.current_device()).gcnArchName
+        # fnuz archs: the gfx94x family (gfx940/941/942, MI300) and gfx90a.
+        if "gfx94" in arch or "gfx90a" in arch:
+            return True
+    return False
+
+
+def nfp8_dtype() -> torch.dtype:
+    """
+    Return the native FP8 (e4m3) torch dtype for the current runtime device.
+    See _nfp8_is_fnuz() for the arch to encoding mapping.
+    """
+    return torch.float8_e4m3fnuz if _nfp8_is_fnuz() else torch.float8_e4m3fn
+
+
 def pad4(value: int) -> int:
     """
     Compute the smallest multiple of 4 that is greater than or equal to the given value.
@@ -363,11 +395,7 @@ def sparse_type_int_to_dtype(ty: int) -> torch.dtype:
     elif ty == 7:  # mx4
         return torch.uint8
     elif ty == 9:
-        return (
-            torch.float8_e4m3fnuz
-            if torch.version.hip is not None
-            else torch.float8_e4m3fn
-        )
+        return torch.float8_e4m3fnuz if _nfp8_is_fnuz() else torch.float8_e4m3fn
     else:  # Invalid is 7 or non enumerated.
         raise ValueError(f"Unsupported sparse type: {ty}")
 
@@ -448,11 +476,7 @@ class SparseType(enum.Enum):
             SparseType.INT2.value: torch.quint2x4,
             SparseType.BF16.value: torch.bfloat16,
             SparseType.MX4.value: torch.uint8,
-            SparseType.NFP8.value: (
-                torch.float8_e4m3fnuz
-                if torch.version.hip is not None
-                else torch.float8_e4m3fn
-            ),
+            SparseType.NFP8.value: nfp8_dtype(),
         }[self.value]
 
     def bit_rate(self) -> int:

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -29,6 +29,27 @@ from torch.autograd.profiler import record_function  # usort:skip
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers as invokers
 from fbgemm_gpu.config import FeatureGate, FeatureGateName
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
+
+try:
+    from fbgemm_gpu.split_embedding_configs import nfp8_dtype
+except ImportError:
+    # Forward-compat for torch.package re-export version blends (S685573): a
+    # model's frozen `split_embedding_configs`, bundled alongside this (newer)
+    # module at GMPP re-export time, may predate `nfp8_dtype`. Import it
+    # defensively and fall back to the pre-arch-aware selection so this module
+    # finishes initializing regardless of the bundled `split_embedding_configs`
+    # version -- otherwise the failed top-level import leaves a poisoned partial
+    # module cached by the torch.package importer and a later
+    # `from ...ops_training import SplitTableBatchedEmbeddingBagsCodegen` fails.
+    # Mirrors the D110788115 `sparse_type_to_int` fallback pattern.
+    def nfp8_dtype() -> torch.dtype:
+        return (
+            torch.float8_e4m3fnuz
+            if torch.version.hip is not None
+            else torch.float8_e4m3fn
+        )
+
+
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     BoundsCheckMode,
     CacheAlgorithm,
@@ -3342,11 +3363,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             for param in splits:
                 tmp_param = torch.zeros(param.shape, device=self.current_device)
                 # Create initialized weights and cast to fp8.
-                fp8_dtype = (
-                    torch.float8_e4m3fnuz
-                    if torch.version.hip is not None
-                    else torch.float8_e4m3fn
-                )
+                fp8_dtype = nfp8_dtype()
                 tmp_param.uniform_(min_val, max_val).to(fp8_dtype)
                 param.data.copy_(tmp_param)
         else:

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
@@ -12,7 +12,11 @@ from typing import Any
 import hypothesis.strategies as st
 import numpy as np
 import torch
-from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
+from fbgemm_gpu.split_embedding_configs import (
+    EmbOptimType as OptimType,
+    nfp8_dtype,
+    SparseType,
+)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     SplitTableBatchedEmbeddingBagsCodegen,
@@ -94,9 +98,7 @@ common_settings: dict[str, Any] = {
     "deadline": None,
 }
 
-fp8_dtype: torch.dtype = (
-    torch.float8_e4m3fnuz if torch.version.hip is not None else torch.float8_e4m3fn
-)
+fp8_dtype: torch.dtype = nfp8_dtype()
 
 
 def execute_backward_adagrad(  # noqa C901

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_test.py
@@ -81,8 +81,7 @@ class BackwardAdagradTest(unittest.TestCase):
     ) -> None:
         kwargs = adjust_mixed_B_st(kwargs)
         # Skip for use_cpu=True, as FP8 is not supported on CPU.
-        # Also disable on AMD for now.
-        if kwargs["use_cpu"] or torch.version.hip:
+        if kwargs["use_cpu"]:
             return
         execute_backward_adagrad(
             weights_precision=SparseType.NFP8,

--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -17,7 +17,11 @@ from unittest.mock import MagicMock, patch
 import hypothesis.strategies as st
 import numpy as np
 import torch
-from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
+from fbgemm_gpu.split_embedding_configs import (
+    EmbOptimType as OptimType,
+    nfp8_dtype,
+    SparseType,
+)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     RESParams,
@@ -50,7 +54,6 @@ if open_source:
     from test_utils import (
         additional_decorators,
         gpu_unavailable,
-        is_nvidia_device,
         optests,
         running_in_oss,
         skipIfNotRocm,
@@ -60,7 +63,6 @@ else:
     from fbgemm_gpu.test.test_utils import (
         additional_decorators,
         gpu_unavailable,
-        is_nvidia_device,
         optests,
         running_in_oss,
         skipIfNotRocm,
@@ -69,9 +71,7 @@ else:
 
 VERBOSITY: Verbosity = Verbosity.verbose
 
-fp8_dtype: torch.dtype = (
-    torch.float8_e4m3fnuz if torch.version.hip is not None else torch.float8_e4m3fn
-)
+fp8_dtype: torch.dtype = nfp8_dtype()
 
 # pyre-ignore
 additional_decorators.update(
@@ -826,10 +826,6 @@ class ForwardTest(unittest.TestCase):
         self,
         use_experimental_tbe: bool = False,  # TODO This does not yet work when True.
     ) -> None:
-        # Skip on rocm as fp8 is not supported for all versions.
-        if not is_nvidia_device:
-            return
-
         weights_precision = SparseType.NFP8
         use_cpu = False
         T = random.randint(1, 10)
@@ -1070,10 +1066,6 @@ class ForwardTest(unittest.TestCase):
         self,
         cache_algorithm: CacheAlgorithm,
     ) -> None:
-        # Skip tests on rocm since it does not work for all versions.
-        if not is_nvidia_device:
-            return
-
         weights_precision = SparseType.NFP8
         use_cpu = False
         T = random.randint(1, 10)

--- a/fbgemm_gpu/test/tbe/training/nfp8_encoding_test.py
+++ b/fbgemm_gpu/test/tbe/training/nfp8_encoding_test.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+# pyre-ignore-all-errors[56]
+
+import unittest
+
+import torch
+from fbgemm_gpu.split_embedding_configs import SparseType
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+    ComputeDevice,
+    EmbeddingLocation,
+)
+from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+    SplitTableBatchedEmbeddingBagsCodegen,
+)
+
+try:
+    # pyre-ignore[21]
+    from test_utils import gpu_unavailable
+except Exception:
+    from fbgemm_gpu.test.test_utils import gpu_unavailable
+
+
+@unittest.skipIf(*gpu_unavailable)
+class NFP8EncodingTest(unittest.TestCase):
+    """Pins the invariant that the NFP8 encoding the device kernel uses matches
+    the encoding the host tensor's dtype label advertises.
+
+    This matters because FP8 e4m3 has two encodings that share a bit layout but
+    differ in exponent bias, so the same byte decodes to a 2x different value:
+
+        byte 0x7A -> 320.0 as float8_e4m3fn   (bias 7, max finite 448)
+        byte 0x7A -> 160.0 as float8_e4m3fnuz (bias 8, max finite 240)
+
+    On ROCm the label is arch-dependent (getNFP8ScalarType: fnuz on gfx94x and
+    gfx90a, OCP fn on gfx950) while only the fnuz kernel variant is instantiated,
+    so host tensors are relabeled to fnuz at the dispatch boundary by
+    relabel_nfp8_for_dispatch. That relabel must NOT change the numerics: the
+    physical encoding is bound per-arch in device code via the __nv_fp8_e4m3
+    alias. This test fails if the relabel ever starts leaking into the math.
+
+    Written arch-agnostically -- it compares the device round-trip against a host
+    round-trip through the tensor's own dtype, so it is a valid check on gfx942
+    (fnuz), gfx950 (fn) and CUDA (fn) alike.
+    """
+
+    def test_device_encoding_matches_host_label(self) -> None:
+        num_embeddings, embedding_dim = 64, 32
+
+        tbe = SplitTableBatchedEmbeddingBagsCodegen(
+            [
+                (
+                    num_embeddings,
+                    embedding_dim,
+                    EmbeddingLocation.DEVICE,
+                    ComputeDevice.CUDA,
+                )
+            ],
+            weights_precision=SparseType.NFP8,
+            output_dtype=SparseType.FP32,
+            device=torch.cuda.current_device(),
+        )
+        weights = tbe.split_embedding_weights()[0]
+
+        # The weight buffer must carry an FP8 e4m3 label, and it must be the
+        # arch-correct one -- never silently relabeled for the caller.
+        self.assertIn(
+            weights.dtype,
+            (torch.float8_e4m3fn, torch.float8_e4m3fnuz),
+            "NFP8 weights must be labeled with an FP8 e4m3 dtype",
+        )
+
+        # 224.0 = 1.75 * 2^7 is exactly representable in BOTH encodings (fn max
+        # 448, fnuz max 240), so the probe is arch-safe, while still exercising
+        # the top of the exponent range where a bias-7 vs bias-8 mismatch is
+        # glaring. Do not use an fn-only value such as 320.0 here: it overflows
+        # fnuz to NaN on gfx942 and assert_close treats NaN != NaN.
+        probe = torch.tensor([0.5, 1.0, 2.0, 224.0], device=torch.cuda.current_device())
+        row = probe.repeat(embedding_dim // probe.numel())
+        weights.copy_(row.expand(num_embeddings, embedding_dim).to(weights.dtype))
+
+        # Reference: round trip on the host through the SAME dtype the tensor
+        # advertises. If the device honors the label, it must agree.
+        expected = row.to(weights.dtype).float()
+
+        indices = torch.zeros(1, device=torch.cuda.current_device(), dtype=torch.int64)
+        offsets = torch.tensor(
+            [0, 1], device=torch.cuda.current_device(), dtype=torch.int64
+        )
+        actual = tbe(indices, offsets)[0]
+
+        torch.testing.assert_close(
+            actual,
+            expected,
+            rtol=0,
+            atol=0,
+            msg=lambda m: (
+                f"Device FP8 encoding disagrees with the host dtype label "
+                f"({weights.dtype}). This usually means a kernel is reading the "
+                f"weights with the other e4m3 bias. {m}"
+            ),
+        )


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3057


Validate that an NFP8 tensor's public dtype matches its owning GPU before creating the dispatch-only view. Preserve metadata-only relabeling for CPU/meta tensors, add direct correct-label, wrong-label, and CPU relabel coverage, and enable the existing ROCm NFP8 forward, cache, and backward tests only on supported CDNA architectures. Python dtype selection and kernel specialization remain in the lower diffs.

Reviewed By: echen4096

Differential Revision: D114977649


