### PR TITLE
Replace raw dispatcher thread with a named CPUThreadPoolExecutor

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
@@ -10,12 +10,17 @@
 #include <ATen/ATen.h>
 #ifdef FBGEMM_FBCODE
 #include <folly/coro/Task.h>
+#include <folly/futures/Future.h>
 #endif
 
 #include <utility>
 #include <vector>
 
 #ifdef FBGEMM_FBCODE
+namespace folly {
+class CPUThreadPoolExecutor;
+} // namespace folly
+
 namespace facebook::aiplatform::gmpp::experimental::training_ps {
 class TrainingPsOdsLogger;
 } // namespace facebook::aiplatform::gmpp::experimental::training_ps
@@ -98,7 +103,7 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
    * Join the pending dispatch (and the copy threads it spawned), making sure it
    * is properly finished before creating new.
    */
-  void join_stream_tensor_copy_thread();
+  void join_dispatch_and_workers();
 
 #ifdef FBGEMM_FBCODE
   folly::coro::Task<void> tensor_stream(
@@ -140,7 +145,10 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
   // and non-blocking stream() paths; this assumes a given table streams in a
   // single mode at a time (blocking OR non-blocking), never concurrently.
   std::vector<std::unique_ptr<std::thread>> chunk_copy_threads_;
-  std::unique_ptr<std::thread> dispatch_thread_;
+  // Persistent size-1 executor that runs the per-iteration dispatch (poll_flag
+  // + chunked_copy_and_enqueue). Named so its thread is identifiable in traces.
+  std::unique_ptr<folly::CPUThreadPoolExecutor> dispatch_executor_;
+  folly::SemiFuture<folly::Unit> dispatch_future_{folly::makeSemiFuture()};
   // OBC logger for RES silent-failure counters (res.fail.*). Emits to the
   // host-level OBC agent, so it reaches ODS from the trainer process without
   // per-process fb303 scrape config. Only constructed when streaming is on.
@@ -157,6 +165,24 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
       std::optional<at::Tensor> runtime_meta,
       const at::Tensor& count,
       std::vector<std::unique_ptr<std::thread>>& target_copy_threads);
+
+  // Waits (spinning) for copy_done_flag to signal the source tensors are safe
+  // to read, resetting it. Returns false on timeout. Shared by the blocking
+  // stream() path and dispatch_copy_task.
+  bool poll_copy_done_flag(const std::optional<at::Tensor>& copy_done_flag);
+
+  // Coroutine form of the non-blocking dispatch (poll_copy_done_flag +
+  // chunked_copy_and_enqueue). Args are taken by value so nothing dangles once
+  // it is scheduled on dispatch_executor_ -- a capturing lambda coroutine would
+  // risk a use-after-free (clang-tidy cppcoreguidelines-avoid-capturing-lambda-
+  // coroutines).
+  folly::coro::Task<void> dispatch_copy_task(
+      at::Tensor indices,
+      at::Tensor weights,
+      std::optional<at::Tensor> identities,
+      std::optional<at::Tensor> runtime_meta,
+      at::Tensor count,
+      std::optional<at::Tensor> copy_done_flag);
 #endif
 };
 

--- a/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
@@ -7,7 +7,11 @@
  */
 
 #ifdef FBGEMM_FBCODE
+#include <fmt/format.h>
 #include <folly/coro/BlockingWait.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/executors/thread_factory/NamedThreadFactory.h>
+#include <folly/futures/Future.h>
 #include <folly/stop_watch.h>
 #include <utility>
 #include "aiplatform/gmpp/experimental/training_ps/TrainingPsOdsLogger.h"
@@ -222,6 +226,17 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
     ods_logger_ = std::make_unique<facebook::aiplatform::gmpp::experimental::
                                        training_ps::TrainingPsOdsLogger>();
 
+    // Persistent size-1 executor that runs the non-blocking per-iteration
+    // dispatch (poll + chunked_copy_and_enqueue) as a coroutine, off the
+    // trainer thread. Named so its thread is identifiable in traces; the
+    // prefix is kept short because Linux caps thread names at 15 chars
+    // (pthread_setname_np) and NamedThreadFactory still appends a suffix, so a
+    // longer prefix would truncate unique_id_ away.
+    dispatch_executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
+        1,
+        std::make_unique<folly::NamedThreadFactory>(
+            fmt::format("RESDisp{}", unique_id_)));
+
     XLOG(INFO) << "[TBE_ID" << unique_id_ << "] Starting " << res_num_consumers_
                << " consumer threads"
                << ", chunk_size=" << res_chunk_size_
@@ -283,7 +298,13 @@ RawEmbeddingStreamer::~RawEmbeddingStreamer() {
   stop_ = true;
 #ifdef FBGEMM_FBCODE
   if (enable_raw_embedding_streaming_) {
-    join_stream_tensor_copy_thread();
+    join_dispatch_and_workers();
+    if (dispatch_executor_ != nullptr) {
+      dispatch_executor_->join();
+    }
+    // Normally a no-op: join_dispatch_and_workers() already joined the copy
+    // threads and no new ones can be spawned once the executor is joined. Kept
+    // as a belt-and-suspenders guard so destruction never races a stray thread.
     join_worker_threads();
     join_consumer_threads();
   }
@@ -316,21 +337,7 @@ void RawEmbeddingStreamer::stream(
     return;
   }
   auto poll_flag = [this, copy_done_flag]() {
-    if (copy_done_flag.has_value()) {
-      auto* ptr = static_cast<volatile int32_t*>(copy_done_flag->data_ptr());
-      folly::stop_watch<std::chrono::microseconds> poll_watch;
-      while (*ptr == 0) {
-        std::this_thread::yield();
-        if (poll_watch.elapsed().count() > kCopyDonePollTimeoutUs) {
-          LOG(ERROR) << "[TBE_ID" << unique_id_
-                     << "] copy_done_flag poll timed out after "
-                     << kCopyDonePollTimeoutUs / 1'000'000 << "s";
-          return false;
-        }
-      }
-      *ptr = 0;
-    }
-    return true;
+    return poll_copy_done_flag(copy_done_flag);
   };
 
   if (blocking_tensor_copy) {
@@ -350,42 +357,50 @@ void RawEmbeddingStreamer::stream(
   // Non-blocking: join the previous dispatch + copy threads, then spawn new
   // ones. The join is the serializer: it guarantees iter i's copy finished
   // reading the source cache rows before iter i+1 overwrites them.
-  join_stream_tensor_copy_thread();
-  dispatch_thread_ = std::make_unique<std::thread>(
-      [this, poll_flag, indices, weights, identities, runtime_meta, count]() {
-        // Guard the dispatcher body so a copy/enqueue failure logs instead of
-        // escaping the std::thread and calling std::terminate.
-        try {
-          if (!poll_flag()) {
-            return;
-          }
-          chunked_copy_and_enqueue(
-              indices,
-              weights,
-              identities,
-              runtime_meta,
-              count,
-              chunk_copy_threads_);
-        } catch (const std::exception& e) {
-          XLOG(ERR) << "[TBE_ID" << unique_id_
-                    << "] stream dispatcher thread caught exception: "
-                    << e.what();
-        } catch (...) {
-          XLOG(ERR) << "[TBE_ID" << unique_id_
-                    << "] stream dispatcher thread caught unknown exception";
-        }
-      });
+  join_dispatch_and_workers();
+  // Dispatch runs as a coroutine on the persistent size-1 executor; folly
+  // captures any exception into dispatch_future_, which is logged when the
+  // future is waited in join_dispatch_and_workers() (log-and-continue, never
+  // terminate).
+  TORCH_CHECK(
+      dispatch_executor_ != nullptr,
+      "dispatch_executor_ is only constructed when raw embedding streaming is "
+      "enabled; stream() must have early-returned otherwise");
+  dispatch_future_ = folly::coro::co_withExecutor(
+                         dispatch_executor_.get(),
+                         dispatch_copy_task(
+                             indices,
+                             weights,
+                             std::move(identities),
+                             std::move(runtime_meta),
+                             count,
+                             std::move(copy_done_flag)))
+                         .start();
   rec->record.end();
 #endif
 }
 
-void RawEmbeddingStreamer::join_stream_tensor_copy_thread() {
+void RawEmbeddingStreamer::join_dispatch_and_workers() {
 #ifdef FBGEMM_FBCODE
   auto rec = torch::autograd::profiler::record_function_enter_new(
-      "## RawEmbeddingStreamer::join_stream_tensor_copy_thread ##");
-  if (dispatch_thread_ != nullptr && dispatch_thread_->joinable()) {
-    dispatch_thread_->join();
+      "## RawEmbeddingStreamer::join_dispatch_and_workers ##");
+  // Wait the previous dispatch. Log-and-continue: an exception the dispatch
+  // deferred into the future must not escape (would std::terminate the
+  // trainer).
+  if (dispatch_future_.valid()) {
+    try {
+      std::move(dispatch_future_).get();
+    } catch (const std::exception& e) {
+      XLOG(ERR) << "[TBE_ID" << unique_id_
+                << "] stream dispatcher caught exception: " << e.what();
+    } catch (...) {
+      XLOG(ERR) << "[TBE_ID" << unique_id_
+                << "] stream dispatcher caught unknown exception";
+    }
+    dispatch_future_ = folly::makeSemiFuture();
   }
+  // The real torn-row barrier: iter i's copy must finish reading the source
+  // cache rows before iter i+1 overwrites them.
   join_worker_threads();
   rec->record.end();
 #endif
@@ -475,6 +490,56 @@ void RawEmbeddingStreamer::chunked_copy_and_enqueue(
       << "[RES] chunked_copy tbe=" << unique_id_ << " rows=" << num_rows
       << " threads=" << thread_chunks.size();
   rec->record.end();
+}
+
+bool RawEmbeddingStreamer::poll_copy_done_flag(
+    const std::optional<at::Tensor>& copy_done_flag) {
+  if (copy_done_flag.has_value()) {
+    auto* ptr = static_cast<volatile int32_t*>(copy_done_flag->data_ptr());
+    folly::stop_watch<std::chrono::microseconds> poll_watch;
+    while (*ptr == 0) {
+      std::this_thread::yield();
+      if (poll_watch.elapsed().count() > kCopyDonePollTimeoutUs) {
+        LOG(ERROR) << "[TBE_ID" << unique_id_
+                   << "] copy_done_flag poll timed out after "
+                   << kCopyDonePollTimeoutUs / 1'000'000 << "s";
+        return false;
+      }
+    }
+    *ptr = 0;
+  }
+  return true;
+}
+
+folly::coro::Task<void> RawEmbeddingStreamer::dispatch_copy_task(
+    at::Tensor indices,
+    at::Tensor weights,
+    std::optional<at::Tensor> identities,
+    std::optional<at::Tensor> runtime_meta,
+    at::Tensor count,
+    std::optional<at::Tensor> copy_done_flag) {
+  if (!poll_copy_done_flag(copy_done_flag)) {
+    co_return;
+  }
+  // Log at failure time instead of letting the exception ride dispatch_future_
+  // to the next join_dispatch_and_workers(): if streaming stalls right after a
+  // failure, that log would be delayed until the next iteration or the
+  // destructor. join_dispatch_and_workers()'s catch remains as a safety net.
+  try {
+    chunked_copy_and_enqueue(
+        indices,
+        weights,
+        std::move(identities),
+        std::move(runtime_meta),
+        count,
+        chunk_copy_threads_);
+  } catch (const std::exception& e) {
+    XLOG(ERR) << "[TBE_ID" << unique_id_
+              << "] stream dispatch caught exception: " << e.what();
+  } catch (...) {
+    XLOG(ERR) << "[TBE_ID" << unique_id_
+              << "] stream dispatch caught unknown exception";
+  }
 }
 
 folly::coro::Task<void> RawEmbeddingStreamer::tensor_stream(

--- a/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
@@ -91,47 +91,45 @@ fbgemm_gpu::StreamQueueItem tensor_copy_chunk(
   }
   auto new_count =
       at::empty({1}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  // Each tensor is copied under its own dispatch. They are independent copies,
+  // so there is no need to nest the dispatches (nesting would only reintroduce
+  // scalar_t shadowing and multiply template instantiations).
+  FBGEMM_DISPATCH_INTEGRAL_TYPES(
+      indices.scalar_type(), "tensor_copy_chunk", [&] {
+        std::copy(
+            indices.const_data_ptr<scalar_t>() + start_row,
+            indices.const_data_ptr<scalar_t>() + end_row,
+            new_indices.mutable_data_ptr<scalar_t>());
+      });
   FBGEMM_DISPATCH_FLOAT_HALF_AND_BYTE(
       weights.scalar_type(), "tensor_copy_chunk", [&] {
-        using value_t = scalar_t;
-        FBGEMM_DISPATCH_INTEGRAL_TYPES(
-            indices.scalar_type(), "tensor_copy_chunk", [&] {
-              using index_t = scalar_t;
-              std::copy(
-                  indices.const_data_ptr<index_t>() + start_row,
-                  indices.const_data_ptr<index_t>() + end_row,
-                  new_indices.mutable_data_ptr<index_t>());
-              std::copy(
-                  weights.const_data_ptr<value_t>() +
-                      start_row * weights.size(1),
-                  weights.const_data_ptr<value_t>() + end_row * weights.size(1),
-                  new_weights.mutable_data_ptr<value_t>());
-              if (identities.has_value()) {
-                FBGEMM_DISPATCH_INTEGRAL_TYPES(
-                    identities->scalar_type(), "tensor_copy_chunk", [&] {
-                      using id_t = scalar_t;
-                      std::copy(
-                          identities->const_data_ptr<id_t>() +
-                              start_row * identities->size(1),
-                          identities->const_data_ptr<id_t>() +
-                              end_row * identities->size(1),
-                          new_identities->mutable_data_ptr<id_t>());
-                    });
-              }
-              if (runtime_meta.has_value()) {
-                FBGEMM_DISPATCH_ALL_TYPES(
-                    runtime_meta->scalar_type(), "tensor_copy_chunk", [&] {
-                      using rm_t = scalar_t;
-                      std::copy(
-                          runtime_meta->const_data_ptr<rm_t>() +
-                              start_row * runtime_meta->size(1),
-                          runtime_meta->const_data_ptr<rm_t>() +
-                              end_row * runtime_meta->size(1),
-                          new_runtime_meta->mutable_data_ptr<rm_t>());
-                    });
-              }
-            });
+        std::copy(
+            weights.const_data_ptr<scalar_t>() + start_row * weights.size(1),
+            weights.const_data_ptr<scalar_t>() + end_row * weights.size(1),
+            new_weights.mutable_data_ptr<scalar_t>());
       });
+  if (identities.has_value()) {
+    FBGEMM_DISPATCH_INTEGRAL_TYPES(
+        identities->scalar_type(), "tensor_copy_chunk", [&] {
+          std::copy(
+              identities->const_data_ptr<scalar_t>() +
+                  start_row * identities->size(1),
+              identities->const_data_ptr<scalar_t>() +
+                  end_row * identities->size(1),
+              new_identities->mutable_data_ptr<scalar_t>());
+        });
+  }
+  if (runtime_meta.has_value()) {
+    FBGEMM_DISPATCH_ALL_TYPES(
+        runtime_meta->scalar_type(), "tensor_copy_chunk", [&] {
+          std::copy(
+              runtime_meta->const_data_ptr<scalar_t>() +
+                  start_row * runtime_meta->size(1),
+              runtime_meta->const_data_ptr<scalar_t>() +
+                  end_row * runtime_meta->size(1),
+              new_runtime_meta->mutable_data_ptr<scalar_t>());
+        });
+  }
   *new_count.mutable_data_ptr<int64_t>() = n;
   return fbgemm_gpu::StreamQueueItem{
       new_indices, new_weights, new_identities, new_runtime_meta, new_count};

--- a/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
@@ -120,8 +120,13 @@ auto raw_embedding_streamer =
                 torch::arg("blocking_tensor_copy"),
                 torch::arg("copy_done_flag") = std::nullopt,
             })
+        // The exposed name is kept as-is for backward compatibility: frozen
+        // fbgemm clones bundled with published models (pyper_models/.../
+        // archive/) still call join_stream_tensor_copy_thread() and are never
+        // updated. Only the C++ method name changes to reflect that it joins
+        // the dispatch, which in turn joins the copy threads.
         .def(
             "join_stream_tensor_copy_thread",
-            &fbgemm_gpu::RawEmbeddingStreamer::join_stream_tensor_copy_thread);
+            &fbgemm_gpu::RawEmbeddingStreamer::join_dispatch_and_workers);
 
 } // namespace

--- a/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
@@ -512,11 +512,11 @@ TEST(RawEmbeddingStreamerTest, TestStreamWithCopy) {
   EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 1);
 
   // Test non-blocking tensor copy. The copy runs on the dispatcher, so we must
-  // join_stream_tensor_copy_thread() before checking the queue -- asserting the
-  // size before the join would race the background copy.
+  // join_dispatch_and_workers() before checking the queue -- asserting the size
+  // before the join would race the background copy.
   streamer->stream(
       indices, weights, std::nullopt, std::nullopt, count, true, false);
-  streamer->join_stream_tensor_copy_thread();
+  streamer->join_dispatch_and_workers();
   EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 2);
 }
 
@@ -894,7 +894,7 @@ TEST(RawEmbeddingStreamerTest, TestStreamWithCopyDoneFlagNonBlockingCopy) {
       copy_done_flag);
 
   // Wait for the async thread to complete
-  streamer->join_stream_tensor_copy_thread();
+  streamer->join_dispatch_and_workers();
   EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 1);
   // poll_flag() must have observed the flag (1) and reset it to 0; without the
   // reset the next iteration would stream before the D2H copy finished.

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -340,9 +340,8 @@ void EmbeddingKVDB::stream_sync_cuda() {
       "## EmbeddingKVDB::stream_sync_cuda ##");
   // take reference to self to avoid lifetime issues.
   auto self = shared_from_this();
-  std::function<void()>* functor = new std::function<void()>([=]() {
-    self->raw_embedding_streamer_->join_stream_tensor_copy_thread();
-  });
+  std::function<void()>* functor = new std::function<void()>(
+      [=]() { self->raw_embedding_streamer_->join_dispatch_and_workers(); });
   AT_CUDA_CHECK(cudaLaunchHostFunc(
       at::cuda::getCurrentCUDAStream(), kv_db_utils::cuda_host_func, functor));
   rec->record.end();


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2978

Replace the per-iteration raw std::thread in the non-blocking stream() dispatch with a persistent named size-1 folly::CPUThreadPoolExecutor + SemiFuture. Kills per-iter thread create/join churn, names the thread in traces, and removes the raw-thread std::terminate risk (folly captures exceptions into the future)

Reviewed By: chouxi

Differential Revision: D113669440


