### PR TITLE
Ship shard RPCs to TrainingPs in parallel

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
@@ -113,16 +113,15 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
       std::optional<at::Tensor> runtime_meta);
 
   /*
-   * FOR TESTING ONLY: latches stop_ so the consumer threads exit, letting a
-   * test read a stable queue size. Not reversible -- the streamer stops
-   * consuming after this call.
+   * FOR TESTING ONLY: drops the ship executor to 0 worker threads so a test can
+   * read a stable queue size (via get_weights_to_stream_queue_size()). Not
+   * reversible -- the executor stops shipping after this call.
    */
   void join_weights_stream_thread();
   // FOR TESTING: get queue size.
   uint64_t get_weights_to_stream_queue_size();
 #endif
  private:
-  std::atomic<bool> stop_{false};
   std::string unique_id_;
   bool enable_raw_embedding_streaming_;
 #ifdef FBGEMM_FBCODE
@@ -138,9 +137,10 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
   size_t res_num_copy_threads_;
 #endif
 #ifdef FBGEMM_FBCODE
-  // Multi-threaded consumers for tensor_stream() RPCs.
-  std::vector<std::unique_ptr<std::thread>> consumer_threads_;
-  folly::UMPMCQueue<StreamQueueItem, true> weights_to_stream_queue_;
+  // Named executor that ships enqueued StreamQueueItems to the PS. Push model:
+  // producers submit one ship task per item and workers wake on submit (no
+  // polling). Sized to res_num_consumers_.
+  std::unique_ptr<folly::CPUThreadPoolExecutor> consumer_executor_;
   // Copy threads for UVM cache (joined every iteration). Shared by the blocking
   // and non-blocking stream() paths; this assumes a given table streams in a
   // single mode at a time (blocking OR non-blocking), never concurrently.
@@ -157,7 +157,9 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
       ods_logger_;
 
   void join_worker_threads();
-  void join_consumer_threads();
+  // Submit one ship task (blockingWait(tensor_stream(...))) for `item` onto
+  // consumer_executor_.
+  void submit_stream_item(StreamQueueItem item);
   void chunked_copy_and_enqueue(
       const at::Tensor& indices,
       const at::Tensor& weights,

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
@@ -10,12 +10,17 @@
 #include <ATen/ATen.h>
 #ifdef FBGEMM_FBCODE
 #include <folly/coro/Task.h>
+#include <folly/futures/Future.h>
 #endif
 
 #include <utility>
 #include <vector>
 
 #ifdef FBGEMM_FBCODE
+namespace folly {
+class CPUThreadPoolExecutor;
+} // namespace folly
+
 namespace facebook::aiplatform::gmpp::experimental::training_ps {
 class TrainingPsOdsLogger;
 } // namespace facebook::aiplatform::gmpp::experimental::training_ps
@@ -98,7 +103,7 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
    * Join the pending dispatch (and the copy threads it spawned), making sure it
    * is properly finished before creating new.
    */
-  void join_stream_tensor_copy_thread();
+  void join_dispatch_and_workers();
 
 #ifdef FBGEMM_FBCODE
   folly::coro::Task<void> tensor_stream(
@@ -140,7 +145,10 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
   // and non-blocking stream() paths; this assumes a given table streams in a
   // single mode at a time (blocking OR non-blocking), never concurrently.
   std::vector<std::unique_ptr<std::thread>> chunk_copy_threads_;
-  std::unique_ptr<std::thread> dispatch_thread_;
+  // Persistent size-1 executor that runs the per-iteration dispatch (poll_flag
+  // + chunked_copy_and_enqueue). Named so its thread is identifiable in traces.
+  std::unique_ptr<folly::CPUThreadPoolExecutor> dispatch_executor_;
+  folly::SemiFuture<folly::Unit> dispatch_future_{folly::makeSemiFuture()};
   // OBC logger for RES silent-failure counters (res.fail.*). Emits to the
   // host-level OBC agent, so it reaches ODS from the trainer process without
   // per-process fb303 scrape config. Only constructed when streaming is on.
@@ -157,6 +165,24 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
       std::optional<at::Tensor> runtime_meta,
       const at::Tensor& count,
       std::vector<std::unique_ptr<std::thread>>& target_copy_threads);
+
+  // Waits (spinning) for copy_done_flag to signal the source tensors are safe
+  // to read, resetting it. Returns false on timeout. Shared by the blocking
+  // stream() path and dispatch_copy_task.
+  bool poll_copy_done_flag(const std::optional<at::Tensor>& copy_done_flag);
+
+  // Coroutine form of the non-blocking dispatch (poll_copy_done_flag +
+  // chunked_copy_and_enqueue). Args are taken by value so nothing dangles once
+  // it is scheduled on dispatch_executor_ -- a capturing lambda coroutine would
+  // risk a use-after-free (clang-tidy cppcoreguidelines-avoid-capturing-lambda-
+  // coroutines).
+  folly::coro::Task<void> dispatch_copy_task(
+      at::Tensor indices,
+      at::Tensor weights,
+      std::optional<at::Tensor> identities,
+      std::optional<at::Tensor> runtime_meta,
+      at::Tensor count,
+      std::optional<at::Tensor> copy_done_flag);
 #endif
 };
 

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
@@ -62,7 +62,8 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
       // experimentation; too many consumer threads per TBE may be wasteful --
       // tune via experiments.
       int64_t res_num_consumers = 8,
-      int64_t res_num_copy_threads = 4);
+      int64_t res_num_copy_threads = 4,
+      int64_t res_num_hbm_copy_threads = 4);
 
   ~RawEmbeddingStreamer() override;
 
@@ -72,8 +73,8 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
   /// weights, and the optional identities / runtime_meta) to CPU and injects
   /// them into the background queue, which is drained by a pool of consumer
   /// threads that stream out to the thrift server (co-located on same host
-  /// now). The copy is split into <= res_chunk_size-row chunks across up to
-  /// res_num_copy_threads copy threads.
+  /// now). The copy is split into <= res_chunk_size-row chunks that run
+  /// concurrently across the res_num_copy_threads-worker copy pool.
   ///
   /// This is used in cuda stream callback, which doesn't require to be
   /// serialized with other callbacks, thus a separate thread is used to
@@ -87,6 +88,14 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
   /// to be processed
   /// @param blocking_tensor_copy whether to copy the tensors to be streamed in
   /// a blocking manner
+  /// @param use_hbm route a stream onto the dedicated HBM path: the
+  /// non-blocking path joins/assigns the separate HBM dispatch future
+  /// (hbm_dispatch_future_) on hbm_dispatch_executor_ instead of the main
+  /// cache-hit one, and the copies fan out on the dedicated hbm_copy_executor_
+  /// instead of the shared copy_executor_, so HBM/UVM-miss drain does not
+  /// interfere with cache-hit streaming at the dispatch or copy level. Only the
+  /// ship path (consumer_executor_) stays shared. Defaults false (main path) --
+  /// inert until an out-of-scope caller opts in.
   ///
   /// @return None
   void stream(
@@ -97,13 +106,24 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
       const at::Tensor& count,
       bool require_tensor_copy,
       bool blocking_tensor_copy = true,
-      std::optional<at::Tensor> copy_done_flag = std::nullopt);
+      std::optional<at::Tensor> copy_done_flag = std::nullopt,
+      bool use_hbm = false);
 
   /*
-   * Join the pending dispatch (and the copy threads it spawned), making sure it
-   * is properly finished before creating new.
+   * Join the pending dispatch future (which resolves only after all copies for
+   * the previous iteration have been enqueued), making sure it is properly
+   * finished before creating new.
    */
   void join_dispatch_and_workers();
+
+  /*
+   * HBM-path counterpart of join_dispatch_and_workers(): wait the pending HBM
+   * dispatch future, which resolves only after its chunked_copy_and_enqueue
+   * collectAllRange completes -- i.e. after the copy workers on
+   * hbm_copy_executor_ finish. The executor itself is drained in the destructor
+   * (join()); this call is the per-iteration wait for that copy work.
+   */
+  void join_hbm_dispatch_and_workers();
 
 #ifdef FBGEMM_FBCODE
   folly::coro::Task<void> tensor_stream(
@@ -135,20 +155,37 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
   size_t res_chunk_size_;
   size_t res_num_consumers_;
   size_t res_num_copy_threads_;
+  size_t res_num_hbm_copy_threads_;
 #endif
 #ifdef FBGEMM_FBCODE
   // Named executor that ships enqueued StreamQueueItems to the PS. Push model:
   // producers submit one ship task per item and workers wake on submit (no
   // polling). Sized to res_num_consumers_.
   std::unique_ptr<folly::CPUThreadPoolExecutor> consumer_executor_;
-  // Copy threads for UVM cache (joined every iteration). Shared by the blocking
-  // and non-blocking stream() paths; this assumes a given table streams in a
-  // single mode at a time (blocking OR non-blocking), never concurrently.
-  std::vector<std::unique_ptr<std::thread>> chunk_copy_threads_;
+  // Persistent pool that runs the per-chunk tensor copies (CPU-bound
+  // std::copy), sized res_num_copy_threads_ so chunks run concurrently. Used by
+  // the blocking and non-blocking main (cache-hit) stream() paths; this assumes
+  // a given table streams in a single mode at a time (blocking OR
+  // non-blocking), never concurrently.
+  std::unique_ptr<folly::CPUThreadPoolExecutor> copy_executor_;
+  // Dedicated HBM copy pool sized res_num_hbm_copy_threads_, so HBM copies
+  // don't contend with hit copies for the shared pool and delay the other
+  // lane's read-before-overwrite barrier.
+  std::unique_ptr<folly::CPUThreadPoolExecutor> hbm_copy_executor_;
   // Persistent size-1 executor that runs the per-iteration dispatch (poll_flag
   // + chunked_copy_and_enqueue). Named so its thread is identifiable in traces.
   std::unique_ptr<folly::CPUThreadPoolExecutor> dispatch_executor_;
+  // Size-1 executor dedicated to the HBM path's dispatch coroutine, so a
+  // hit-path poll_copy_done_flag spin can't hold the only dispatch worker and
+  // stall HBM drain.
+  std::unique_ptr<folly::CPUThreadPoolExecutor> hbm_dispatch_executor_;
   folly::SemiFuture<folly::Unit> dispatch_future_{folly::makeSemiFuture()};
+  // Second dispatch future for the HBM path. The HBM path runs on its own
+  // hbm_dispatch_executor_ + hbm_copy_executor_, so it does not contend with
+  // the main path at the dispatch or copy level; the only shared resource is
+  // the ship path (consumer_executor_). This future is the per-lane state that
+  // stream() joins/assigns.
+  folly::SemiFuture<folly::Unit> hbm_dispatch_future_{folly::makeSemiFuture()};
   // OBC logger for RES silent-failure counters (res.fail.*). Emits to the
   // host-level OBC agent, so it reaches ODS from the trainer process without
   // per-process fb303 scrape config. Only constructed when streaming is on.
@@ -156,17 +193,35 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
                       TrainingPsOdsLogger>
       ods_logger_;
 
-  void join_worker_threads();
   // Submit one ship task (blockingWait(tensor_stream(...))) for `item` onto
   // consumer_executor_.
   void submit_stream_item(StreamQueueItem item);
-  void chunked_copy_and_enqueue(
-      const at::Tensor& indices,
-      const at::Tensor& weights,
+  // Copies `count` rows of the source tensors into CPU chunks and enqueues each
+  // via submit_stream_item, fanning the per-chunk copies out across the
+  // selected copy pool (hbm_copy_executor_ when use_hbm, else copy_executor_)
+  // and awaiting them all (the read-before-overwrite barrier). A coroutine so
+  // the non-blocking dispatch can co_await it; tensor args are by value so
+  // nothing dangles once a chunk is scheduled.
+  folly::coro::Task<void> chunked_copy_and_enqueue(
+      at::Tensor indices,
+      at::Tensor weights,
       std::optional<at::Tensor> identities,
       std::optional<at::Tensor> runtime_meta,
-      const at::Tensor& count,
-      std::vector<std::unique_ptr<std::thread>>& target_copy_threads);
+      at::Tensor count,
+      bool use_hbm);
+  // Copies one chunk [start, end) and enqueues it via submit_stream_item. Runs
+  // to completion on a single copy_executor_ worker; the per-chunk try/catch
+  // keeps an exception from escaping into collectAllRange (which awaits every
+  // sibling to completion and then rethrows one exception onto the blocking
+  // caller / dispatch future). By value for the same reason as
+  // chunked_copy_and_enqueue.
+  folly::coro::Task<void> copy_chunk_task(
+      at::Tensor indices,
+      at::Tensor weights,
+      std::optional<at::Tensor> identities,
+      std::optional<at::Tensor> runtime_meta,
+      int64_t start,
+      int64_t end);
 
   // Waits (spinning) for copy_done_flag to signal the source tensors are safe
   // to read, resetting it. Returns false on timeout. Shared by the blocking
@@ -184,7 +239,8 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
       std::optional<at::Tensor> identities,
       std::optional<at::Tensor> runtime_meta,
       at::Tensor count,
-      std::optional<at::Tensor> copy_done_flag);
+      std::optional<at::Tensor> copy_done_flag,
+      bool use_hbm);
 #endif
 };
 
@@ -196,13 +252,12 @@ fbgemm_gpu::StreamQueueItem tensor_copy_chunk(
     int64_t start_row,
     int64_t end_row);
 
-// Tiles [0, num_rows) into per-thread groups of [start, end) chunk ranges, each
-// chunk of size <= chunk_size, contiguous and non-overlapping (union is the
-// whole range). The outer index is the thread; each inner vector is that
-// thread's contiguous band split into chunks. Empty bands produce no group.
-// Pure/build-agnostic so it is unit-testable without a GPU or FBGEMM_FBCODE.
-// num_threads bounds how the rows are pre-split before chunking, matching
-// chunked_copy_and_enqueue's tiling.
-std::vector<std::vector<std::pair<int64_t, int64_t>>>
-computeChunkRanges(int64_t num_rows, size_t chunk_size, size_t num_threads);
+// Tiles [0, num_rows) into flat [start, end) chunks of size <= chunk_size,
+// contiguous and non-overlapping (their union is the whole range). One task per
+// chunk is submitted to copy_executor_, which load-balances them across its
+// workers. Pure/build-agnostic so it is unit-testable without a GPU or
+// FBGEMM_FBCODE.
+std::vector<std::pair<int64_t, int64_t>> computeChunks(
+    int64_t num_rows,
+    size_t chunk_size);
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
@@ -57,6 +57,73 @@ get_res_client(int64_t res_server_port) {
       "realtime.delta.publish.esr", params);
 }
 
+// One shard's prepared request, built up front so the ship section is pure I/O.
+struct ShardReq {
+  int shard_id{0};
+  ::aiplatform::gmpp::experimental::training_ps::SetEmbeddingsRequest req;
+};
+
+// Per-shard RPC timing recorded by ship_one_shard for the tensor_stream
+// breakdown log.
+struct ShardTiming {
+  int shard_id{0};
+  int64_t rpc_ms{0};
+};
+
+// Ship one shard's SetEmbeddingsRequest and record its timing. A named
+// coroutine (not a capturing lambda) so every input is owned by the coroutine
+// frame and nothing dangles across the co_await -- the capture-free form the
+// cppcoreguidelines-avoid-capturing-lambda-coroutines rule requires. Isolates
+// its own failure: an RPC throw is logged/counted and swallowed, so it neither
+// cancels its still-in-flight siblings under collectAllRange nor escapes the
+// ship task.
+folly::coro::Task<void> ship_one_shard(
+    apache::thrift::Client<::aiplatform::gmpp::experimental::training_ps::
+                               TrainingParameterServerService>* client,
+    ::aiplatform::gmpp::experimental::training_ps::SetEmbeddingsRequest req,
+    int shard_id,
+    std::string unique_id,
+    facebook::aiplatform::gmpp::experimental::training_ps::TrainingPsOdsLogger*
+        ods_logger,
+    std::shared_ptr<std::vector<ShardTiming>> timings,
+    size_t idx) {
+  folly::stop_watch<std::chrono::milliseconds> sw;
+  try {
+    co_await client->co_setEmbeddings(req);
+  } catch (const std::exception& e) {
+    if (ods_logger != nullptr) {
+      ods_logger->bumpKey("set_embeddings_rpc_failure", 1);
+    }
+    XLOG(ERR) << "[TBE_ID" << unique_id << "] co_setEmbeddings threw on shard "
+              << shard_id << ": " << e.what();
+  }
+  (*timings)[idx] = ShardTiming{shard_id, sw.elapsed().count()};
+}
+
+// Find the slowest shard and emit a rate-limited tensor_stream timing
+// breakdown.
+void log_shard_ship_breakdown(
+    const std::string& unique_id,
+    const std::vector<ShardTiming>& shard_timings,
+    int64_t total_rpc_ms,
+    int64_t total_rows,
+    int64_t num_shards) {
+  int64_t max_shard_ms = 0;
+  std::optional<int> max_shard_id;
+  for (const auto& st : shard_timings) {
+    if (!max_shard_id || st.rpc_ms > max_shard_ms) {
+      max_shard_ms = st.rpc_ms;
+      max_shard_id = st.shard_id;
+    }
+  }
+  XLOG_EVERY_MS(INFO, 15000)
+      << "[TBE_ID" << unique_id
+      << "] tensor_stream breakdown: total_rpc_ms=" << total_rpc_ms
+      << " max_shard_ms=" << max_shard_ms
+      << " max_shard_id=" << max_shard_id.value_or(-1) << " rows=" << total_rows
+      << " shards=" << num_shards << " parallel_rpcs=" << shard_timings.size();
+}
+
 /// Read a scalar value from a tensor that is maybe a UVM tensor
 /// Note that `tensor.item<type>()` is not allowed on a UVM tensor in
 /// PyTorch
@@ -679,7 +746,10 @@ folly::coro::Task<void> RawEmbeddingStreamer::tensor_stream(
   stop_watch.reset();
 
   auto res_client = get_res_client(res_server_port_);
-  // 2. Split by shards
+  // 2. Split by shards -- prepare every shard's request up front so the
+  // subsequent ship section is pure I/O with nothing serialized between RPCs.
+  std::vector<ShardReq> shard_requests;
+  shard_requests.reserve(res_store_shards_);
   for (int i = 0; i < res_store_shards_; ++i) {
     auto shard_mask = shard_indices_tensor.eq(i).nonzero().squeeze();
     auto table_indices_masked = table_indices.index_select(0, shard_mask);
@@ -722,20 +792,36 @@ folly::coro::Task<void> RawEmbeddingStreamer::tensor_stream(
       req.runtimeMeta() =
           torch::distributed::wireDumpTensor(runtime_meta_masked);
     }
-    try {
-      co_await res_client->co_setEmbeddings(req);
-    } catch (const std::exception& e) {
-      // A transient per-shard RPC failure must not propagate: it would tear
-      // down the consumer thread (std::terminate). Log, bump the counter, and
-      // move on to the next shard.
-      if (ods_logger_) {
-        ods_logger_->bumpKey("set_embeddings_rpc_failure", 1);
-      }
-      XLOG(ERR) << "[TBE_ID" << unique_id_
-                << "] co_setEmbeddings threw on shard " << i << ": "
-                << e.what();
-    }
+    shard_requests.push_back(ShardReq{i, std::move(req)});
   }
+
+  // 3. Ship every shard RPC in parallel (all suspended on co_setEmbeddings at
+  // once, so their round-trips overlap), tracking per-shard timing. Each task
+  // isolates its own failure: a shard whose RPC throws is logged and counted,
+  // and the task completes normally WITHOUT propagating -- so one dead shard
+  // neither cancels its still-in-flight siblings (as a bare collectAllRange
+  // over throwing tasks would) nor escapes the ship task.
+  auto shard_timings =
+      std::make_shared<std::vector<ShardTiming>>(shard_requests.size());
+  folly::stop_watch<std::chrono::milliseconds> rpc_sw;
+  std::vector<folly::coro::Task<void>> rpc_tasks;
+  rpc_tasks.reserve(shard_requests.size());
+  for (size_t idx = 0; idx < shard_requests.size(); ++idx) {
+    auto& shard_request = shard_requests[idx];
+    rpc_tasks.push_back(ship_one_shard(
+        res_client.get(),
+        std::move(shard_request.req),
+        shard_request.shard_id,
+        unique_id_,
+        ods_logger_.get(),
+        shard_timings,
+        idx));
+  }
+  co_await folly::coro::collectAllRange(std::move(rpc_tasks));
+  const auto total_rpc_ms = rpc_sw.elapsed().count();
+
+  log_shard_ship_breakdown(
+      unique_id_, *shard_timings, total_rpc_ms, total_rows, res_store_shards_);
   co_return;
 }
 

--- a/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
@@ -7,7 +7,11 @@
  */
 
 #ifdef FBGEMM_FBCODE
+#include <fmt/format.h>
 #include <folly/coro/BlockingWait.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/executors/thread_factory/NamedThreadFactory.h>
+#include <folly/futures/Future.h>
 #include <folly/stop_watch.h>
 #include <utility>
 #include "aiplatform/gmpp/experimental/training_ps/TrainingPsOdsLogger.h"
@@ -222,6 +226,17 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
     ods_logger_ = std::make_unique<facebook::aiplatform::gmpp::experimental::
                                        training_ps::TrainingPsOdsLogger>();
 
+    // Persistent size-1 executor that runs the non-blocking per-iteration
+    // dispatch (poll + chunked_copy_and_enqueue) as a coroutine, off the
+    // trainer thread. Named so its thread is identifiable in traces; the
+    // prefix is kept short because Linux caps thread names at 15 chars
+    // (pthread_setname_np) and NamedThreadFactory still appends a suffix, so a
+    // longer prefix would truncate unique_id_ away.
+    dispatch_executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
+        1,
+        std::make_unique<folly::NamedThreadFactory>(
+            fmt::format("RESDisp{}", unique_id_)));
+
     XLOG(INFO) << "[TBE_ID" << unique_id_ << "] Starting " << res_num_consumers_
                << " consumer threads"
                << ", chunk_size=" << res_chunk_size_
@@ -283,7 +298,13 @@ RawEmbeddingStreamer::~RawEmbeddingStreamer() {
   stop_ = true;
 #ifdef FBGEMM_FBCODE
   if (enable_raw_embedding_streaming_) {
-    join_stream_tensor_copy_thread();
+    join_dispatch_and_workers();
+    if (dispatch_executor_ != nullptr) {
+      dispatch_executor_->join();
+    }
+    // Normally a no-op: join_dispatch_and_workers() already joined the copy
+    // threads and no new ones can be spawned once the executor is joined. Kept
+    // as a belt-and-suspenders guard so destruction never races a stray thread.
     join_worker_threads();
     join_consumer_threads();
   }
@@ -316,21 +337,7 @@ void RawEmbeddingStreamer::stream(
     return;
   }
   auto poll_flag = [this, copy_done_flag]() {
-    if (copy_done_flag.has_value()) {
-      auto* ptr = static_cast<volatile int32_t*>(copy_done_flag->data_ptr());
-      folly::stop_watch<std::chrono::microseconds> poll_watch;
-      while (*ptr == 0) {
-        std::this_thread::yield();
-        if (poll_watch.elapsed().count() > kCopyDonePollTimeoutUs) {
-          LOG(ERROR) << "[TBE_ID" << unique_id_
-                     << "] copy_done_flag poll timed out after "
-                     << kCopyDonePollTimeoutUs / 1'000'000 << "s";
-          return false;
-        }
-      }
-      *ptr = 0;
-    }
-    return true;
+    return poll_copy_done_flag(copy_done_flag);
   };
 
   if (blocking_tensor_copy) {
@@ -350,42 +357,50 @@ void RawEmbeddingStreamer::stream(
   // Non-blocking: join the previous dispatch + copy threads, then spawn new
   // ones. The join is the serializer: it guarantees iter i's copy finished
   // reading the source cache rows before iter i+1 overwrites them.
-  join_stream_tensor_copy_thread();
-  dispatch_thread_ = std::make_unique<std::thread>(
-      [this, poll_flag, indices, weights, identities, runtime_meta, count]() {
-        // Guard the dispatcher body so a copy/enqueue failure logs instead of
-        // escaping the std::thread and calling std::terminate.
-        try {
-          if (!poll_flag()) {
-            return;
-          }
-          chunked_copy_and_enqueue(
-              indices,
-              weights,
-              identities,
-              runtime_meta,
-              count,
-              chunk_copy_threads_);
-        } catch (const std::exception& e) {
-          XLOG(ERR) << "[TBE_ID" << unique_id_
-                    << "] stream dispatcher thread caught exception: "
-                    << e.what();
-        } catch (...) {
-          XLOG(ERR) << "[TBE_ID" << unique_id_
-                    << "] stream dispatcher thread caught unknown exception";
-        }
-      });
+  join_dispatch_and_workers();
+  // Dispatch runs as a coroutine on the persistent size-1 executor; folly
+  // captures any exception into dispatch_future_, which is logged when the
+  // future is waited in join_dispatch_and_workers() (log-and-continue, never
+  // terminate).
+  TORCH_CHECK(
+      dispatch_executor_ != nullptr,
+      "dispatch_executor_ is only constructed when raw embedding streaming is "
+      "enabled; stream() must have early-returned otherwise");
+  dispatch_future_ = folly::coro::co_withExecutor(
+                         dispatch_executor_.get(),
+                         dispatch_copy_task(
+                             indices,
+                             weights,
+                             std::move(identities),
+                             std::move(runtime_meta),
+                             count,
+                             std::move(copy_done_flag)))
+                         .start();
   rec->record.end();
 #endif
 }
 
-void RawEmbeddingStreamer::join_stream_tensor_copy_thread() {
+void RawEmbeddingStreamer::join_dispatch_and_workers() {
 #ifdef FBGEMM_FBCODE
   auto rec = torch::autograd::profiler::record_function_enter_new(
-      "## RawEmbeddingStreamer::join_stream_tensor_copy_thread ##");
-  if (dispatch_thread_ != nullptr && dispatch_thread_->joinable()) {
-    dispatch_thread_->join();
+      "## RawEmbeddingStreamer::join_dispatch_and_workers ##");
+  // Wait the previous dispatch. Log-and-continue: an exception the dispatch
+  // deferred into the future must not escape (would std::terminate the
+  // trainer).
+  if (dispatch_future_.valid()) {
+    try {
+      std::move(dispatch_future_).get();
+    } catch (const std::exception& e) {
+      XLOG(ERR) << "[TBE_ID" << unique_id_
+                << "] stream dispatcher caught exception: " << e.what();
+    } catch (...) {
+      XLOG(ERR) << "[TBE_ID" << unique_id_
+                << "] stream dispatcher caught unknown exception";
+    }
+    dispatch_future_ = folly::makeSemiFuture();
   }
+  // The real torn-row barrier: iter i's copy must finish reading the source
+  // cache rows before iter i+1 overwrites them.
   join_worker_threads();
   rec->record.end();
 #endif
@@ -475,6 +490,56 @@ void RawEmbeddingStreamer::chunked_copy_and_enqueue(
       << "[RES] chunked_copy tbe=" << unique_id_ << " rows=" << num_rows
       << " threads=" << thread_chunks.size();
   rec->record.end();
+}
+
+bool RawEmbeddingStreamer::poll_copy_done_flag(
+    const std::optional<at::Tensor>& copy_done_flag) {
+  if (copy_done_flag.has_value()) {
+    auto* ptr = static_cast<volatile int32_t*>(copy_done_flag->data_ptr());
+    folly::stop_watch<std::chrono::microseconds> poll_watch;
+    while (*ptr == 0) {
+      std::this_thread::yield();
+      if (poll_watch.elapsed().count() > kCopyDonePollTimeoutUs) {
+        LOG(ERROR) << "[TBE_ID" << unique_id_
+                   << "] copy_done_flag poll timed out after "
+                   << kCopyDonePollTimeoutUs / 1'000'000 << "s";
+        return false;
+      }
+    }
+    *ptr = 0;
+  }
+  return true;
+}
+
+folly::coro::Task<void> RawEmbeddingStreamer::dispatch_copy_task(
+    at::Tensor indices,
+    at::Tensor weights,
+    std::optional<at::Tensor> identities,
+    std::optional<at::Tensor> runtime_meta,
+    at::Tensor count,
+    std::optional<at::Tensor> copy_done_flag) {
+  if (!poll_copy_done_flag(copy_done_flag)) {
+    co_return;
+  }
+  // Log at failure time instead of letting the exception ride dispatch_future_
+  // to the next join_dispatch_and_workers(): if streaming stalls right after a
+  // failure, that log would be delayed until the next iteration or the
+  // destructor. join_dispatch_and_workers()'s catch remains as a safety net.
+  try {
+    chunked_copy_and_enqueue(
+        indices,
+        weights,
+        std::move(identities),
+        std::move(runtime_meta),
+        count,
+        chunk_copy_threads_);
+  } catch (const std::exception& e) {
+    XLOG(ERR) << "[TBE_ID" << unique_id_
+              << "] stream dispatch caught exception: " << e.what();
+  } catch (...) {
+    XLOG(ERR) << "[TBE_ID" << unique_id_
+              << "] stream dispatch caught unknown exception";
+  }
 }
 
 folly::coro::Task<void> RawEmbeddingStreamer::tensor_stream(

--- a/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
@@ -9,6 +9,8 @@
 #ifdef FBGEMM_FBCODE
 #include <fmt/format.h>
 #include <folly/coro/BlockingWait.h>
+#include <folly/coro/Collect.h>
+#include <folly/coro/Task.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/executors/thread_factory/NamedThreadFactory.h>
 #include <folly/futures/Future.h>
@@ -139,39 +141,20 @@ fbgemm_gpu::StreamQueueItem tensor_copy_chunk(
       new_indices, new_weights, new_identities, new_runtime_meta, new_count};
 }
 
-std::vector<std::vector<std::pair<int64_t, int64_t>>>
-computeChunkRanges(int64_t num_rows, size_t chunk_size, size_t num_threads) {
-  // Split [0, num_rows) across up to num_threads contiguous per-thread bands,
-  // then split each band into <= chunk_size chunks. Returns one inner vector of
-  // [start, end) chunk ranges per thread (outer index = thread); ranges are
-  // contiguous, non-overlapping, and their union is the whole range. Empty
-  // bands produce no group.
-  std::vector<std::vector<std::pair<int64_t, int64_t>>> thread_chunks;
-  if (num_rows <= 0 || chunk_size == 0 || num_threads == 0) {
-    return thread_chunks;
+std::vector<std::pair<int64_t, int64_t>> computeChunks(
+    int64_t num_rows,
+    size_t chunk_size) {
+  // Split [0, num_rows) into flat [start, end) chunks of <= chunk_size rows;
+  // chunks are contiguous, non-overlapping, and their union is the whole range.
+  std::vector<std::pair<int64_t, int64_t>> chunks;
+  if (num_rows <= 0 || chunk_size == 0) {
+    return chunks;
   }
-  // ceil-div (a + b - 1) / b: rounds up so a partial final chunk/band counts.
-  const size_t n_chunks =
-      (static_cast<size_t>(num_rows) + chunk_size - 1) / chunk_size;
-  const size_t n_threads = std::min(n_chunks, num_threads);
-  const size_t rows_per_thread =
-      (static_cast<size_t>(num_rows) + n_threads - 1) / n_threads;
-  for (size_t ti = 0; ti < n_threads; ++ti) {
-    const int64_t thread_start = static_cast<int64_t>(ti * rows_per_thread);
-    const int64_t thread_end =
-        std::min(static_cast<int64_t>((ti + 1) * rows_per_thread), num_rows);
-    std::vector<std::pair<int64_t, int64_t>> chunks;
-    for (int64_t s = thread_start; s < thread_end;
-         s += static_cast<int64_t>(chunk_size)) {
-      const int64_t e =
-          std::min(s + static_cast<int64_t>(chunk_size), thread_end);
-      chunks.emplace_back(s, e);
-    }
-    if (!chunks.empty()) {
-      thread_chunks.push_back(std::move(chunks));
-    }
+  for (int64_t s = 0; s < num_rows; s += static_cast<int64_t>(chunk_size)) {
+    const int64_t e = std::min(s + static_cast<int64_t>(chunk_size), num_rows);
+    chunks.emplace_back(s, e);
   }
-  return thread_chunks;
+  return chunks;
 }
 
 RawEmbeddingStreamer::RawEmbeddingStreamer(
@@ -184,7 +167,8 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
     const std::vector<int64_t>& table_sizes,
     int64_t res_chunk_size [[maybe_unused]],
     int64_t res_num_consumers [[maybe_unused]],
-    int64_t res_num_copy_threads [[maybe_unused]])
+    int64_t res_num_copy_threads [[maybe_unused]],
+    int64_t res_num_hbm_copy_threads [[maybe_unused]])
     : unique_id_(std::move(unique_id)),
       enable_raw_embedding_streaming_(enable_raw_embedding_streaming),
 #ifdef FBGEMM_FBCODE
@@ -198,7 +182,8 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
       ,
       res_chunk_size_(res_chunk_size),
       res_num_consumers_(res_num_consumers),
-      res_num_copy_threads_(res_num_copy_threads)
+      res_num_copy_threads_(res_num_copy_threads),
+      res_num_hbm_copy_threads_(res_num_hbm_copy_threads)
 #endif
 {
 #ifdef FBGEMM_FBCODE
@@ -206,17 +191,21 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
     // Fail loud on a misconfigured knob. These are now caller-supplied (were
     // compile-time constants), and 0 -- or a negative that wrapped to a huge
     // size_t -- would silently break streaming: res_num_consumers=0 spawns no
-    // drain threads (queue grows unbounded), res_chunk_size=0 /
-    // res_num_copy_threads=0 make computeChunkRanges return empty (enqueues
-    // nothing). Reject rather than silently no-op.
+    // drain threads (queue grows unbounded), res_chunk_size=0 makes
+    // computeChunks return empty (enqueues nothing), res_num_copy_threads=0
+    // sizes copy_executor_ to zero workers (copy tasks never run). Reject
+    // rather than silently no-op.
     TORCH_CHECK(
-        res_chunk_size > 0 && res_num_consumers > 0 && res_num_copy_threads > 0,
+        res_chunk_size > 0 && res_num_consumers > 0 &&
+            res_num_copy_threads > 0 && res_num_hbm_copy_threads > 0,
         "RES config knobs must be > 0: res_chunk_size=",
         res_chunk_size,
         ", res_num_consumers=",
         res_num_consumers,
         ", res_num_copy_threads=",
-        res_num_copy_threads);
+        res_num_copy_threads,
+        ", res_num_hbm_copy_threads=",
+        res_num_hbm_copy_threads);
     XLOG(INFO) << "[TBE_ID" << unique_id_
                << "] Raw embedding streaming enabled with res_server_port at"
                << res_server_port_;
@@ -258,6 +247,29 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
         res_num_consumers_,
         std::make_unique<folly::NamedThreadFactory>(
             fmt::format("RESShip.{}", unique_id_)));
+
+    // Persistent pool that runs the per-chunk tensor copies (CPU-bound
+    // std::copy) off the trainer thread. Sized res_num_copy_threads_ so N
+    // chunks run concurrently -- the same N-way parallelism the old
+    // one-std::thread-per-group model gave.
+    copy_executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
+        res_num_copy_threads_,
+        std::make_unique<folly::NamedThreadFactory>(
+            fmt::format("RESCopy.{}", unique_id_)));
+
+    // Dedicated HBM-path executors so the HBM path does not contend with the
+    // hit path at the dispatch (size-1) or copy level. The ship path
+    // (consumer_executor_) stays shared across both lanes. Inert until a caller
+    // opts a stream onto the HBM path. Prefixes are kept short for the same
+    // 15-char thread-name cap as above, so unique_id_ is not truncated away.
+    hbm_dispatch_executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
+        1,
+        std::make_unique<folly::NamedThreadFactory>(
+            fmt::format("RESHbmDisp{}", unique_id_)));
+    hbm_copy_executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
+        res_num_hbm_copy_threads_,
+        std::make_unique<folly::NamedThreadFactory>(
+            fmt::format("RESHbmCopy{}", unique_id_)));
   }
 #endif
 }
@@ -265,16 +277,28 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
 RawEmbeddingStreamer::~RawEmbeddingStreamer() {
 #ifdef FBGEMM_FBCODE
   if (enable_raw_embedding_streaming_) {
+    // Drain in producer order: dispatch schedules onto copy_executor_, and copy
+    // groups submit ship tasks onto consumer_executor_, so join dispatch ->
+    // copy -> consumer. A wrong order risks joining an executor while a
+    // producer still schedules onto it.
     join_dispatch_and_workers();
+    // The HBM path has its own dispatch + copy executors; drain its dispatch
+    // future too before joining those executors.
+    join_hbm_dispatch_and_workers();
     if (dispatch_executor_ != nullptr) {
       dispatch_executor_->join();
     }
-    // Normally a no-op: join_dispatch_and_workers() already joined the copy
-    // threads and no new ones can be spawned once the executor is joined. Kept
-    // as a belt-and-suspenders guard so destruction never races a stray thread.
-    join_worker_threads();
-    // Producers (dispatch + copy threads) are all joined above, so no further
-    // ship tasks will be submitted. join() drains the in-flight ones before the
+    if (hbm_dispatch_executor_ != nullptr) {
+      hbm_dispatch_executor_->join();
+    }
+    if (copy_executor_ != nullptr) {
+      copy_executor_->join();
+    }
+    if (hbm_copy_executor_ != nullptr) {
+      hbm_copy_executor_->join();
+    }
+    // Producers (dispatch + copy) are all joined above, so no further ship
+    // tasks will be submitted. join() drains the in-flight ones before the
     // executor's threads stop, then destroys members in a safe order.
     if (consumer_executor_ != nullptr) {
       consumer_executor_->join();
@@ -291,7 +315,8 @@ void RawEmbeddingStreamer::stream(
     const at::Tensor& count [[maybe_unused]],
     bool require_tensor_copy [[maybe_unused]],
     bool blocking_tensor_copy [[maybe_unused]],
-    std::optional<at::Tensor> copy_done_flag [[maybe_unused]]) {
+    std::optional<at::Tensor> copy_done_flag [[maybe_unused]],
+    bool use_hbm [[maybe_unused]]) {
   if (!enable_raw_embedding_streaming_) {
     return;
   }
@@ -311,42 +336,68 @@ void RawEmbeddingStreamer::stream(
     return poll_copy_done_flag(copy_done_flag);
   };
 
+  // Select the lane's executors once: the HBM path runs on its own dispatch +
+  // copy pools so it does not contend with the hit path. Only the ship path
+  // (consumer_executor_) is shared.
+  //
+  // CAVEAT for a future use_hbm caller: the two lanes have independent
+  // futures/executors, so there is NO cross-lane read-before-overwrite barrier.
+  // A row that is cache-miss in iter i (HBM path) then cache-hit in iter i+1
+  // (hit path) has no happens-before across the lanes -- the caller must pin a
+  // given row/table to a single lane (or join both futures on a lane
+  // transition) and rely on the arrival-wins / versioned store (T281413204) for
+  // cross-lane freshness.
+  auto* dispatch_exec =
+      use_hbm ? hbm_dispatch_executor_.get() : dispatch_executor_.get();
+
   if (blocking_tensor_copy) {
     if (!poll_flag()) {
       return;
     }
-    chunked_copy_and_enqueue(
+    // blockingWait is itself the barrier: it blocks the trainer thread until
+    // every copy group (on the selected copy pool) has finished and enqueued --
+    // the read-before-overwrite barrier. The trainer thread is not a copy-pool
+    // worker, so this cannot self-deadlock. The per-group try/catch keeps
+    // collectAllRange from rethrowing here. The ship path (consumer_executor_)
+    // is shared, so both lanes' enqueued items drain the same way.
+    folly::coro::blockingWait(chunked_copy_and_enqueue(
         indices,
         weights,
         std::move(identities),
         std::move(runtime_meta),
         count,
-        chunk_copy_threads_);
-    join_worker_threads();
+        use_hbm));
     return;
   }
-  // Non-blocking: join the previous dispatch + copy threads, then spawn new
-  // ones. The join is the serializer: it guarantees iter i's copy finished
-  // reading the source cache rows before iter i+1 overwrites them.
-  join_dispatch_and_workers();
-  // Dispatch runs as a coroutine on the persistent size-1 executor; folly
-  // captures any exception into dispatch_future_, which is logged when the
-  // future is waited in join_dispatch_and_workers() (log-and-continue, never
+  // Non-blocking: join the previous dispatch on the SELECTED lane (which
+  // awaited its copies on that lane's copy pool) before starting a new one. The
+  // join is the serializer: it guarantees iter i's copies finished reading the
+  // source cache rows before iter i+1 overwrites them.
+  if (use_hbm) {
+    join_hbm_dispatch_and_workers();
+  } else {
+    join_dispatch_and_workers();
+  }
+  // Dispatch runs as a coroutine on the selected size-1 dispatch executor;
+  // folly captures any exception into the selected future, which is logged when
+  // the future is waited in join_(hbm_)dispatch() (log-and-continue, never
   // terminate).
   TORCH_CHECK(
-      dispatch_executor_ != nullptr,
-      "dispatch_executor_ is only constructed when raw embedding streaming is "
+      dispatch_exec != nullptr,
+      "dispatch executors are only constructed when raw embedding streaming is "
       "enabled; stream() must have early-returned otherwise");
-  dispatch_future_ = folly::coro::co_withExecutor(
-                         dispatch_executor_.get(),
-                         dispatch_copy_task(
-                             indices,
-                             weights,
-                             std::move(identities),
-                             std::move(runtime_meta),
-                             count,
-                             std::move(copy_done_flag)))
-                         .start();
+  auto& dispatch_future = use_hbm ? hbm_dispatch_future_ : dispatch_future_;
+  dispatch_future = folly::coro::co_withExecutor(
+                        dispatch_exec,
+                        dispatch_copy_task(
+                            indices,
+                            weights,
+                            std::move(identities),
+                            std::move(runtime_meta),
+                            count,
+                            std::move(copy_done_flag),
+                            use_hbm))
+                        .start();
   rec->record.end();
 #endif
 }
@@ -355,9 +406,12 @@ void RawEmbeddingStreamer::join_dispatch_and_workers() {
 #ifdef FBGEMM_FBCODE
   auto rec = torch::autograd::profiler::record_function_enter_new(
       "## RawEmbeddingStreamer::join_dispatch_and_workers ##");
-  // Wait the previous dispatch. Log-and-continue: an exception the dispatch
-  // deferred into the future must not escape (would std::terminate the
-  // trainer).
+  // Wait the previous dispatch. The dispatch future resolves only after
+  // chunked_copy_and_enqueue's collectAllRange completes, so this is also the
+  // read-before-overwrite barrier: iter i's copies finish reading the source
+  // cache rows before iter i+1 overwrites them. Log-and-continue: an exception
+  // the dispatch deferred into the future must not escape (would std::terminate
+  // the trainer).
   if (dispatch_future_.valid()) {
     try {
       std::move(dispatch_future_).get();
@@ -370,23 +424,36 @@ void RawEmbeddingStreamer::join_dispatch_and_workers() {
     }
     dispatch_future_ = folly::makeSemiFuture();
   }
-  // The real torn-row barrier: iter i's copy must finish reading the source
-  // cache rows before iter i+1 overwrites them.
-  join_worker_threads();
+  rec->record.end();
+#endif
+}
+
+void RawEmbeddingStreamer::join_hbm_dispatch_and_workers() {
+#ifdef FBGEMM_FBCODE
+  auto rec = torch::autograd::profiler::record_function_enter_new(
+      "## RawEmbeddingStreamer::join_hbm_dispatch_and_workers ##");
+  // HBM-path mirror of join_dispatch(). The HBM dispatch future resolves only
+  // after its chunked_copy_and_enqueue collectAllRange completes (copies run on
+  // the dedicated hbm_copy_executor_), so this is also the HBM path's
+  // read-before-overwrite barrier. Log-and-continue: a deferred exception must
+  // not escape (would std::terminate the trainer).
+  if (hbm_dispatch_future_.valid()) {
+    try {
+      std::move(hbm_dispatch_future_).get();
+    } catch (const std::exception& e) {
+      XLOG(ERR) << "[TBE_ID" << unique_id_
+                << "] HBM stream dispatcher caught exception: " << e.what();
+    } catch (...) {
+      XLOG(ERR) << "[TBE_ID" << unique_id_
+                << "] HBM stream dispatcher caught unknown exception";
+    }
+    hbm_dispatch_future_ = folly::makeSemiFuture();
+  }
   rec->record.end();
 #endif
 }
 
 #ifdef FBGEMM_FBCODE
-void RawEmbeddingStreamer::join_worker_threads() {
-  for (auto& t : chunk_copy_threads_) {
-    if (t && t->joinable()) {
-      t->join();
-    }
-  }
-  chunk_copy_threads_.clear();
-}
-
 void RawEmbeddingStreamer::submit_stream_item(StreamQueueItem item) {
   // Push model: hand the item to a ship worker that wakes on submit. folly
   // captures any task exception (so an escaped throw can't std::terminate the
@@ -417,71 +484,73 @@ void RawEmbeddingStreamer::submit_stream_item(StreamQueueItem item) {
   });
 }
 
-void RawEmbeddingStreamer::chunked_copy_and_enqueue(
-    const at::Tensor& indices,
-    const at::Tensor& weights,
+folly::coro::Task<void> RawEmbeddingStreamer::copy_chunk_task(
+    at::Tensor indices,
+    at::Tensor weights,
     std::optional<at::Tensor> identities,
     std::optional<at::Tensor> runtime_meta,
-    const at::Tensor& count,
-    std::vector<std::unique_ptr<std::thread>>& target_copy_threads) {
+    int64_t start,
+    int64_t end) {
+  // Guard the copy body so a per-chunk failure logs instead of escaping into
+  // collectAllRange (which would cancel siblings and rethrow onto the blocking
+  // caller / std::terminate).
+  try {
+    auto chunk_item = tensor_copy_chunk(
+        indices, weights, identities, runtime_meta, start, end);
+    submit_stream_item(std::move(chunk_item));
+  } catch (const std::exception& e) {
+    XLOG(ERR) << "[TBE_ID" << unique_id_ << "] copy_chunk [" << start << ", "
+              << end << ") caught exception: " << e.what();
+  } catch (...) {
+    XLOG(ERR) << "[TBE_ID" << unique_id_ << "] copy_chunk [" << start << ", "
+              << end << ") caught unknown exception";
+  }
+  co_return;
+}
+
+folly::coro::Task<void> RawEmbeddingStreamer::chunked_copy_and_enqueue(
+    at::Tensor indices,
+    at::Tensor weights,
+    std::optional<at::Tensor> identities,
+    std::optional<at::Tensor> runtime_meta,
+    at::Tensor count,
+    bool use_hbm) {
   auto rec = torch::autograd::profiler::record_function_enter_new(
       "## RawEmbeddingStreamer::chunked_copy_and_enqueue ##");
   const auto num_rows = get_maybe_uvm_scalar(count);
-  const auto thread_chunks =
-      computeChunkRanges(num_rows, res_chunk_size_, res_num_copy_threads_);
-
-  for (auto& t : target_copy_threads) { // join+clear the previous batch
-    if (t && t->joinable()) {
-      t->join();
-    }
-  }
-  target_copy_threads.clear();
-  if (thread_chunks.empty()) {
-    rec->record.end();
-    return;
-  }
-
-  // One copy thread per pre-computed group. Chunk boundaries and per-thread
-  // grouping live entirely in computeChunkRanges, so the enqueued row set is
-  // identical regardless of how threads are laid out here.
-  target_copy_threads.reserve(thread_chunks.size());
-  for (size_t ti = 0; ti < thread_chunks.size(); ++ti) {
-    target_copy_threads.push_back(
-        std::make_unique<std::thread>([this,
-                                       indices,
-                                       weights,
-                                       identities,
-                                       runtime_meta,
-                                       chunks = thread_chunks[ti],
-                                       ti]() {
-          // Guard the copy body so a per-chunk failure logs instead of escaping
-          // the std::thread and calling std::terminate.
-          try {
-            folly::stop_watch<std::chrono::milliseconds> thread_watch;
-            int64_t rows_done = 0;
-            for (const auto& [s, e] : chunks) {
-              auto chunk_item = tensor_copy_chunk(
-                  indices, weights, identities, runtime_meta, s, e);
-              submit_stream_item(std::move(chunk_item));
-              rows_done += (e - s);
-            }
-            XLOG_EVERY_MS(INFO, 15000)
-                << "[TBE_ID" << unique_id_ << "] copy_thread tid=" << ti
-                << " rows=" << rows_done << " chunks=" << chunks.size()
-                << " copy_ms=" << thread_watch.elapsed().count();
-          } catch (const std::exception& e) {
-            XLOG(ERR) << "[TBE_ID" << unique_id_ << "] copy_thread tid=" << ti
-                      << " caught exception: " << e.what();
-          } catch (...) {
-            XLOG(ERR) << "[TBE_ID" << unique_id_ << "] copy_thread tid=" << ti
-                      << " caught unknown exception";
-          }
-        }));
-  }
+  const auto chunks = computeChunks(num_rows, res_chunk_size_);
   XLOG_EVERY_MS(INFO, 15000)
       << "[RES] chunked_copy tbe=" << unique_id_ << " rows=" << num_rows
-      << " threads=" << thread_chunks.size();
+      << " chunks=" << chunks.size();
+  if (chunks.empty()) {
+    rec->record.end();
+    co_return;
+  }
+
+  // Pick the copy pool for this stream's path: the dedicated hbm_copy_executor_
+  // for HBM drain, else the main copy_executor_. Only the ship path
+  // (consumer_executor_) is shared between the two.
+  auto* copy_exec = use_hbm ? hbm_copy_executor_.get() : copy_executor_.get();
+
+  // One copy task per chunk. Chunk boundaries live entirely in computeChunks,
+  // so the enqueued row set is identical regardless of how the tasks run.
+  // co_withExecutor binds each task to copy_exec (the selected copy pool) -- so
+  // a bare Task does not inherit the size-1 dispatch executor and serialize the
+  // copies; collectAllRange then runs the tasks across the pool -- the workers
+  // pull them, so the pool load-balances -- and completes only after every one
+  // is done (the barrier).
+  std::vector<folly::coro::TaskWithExecutor<void>> tasks;
+  tasks.reserve(chunks.size());
+  for (const auto& [start, end] : chunks) {
+    tasks.push_back(
+        folly::coro::co_withExecutor(
+            copy_exec,
+            copy_chunk_task(
+                indices, weights, identities, runtime_meta, start, end)));
+  }
+  co_await folly::coro::collectAllRange(std::move(tasks));
   rec->record.end();
+  co_return;
 }
 
 bool RawEmbeddingStreamer::poll_copy_done_flag(
@@ -509,7 +578,8 @@ folly::coro::Task<void> RawEmbeddingStreamer::dispatch_copy_task(
     std::optional<at::Tensor> identities,
     std::optional<at::Tensor> runtime_meta,
     at::Tensor count,
-    std::optional<at::Tensor> copy_done_flag) {
+    std::optional<at::Tensor> copy_done_flag,
+    bool use_hbm) {
   if (!poll_copy_done_flag(copy_done_flag)) {
     co_return;
   }
@@ -518,13 +588,13 @@ folly::coro::Task<void> RawEmbeddingStreamer::dispatch_copy_task(
   // failure, that log would be delayed until the next iteration or the
   // destructor. join_dispatch_and_workers()'s catch remains as a safety net.
   try {
-    chunked_copy_and_enqueue(
+    co_await chunked_copy_and_enqueue(
         indices,
         weights,
         std::move(identities),
         std::move(runtime_meta),
         count,
-        chunk_copy_threads_);
+        use_hbm);
   } catch (const std::exception& e) {
     XLOG(ERR) << "[TBE_ID" << unique_id_
               << "] stream dispatch caught exception: " << e.what();
@@ -532,6 +602,7 @@ folly::coro::Task<void> RawEmbeddingStreamer::dispatch_copy_task(
     XLOG(ERR) << "[TBE_ID" << unique_id_
               << "] stream dispatch caught unknown exception";
   }
+  co_return;
 }
 
 folly::coro::Task<void> RawEmbeddingStreamer::tensor_stream(

--- a/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
@@ -237,65 +237,32 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
         std::make_unique<folly::NamedThreadFactory>(
             fmt::format("RESDisp{}", unique_id_)));
 
-    XLOG(INFO) << "[TBE_ID" << unique_id_ << "] Starting " << res_num_consumers_
-               << " consumer threads"
+    XLOG(INFO) << "[TBE_ID" << unique_id_
+               << "] Starting RES ship executor with " << res_num_consumers_
+               << " threads"
                << ", chunk_size=" << res_chunk_size_
                << ", copy_threads=" << res_num_copy_threads_;
-    // Ordering caveat: with res_num_consumers_ > 1, these consumers drain the
-    // queue concurrently, so arrival order at the PS is NOT enqueue (iteration)
+    // Push model: ship tasks are submitted onto this executor (one per enqueued
+    // StreamQueueItem) and its workers wake on submit -- no polled queue, no
+    // raw std::thread that could std::terminate on an escaped exception.
+    //
+    // Ordering caveat: with res_num_consumers_ > 1, ship tasks run
+    // concurrently, so arrival order at the PS is NOT enqueue (iteration)
     // order. The store (TrainingPsHandler) applies same-(fqn,row_id) writes
     // arrival-wins with no version compare, so a stale iter-i write can
     // transiently clobber a fresh iter-(i+1) one for a hot row (self-heals on
-    // the row's next in-order update). A single consumer would be ordered/safe.
-    // TODO(T281413204): proper fix is to carry a per-row iteration/version and
-    // keep-newest in the store.
-    for (size_t ci = 0; ci < res_num_consumers_; ++ci) {
-      consumer_threads_.push_back(std::make_unique<std::thread>([this] {
-        while (!stop_) {
-          auto item = weights_to_stream_queue_.try_dequeue();
-          if (!item.has_value()) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
-            continue;
-          }
-          if (stop_) {
-            return;
-          }
-          // Guard the per-item body: a transient tensor_stream failure must log
-          // and move on to the next item, never escape and std::terminate the
-          // trainer.
-          try {
-            folly::stop_watch<std::chrono::milliseconds> stop_watch;
-            folly::coro::blockingWait(tensor_stream(
-                item->indices,
-                item->weights,
-                item->identities,
-                item->runtime_meta));
-            if (ods_logger_) {
-              ods_logger_->bumpKeyGauge(
-                  "tbe_stream_queue_depth",
-                  static_cast<double>(weights_to_stream_queue_.size()));
-            }
-            XLOG_EVERY_MS(INFO, 60000)
-                << "[TBE_ID" << unique_id_ << "] end stream queue size: "
-                << weights_to_stream_queue_.size() << " stream takes "
-                << stop_watch.elapsed().count() << "ms"
-                << " rows=" << item->indices.size(0);
-          } catch (const std::exception& e) {
-            XLOG(ERR) << "[TBE_ID" << unique_id_
-                      << "] consumer thread caught exception: " << e.what();
-          } catch (...) {
-            XLOG(ERR) << "[TBE_ID" << unique_id_
-                      << "] consumer thread caught unknown exception";
-          }
-        }
-      }));
-    }
+    // the row's next in-order update). res_num_consumers_ == 1 is
+    // ordered/safe. TODO(T281413204): proper fix is to carry a per-row
+    // iteration/version and keep-newest in the store.
+    consumer_executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
+        res_num_consumers_,
+        std::make_unique<folly::NamedThreadFactory>(
+            fmt::format("RESShip.{}", unique_id_)));
   }
 #endif
 }
 
 RawEmbeddingStreamer::~RawEmbeddingStreamer() {
-  stop_ = true;
 #ifdef FBGEMM_FBCODE
   if (enable_raw_embedding_streaming_) {
     join_dispatch_and_workers();
@@ -306,7 +273,12 @@ RawEmbeddingStreamer::~RawEmbeddingStreamer() {
     // threads and no new ones can be spawned once the executor is joined. Kept
     // as a belt-and-suspenders guard so destruction never races a stray thread.
     join_worker_threads();
-    join_consumer_threads();
+    // Producers (dispatch + copy threads) are all joined above, so no further
+    // ship tasks will be submitted. join() drains the in-flight ones before the
+    // executor's threads stop, then destroys members in a safe order.
+    if (consumer_executor_ != nullptr) {
+      consumer_executor_->join();
+    }
   }
 #endif
 }
@@ -327,13 +299,12 @@ void RawEmbeddingStreamer::stream(
   auto rec = torch::autograd::profiler::record_function_enter_new(
       "## RawEmbeddingStreamer::stream_callback ##");
   if (!require_tensor_copy) {
-    StreamQueueItem stream_item(
+    submit_stream_item(StreamQueueItem(
         indices,
         weights,
         std::move(identities),
         std::move(runtime_meta),
-        count);
-    weights_to_stream_queue_.enqueue(stream_item);
+        count));
     return;
   }
   auto poll_flag = [this, copy_done_flag]() {
@@ -416,13 +387,34 @@ void RawEmbeddingStreamer::join_worker_threads() {
   chunk_copy_threads_.clear();
 }
 
-void RawEmbeddingStreamer::join_consumer_threads() {
-  for (auto& t : consumer_threads_) {
-    if (t && t->joinable()) {
-      t->join();
+void RawEmbeddingStreamer::submit_stream_item(StreamQueueItem item) {
+  // Push model: hand the item to a ship worker that wakes on submit. folly
+  // captures any task exception (so an escaped throw can't std::terminate the
+  // trainer); we still wrap the body to log a transient tensor_stream failure
+  // and to keep the depth-gauge / periodic-log behavior of the old consumer.
+  consumer_executor_->add([this, item = std::move(item)]() mutable {
+    try {
+      folly::stop_watch<std::chrono::milliseconds> stop_watch;
+      folly::coro::blockingWait(tensor_stream(
+          item.indices, item.weights, item.identities, item.runtime_meta));
+      if (ods_logger_) {
+        ods_logger_->bumpKeyGauge(
+            "stream_mpmc_depth",
+            static_cast<double>(consumer_executor_->getTaskQueueSize()));
+      }
+      XLOG_EVERY_MS(INFO, 60000)
+          << "[TBE_ID" << unique_id_ << "] end stream queue size: "
+          << consumer_executor_->getTaskQueueSize() << " stream takes "
+          << stop_watch.elapsed().count() << "ms"
+          << " rows=" << item.indices.size(0);
+    } catch (const std::exception& e) {
+      XLOG(ERR) << "[TBE_ID" << unique_id_
+                << "] ship task caught exception: " << e.what();
+    } catch (...) {
+      XLOG(ERR) << "[TBE_ID" << unique_id_
+                << "] ship task caught unknown exception";
     }
-  }
-  consumer_threads_.clear();
+  });
 }
 
 void RawEmbeddingStreamer::chunked_copy_and_enqueue(
@@ -470,7 +462,7 @@ void RawEmbeddingStreamer::chunked_copy_and_enqueue(
             for (const auto& [s, e] : chunks) {
               auto chunk_item = tensor_copy_chunk(
                   indices, weights, identities, runtime_meta, s, e);
-              weights_to_stream_queue_.enqueue(std::move(chunk_item));
+              submit_stream_item(std::move(chunk_item));
               rows_done += (e - s);
             }
             XLOG_EVERY_MS(INFO, 15000)
@@ -677,12 +669,19 @@ folly::coro::Task<void> RawEmbeddingStreamer::tensor_stream(
 }
 
 void RawEmbeddingStreamer::join_weights_stream_thread() {
-  stop_ = true;
-  join_consumer_threads();
+  // TESTING only: drop the ship executor to 0 worker threads so subsequently
+  // submitted tasks accumulate in its queue (observable via
+  // get_weights_to_stream_queue_size()) instead of being shipped. Mirrors the
+  // old "stop the consumer threads" behavior; unlike join() the executor still
+  // accepts newly submitted tasks.
+  if (consumer_executor_ != nullptr) {
+    consumer_executor_->setNumThreads(0);
+  }
 }
 
 uint64_t RawEmbeddingStreamer::get_weights_to_stream_queue_size() {
-  return weights_to_stream_queue_.size();
+  return consumer_executor_ != nullptr ? consumer_executor_->getTaskQueueSize()
+                                       : 0;
 }
 #endif
 

--- a/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
@@ -91,47 +91,45 @@ fbgemm_gpu::StreamQueueItem tensor_copy_chunk(
   }
   auto new_count =
       at::empty({1}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  // Each tensor is copied under its own dispatch. They are independent copies,
+  // so there is no need to nest the dispatches (nesting would only reintroduce
+  // scalar_t shadowing and multiply template instantiations).
+  FBGEMM_DISPATCH_INTEGRAL_TYPES(
+      indices.scalar_type(), "tensor_copy_chunk", [&] {
+        std::copy(
+            indices.const_data_ptr<scalar_t>() + start_row,
+            indices.const_data_ptr<scalar_t>() + end_row,
+            new_indices.mutable_data_ptr<scalar_t>());
+      });
   FBGEMM_DISPATCH_FLOAT_HALF_AND_BYTE(
       weights.scalar_type(), "tensor_copy_chunk", [&] {
-        using value_t = scalar_t;
-        FBGEMM_DISPATCH_INTEGRAL_TYPES(
-            indices.scalar_type(), "tensor_copy_chunk", [&] {
-              using index_t = scalar_t;
-              std::copy(
-                  indices.const_data_ptr<index_t>() + start_row,
-                  indices.const_data_ptr<index_t>() + end_row,
-                  new_indices.mutable_data_ptr<index_t>());
-              std::copy(
-                  weights.const_data_ptr<value_t>() +
-                      start_row * weights.size(1),
-                  weights.const_data_ptr<value_t>() + end_row * weights.size(1),
-                  new_weights.mutable_data_ptr<value_t>());
-              if (identities.has_value()) {
-                FBGEMM_DISPATCH_INTEGRAL_TYPES(
-                    identities->scalar_type(), "tensor_copy_chunk", [&] {
-                      using id_t = scalar_t;
-                      std::copy(
-                          identities->const_data_ptr<id_t>() +
-                              start_row * identities->size(1),
-                          identities->const_data_ptr<id_t>() +
-                              end_row * identities->size(1),
-                          new_identities->mutable_data_ptr<id_t>());
-                    });
-              }
-              if (runtime_meta.has_value()) {
-                FBGEMM_DISPATCH_ALL_TYPES(
-                    runtime_meta->scalar_type(), "tensor_copy_chunk", [&] {
-                      using rm_t = scalar_t;
-                      std::copy(
-                          runtime_meta->const_data_ptr<rm_t>() +
-                              start_row * runtime_meta->size(1),
-                          runtime_meta->const_data_ptr<rm_t>() +
-                              end_row * runtime_meta->size(1),
-                          new_runtime_meta->mutable_data_ptr<rm_t>());
-                    });
-              }
-            });
+        std::copy(
+            weights.const_data_ptr<scalar_t>() + start_row * weights.size(1),
+            weights.const_data_ptr<scalar_t>() + end_row * weights.size(1),
+            new_weights.mutable_data_ptr<scalar_t>());
       });
+  if (identities.has_value()) {
+    FBGEMM_DISPATCH_INTEGRAL_TYPES(
+        identities->scalar_type(), "tensor_copy_chunk", [&] {
+          std::copy(
+              identities->const_data_ptr<scalar_t>() +
+                  start_row * identities->size(1),
+              identities->const_data_ptr<scalar_t>() +
+                  end_row * identities->size(1),
+              new_identities->mutable_data_ptr<scalar_t>());
+        });
+  }
+  if (runtime_meta.has_value()) {
+    FBGEMM_DISPATCH_ALL_TYPES(
+        runtime_meta->scalar_type(), "tensor_copy_chunk", [&] {
+          std::copy(
+              runtime_meta->const_data_ptr<scalar_t>() +
+                  start_row * runtime_meta->size(1),
+              runtime_meta->const_data_ptr<scalar_t>() +
+                  end_row * runtime_meta->size(1),
+              new_runtime_meta->mutable_data_ptr<scalar_t>());
+        });
+  }
   *new_count.mutable_data_ptr<int64_t>() = n;
   return fbgemm_gpu::StreamQueueItem{
       new_indices, new_weights, new_identities, new_runtime_meta, new_count};

--- a/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
@@ -92,6 +92,7 @@ auto raw_embedding_streamer =
                 std::vector<int64_t>,
                 int64_t,
                 int64_t,
+                int64_t,
                 int64_t>(),
             "",
             {
@@ -105,6 +106,7 @@ auto raw_embedding_streamer =
                 torch::arg("res_chunk_size") = 500000,
                 torch::arg("res_num_consumers") = 8,
                 torch::arg("res_num_copy_threads") = 4,
+                torch::arg("res_num_hbm_copy_threads") = 4,
             })
         .def(
             "stream",
@@ -119,6 +121,7 @@ auto raw_embedding_streamer =
                 torch::arg("require_tensor_copy"),
                 torch::arg("blocking_tensor_copy"),
                 torch::arg("copy_done_flag") = std::nullopt,
+                torch::arg("use_hbm") = false,
             })
         // The exposed name is kept as-is for backward compatibility: frozen
         // fbgemm clones bundled with published models (pyper_models/.../
@@ -127,6 +130,9 @@ auto raw_embedding_streamer =
         // the dispatch, which in turn joins the copy threads.
         .def(
             "join_stream_tensor_copy_thread",
-            &fbgemm_gpu::RawEmbeddingStreamer::join_dispatch_and_workers);
+            &fbgemm_gpu::RawEmbeddingStreamer::join_dispatch_and_workers)
+        .def(
+            "join_hbm_dispatch_and_workers",
+            &fbgemm_gpu::RawEmbeddingStreamer::join_hbm_dispatch_and_workers);
 
 } // namespace

--- a/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
@@ -120,8 +120,13 @@ auto raw_embedding_streamer =
                 torch::arg("blocking_tensor_copy"),
                 torch::arg("copy_done_flag") = std::nullopt,
             })
+        // The exposed name is kept as-is for backward compatibility: frozen
+        // fbgemm clones bundled with published models (pyper_models/.../
+        // archive/) still call join_stream_tensor_copy_thread() and are never
+        // updated. Only the C++ method name changes to reflect that it joins
+        // the dispatch, which in turn joins the copy threads.
         .def(
             "join_stream_tensor_copy_thread",
-            &fbgemm_gpu::RawEmbeddingStreamer::join_stream_tensor_copy_thread);
+            &fbgemm_gpu::RawEmbeddingStreamer::join_dispatch_and_workers);
 
 } // namespace

--- a/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
@@ -255,147 +255,85 @@ TEST(RawEmbeddingStreamerTest, TensorCopyChunkByteWeights) {
 }
 
 namespace {
-// computeChunkRanges groups chunks per thread (outer index = thread). Flatten
-// to the in-order chunk list so the coverage/contiguity invariants can be
-// checked across the whole range regardless of the thread grouping.
-std::vector<std::pair<int64_t, int64_t>> flatten(
-    const std::vector<std::vector<std::pair<int64_t, int64_t>>>&
-        thread_chunks) {
-  std::vector<std::pair<int64_t, int64_t>> ranges;
-  for (const auto& chunks : thread_chunks) {
-    ranges.insert(ranges.end(), chunks.begin(), chunks.end());
-  }
-  return ranges;
-}
-
-// Structural invariants computeChunkRanges must always satisfy: ranges are
-// contiguous + non-overlapping starting at 0, cover exactly [0, num_rows), and
-// every chunk is non-empty and no larger than chunk_size. An off-by-one in the
-// tiling arithmetic breaks at least one of these.
-void expectValidChunkRanges(
-    const std::vector<std::pair<int64_t, int64_t>>& ranges,
+// Structural invariants computeChunks must always satisfy: chunks are
+// contiguous
+// + non-overlapping starting at 0, cover exactly [0, num_rows), and every chunk
+// is non-empty and no larger than chunk_size. An off-by-one in the tiling
+// arithmetic breaks at least one of these.
+void expectValidChunks(
+    const std::vector<std::pair<int64_t, int64_t>>& chunks,
     int64_t num_rows,
     int64_t chunk_size) {
   int64_t cursor = 0;
-  for (const auto& [start, end] : ranges) {
-    EXPECT_EQ(start, cursor) << "ranges must be contiguous and non-overlapping";
-    EXPECT_GT(end, start) << "no empty ranges";
+  for (const auto& [start, end] : chunks) {
+    EXPECT_EQ(start, cursor) << "chunks must be contiguous and non-overlapping";
+    EXPECT_GT(end, start) << "no empty chunks";
     EXPECT_LE(end - start, chunk_size) << "each chunk must be <= chunk_size";
     cursor = end;
   }
-  EXPECT_EQ(cursor, num_rows) << "ranges must cover exactly [0, num_rows)";
+  EXPECT_EQ(cursor, num_rows) << "chunks must cover exactly [0, num_rows)";
 }
 } // namespace
 
-// computeChunkRanges (like tensor_copy_chunk) is build-agnostic. Expected
-// ranges are constructed independently.
-TEST(RawEmbeddingStreamerTest, ComputeChunkRangesExactMultiple) {
-  const auto ranges = flatten(
-      computeChunkRanges(/*num_rows=*/8, /*chunk_size=*/4, /*num_threads=*/2));
+// computeChunks (like tensor_copy_chunk) is build-agnostic. Expected chunks are
+// constructed independently.
+TEST(RawEmbeddingStreamerTest, ComputeChunksExactMultiple) {
+  const auto chunks = computeChunks(/*num_rows=*/8, /*chunk_size=*/4);
   const std::vector<std::pair<int64_t, int64_t>> expected = {{0, 4}, {4, 8}};
-  EXPECT_EQ(ranges, expected);
-  expectValidChunkRanges(ranges, /*num_rows=*/8, /*chunk_size=*/4);
+  EXPECT_EQ(chunks, expected);
+  expectValidChunks(chunks, /*num_rows=*/8, /*chunk_size=*/4);
 }
 
-TEST(RawEmbeddingStreamerTest, ComputeChunkRangesRemainderChunk) {
-  // Single thread => pure chunking; last chunk carries the remainder.
-  const auto ranges = flatten(
-      computeChunkRanges(/*num_rows=*/10, /*chunk_size=*/4, /*num_threads=*/1));
+TEST(RawEmbeddingStreamerTest, ComputeChunksRemainderChunk) {
+  // Last chunk carries the remainder when num_rows isn't a multiple of
+  // chunk_size.
+  const auto chunks = computeChunks(/*num_rows=*/10, /*chunk_size=*/4);
   const std::vector<std::pair<int64_t, int64_t>> expected = {
       {0, 4}, {4, 8}, {8, 10}};
-  EXPECT_EQ(ranges, expected);
-  expectValidChunkRanges(ranges, /*num_rows=*/10, /*chunk_size=*/4);
+  EXPECT_EQ(chunks, expected);
+  expectValidChunks(chunks, /*num_rows=*/10, /*chunk_size=*/4);
 }
 
-TEST(RawEmbeddingStreamerTest, ComputeChunkRangesCountLessThanChunkSize) {
-  const auto ranges = flatten(
-      computeChunkRanges(/*num_rows=*/3, /*chunk_size=*/10, /*num_threads=*/4));
+TEST(RawEmbeddingStreamerTest, ComputeChunksCountLessThanChunkSize) {
+  // num_rows < chunk_size collapses to a single partial chunk.
+  const auto chunks = computeChunks(/*num_rows=*/3, /*chunk_size=*/10);
   const std::vector<std::pair<int64_t, int64_t>> expected = {{0, 3}};
-  EXPECT_EQ(ranges, expected);
-  expectValidChunkRanges(ranges, /*num_rows=*/3, /*chunk_size=*/10);
+  EXPECT_EQ(chunks, expected);
+  expectValidChunks(chunks, /*num_rows=*/3, /*chunk_size=*/10);
 }
 
-TEST(RawEmbeddingStreamerTest, ComputeChunkRangesSingleChunk) {
-  const auto ranges = flatten(
-      computeChunkRanges(/*num_rows=*/5, /*chunk_size=*/5, /*num_threads=*/4));
+TEST(RawEmbeddingStreamerTest, ComputeChunksSingleChunk) {
+  // num_rows == chunk_size is exactly one full chunk (no empty trailing chunk).
+  const auto chunks = computeChunks(/*num_rows=*/5, /*chunk_size=*/5);
   const std::vector<std::pair<int64_t, int64_t>> expected = {{0, 5}};
-  EXPECT_EQ(ranges, expected);
-  expectValidChunkRanges(ranges, /*num_rows=*/5, /*chunk_size=*/5);
+  EXPECT_EQ(chunks, expected);
+  expectValidChunks(chunks, /*num_rows=*/5, /*chunk_size=*/5);
 }
 
-TEST(RawEmbeddingStreamerTest, ComputeChunkRangesChunkSizeOne) {
-  const auto ranges = flatten(
-      computeChunkRanges(/*num_rows=*/4, /*chunk_size=*/1, /*num_threads=*/1));
+TEST(RawEmbeddingStreamerTest, ComputeChunksChunkSizeOne) {
+  const auto chunks = computeChunks(/*num_rows=*/4, /*chunk_size=*/1);
   const std::vector<std::pair<int64_t, int64_t>> expected = {
       {0, 1}, {1, 2}, {2, 3}, {3, 4}};
-  EXPECT_EQ(ranges, expected);
-  expectValidChunkRanges(ranges, /*num_rows=*/4, /*chunk_size=*/1);
+  EXPECT_EQ(chunks, expected);
+  expectValidChunks(chunks, /*num_rows=*/4, /*chunk_size=*/1);
 }
 
-TEST(RawEmbeddingStreamerTest, ComputeChunkRangesZeroRowsIsEmpty) {
-  EXPECT_TRUE(
-      computeChunkRanges(/*num_rows=*/0, /*chunk_size=*/4, /*num_threads=*/4)
-          .empty());
-}
-
-TEST(RawEmbeddingStreamerTest, ComputeChunkRangesNumThreadsExceedsNumChunks) {
-  // n_threads is clamped to n_chunks, so exactly n_chunks groups are emitted,
-  // one chunk each, with no empty group.
-  const auto thread_chunks =
-      computeChunkRanges(/*num_rows=*/6, /*chunk_size=*/3, /*num_threads=*/10);
-  EXPECT_EQ(thread_chunks.size(), 2u) << "one group per chunk";
-  const auto ranges = flatten(thread_chunks);
-  const std::vector<std::pair<int64_t, int64_t>> expected = {{0, 3}, {3, 6}};
-  EXPECT_EQ(ranges, expected);
-  expectValidChunkRanges(ranges, /*num_rows=*/6, /*chunk_size=*/3);
-}
-
-TEST(RawEmbeddingStreamerTest, ComputeChunkRangesThreadSplitThenChunk) {
-  // num_threads < num_chunks and rows_per_thread not a multiple of chunk_size:
-  // rows are pre-split into 2 per-thread bands ([0,50), [50,100)) and each band
-  // is then chunked by 30, so boundaries land at the thread split (50), not at
-  // 60. This locks the tiling to the original inline behavior.
-  const auto thread_chunks = computeChunkRanges(
-      /*num_rows=*/100, /*chunk_size=*/30, /*num_threads=*/2);
-  EXPECT_EQ(thread_chunks.size(), 2u) << "one group per thread band";
-  const std::vector<std::vector<std::pair<int64_t, int64_t>>> expected_groups =
-      {{{0, 30}, {30, 50}}, {{50, 80}, {80, 100}}};
-  EXPECT_EQ(thread_chunks, expected_groups);
-  expectValidChunkRanges(
-      flatten(thread_chunks), /*num_rows=*/100, /*chunk_size=*/30);
-}
-
-TEST(RawEmbeddingStreamerTest, ComputeChunkRangesNoEmptyTailRange) {
-  // rows_per_thread rounds up (ceil(5/4)=2) so the 4th thread's band would be
-  // [6,5); that empty band must be dropped, leaving 3 non-empty groups.
-  const auto thread_chunks =
-      computeChunkRanges(/*num_rows=*/5, /*chunk_size=*/1, /*num_threads=*/4);
-  EXPECT_EQ(thread_chunks.size(), 3u) << "empty trailing band is dropped";
-  const auto ranges = flatten(thread_chunks);
-  const std::vector<std::pair<int64_t, int64_t>> expected = {
-      {0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5}};
-  EXPECT_EQ(ranges, expected);
-  expectValidChunkRanges(ranges, /*num_rows=*/5, /*chunk_size=*/1);
-}
-
-TEST(RawEmbeddingStreamerTest, ComputeChunkRangesOneOverChunk) {
+TEST(RawEmbeddingStreamerTest, ComputeChunksOneOverChunk) {
   // num_rows == chunk_size + 1: the +1 spills into a second, single-row chunk.
-  const auto ranges = flatten(
-      computeChunkRanges(/*num_rows=*/5, /*chunk_size=*/4, /*num_threads=*/1));
+  const auto chunks = computeChunks(/*num_rows=*/5, /*chunk_size=*/4);
   const std::vector<std::pair<int64_t, int64_t>> expected = {{0, 4}, {4, 5}};
-  EXPECT_EQ(ranges, expected);
-  expectValidChunkRanges(ranges, /*num_rows=*/5, /*chunk_size=*/4);
+  EXPECT_EQ(chunks, expected);
+  expectValidChunks(chunks, /*num_rows=*/5, /*chunk_size=*/4);
 }
 
-TEST(RawEmbeddingStreamerTest, ComputeChunkRangesZeroThreadsOrChunkSizeEmpty) {
-  // Defensive guards: chunk_size==0 and num_threads==0 would divide by zero in
-  // the ceil-div tiling, so both must short-circuit to an empty result.
-  EXPECT_TRUE(
-      computeChunkRanges(/*num_rows=*/5, /*chunk_size=*/0, /*num_threads=*/4)
-          .empty());
-  EXPECT_TRUE(
-      computeChunkRanges(/*num_rows=*/5, /*chunk_size=*/4, /*num_threads=*/0)
-          .empty());
+TEST(RawEmbeddingStreamerTest, ComputeChunksZeroRowsIsEmpty) {
+  EXPECT_TRUE(computeChunks(/*num_rows=*/0, /*chunk_size=*/4).empty());
+}
+
+TEST(RawEmbeddingStreamerTest, ComputeChunksZeroChunkSizeIsEmpty) {
+  // Defensive guard: chunk_size==0 would loop forever (s += 0), so it must
+  // short-circuit to an empty result.
+  EXPECT_TRUE(computeChunks(/*num_rows=*/5, /*chunk_size=*/0).empty());
 }
 
 #ifdef FBGEMM_FBCODE
@@ -416,6 +354,89 @@ TEST(RawEmbeddingStreamerTest, CtorRejectsZeroKnob) {
           /*res_chunk_size=*/0,
           /*res_num_consumers=*/8,
           /*res_num_copy_threads=*/4));
+}
+
+TEST(RawEmbeddingStreamerTest, TestMultiChunkFanOutShipsEveryChunk) {
+  // The stream()/tensor_stream tests all run at the default res_chunk_size (one
+  // chunk), so the chunked_copy_and_enqueue -> computeChunks -> copy_executor_
+  // fan-out -> collectAllRange -> per-chunk submit_stream_item composition is
+  // otherwise never exercised with >1 chunk. Here res_chunk_size=4 over 10 rows
+  // tiles into ceil(10/4)=3 chunks; with a single shard each chunk ships
+  // exactly one co_setEmbeddings, so RPC count == chunk count proves every
+  // chunk is copied and shipped -- a dropped/duplicated chunk future or an
+  // off-by-one in the fan-out would change the count. computeChunks' partition
+  // correctness (no gap/dup/overflow) is covered by the ComputeChunks* unit
+  // tests above.
+  std::vector<std::string> table_names = {"tb1"};
+  std::vector<int64_t> table_offsets = {0};
+  std::vector<int64_t> table_sizes = {0, 300};
+
+  // Static storage duration so the co_setEmbeddings coroutine mock can read it
+  // WITHOUT capturing (avoids the capturing-lambda-coroutine UAF lint).
+  static std::atomic<int> rpc_count;
+  rpc_count.store(0);
+  auto mock_service = std::make_shared<MockTrainingParameterServerService>();
+  auto mock_server =
+      std::make_shared<apache::thrift::ScopedServerInterfaceThread>(
+          mock_service,
+          "::1",
+          0,
+          facebook::services::TLSConfig::applyDefaultsToThriftServer);
+  auto& mock_client_factory =
+      facebook::servicerouter::getMockSRClientFactory(false /* strict */);
+  mock_client_factory.registerMockService(
+      "realtime.delta.publish.esr", mock_server);
+
+  auto counting_response =
+      [](std::unique_ptr<
+          aiplatform::gmpp::experimental::training_ps::SetEmbeddingsRequest>)
+      -> folly::coro::Task<std::unique_ptr<
+          aiplatform::gmpp::experimental::training_ps::SetEmbeddingsResponse>> {
+    rpc_count.fetch_add(1);
+    co_return std::make_unique<
+        aiplatform::gmpp::experimental::training_ps::SetEmbeddingsResponse>();
+  };
+  EXPECT_CALL(*mock_service, co_setEmbeddings(_))
+      .WillRepeatedly(folly::coro::gmock_helpers::CoInvoke(counting_response));
+
+  // res_chunk_size=4 (not the 500000 default) so 10 rows fan out into 3 chunks
+  // across the 3-worker copy pool; res_store_shards=1 so each chunk ships once.
+  auto streamer = std::make_unique<fbgemm_gpu::RawEmbeddingStreamer>(
+      "test_multi_chunk_fanout",
+      /*enable_raw_embedding_streaming=*/true,
+      /*res_store_shards=*/1,
+      /*res_server_port=*/0,
+      table_names,
+      table_offsets,
+      table_sizes,
+      /*res_chunk_size=*/4,
+      /*res_num_consumers=*/2,
+      /*res_num_copy_threads=*/3,
+      /*res_num_hbm_copy_threads=*/4);
+
+  constexpr int64_t kNumRows = 10;
+  auto indices = at::arange(
+      kNumRows, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = makeRowMajor(kNumRows, EMBEDDING_DIMENSION, c10::kFloat);
+  auto count = at::tensor(
+      {kNumRows}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  streamer->stream(
+      indices,
+      weights,
+      std::nullopt,
+      std::nullopt,
+      count,
+      /*require_tensor_copy=*/true,
+      /*blocking_tensor_copy=*/true);
+
+  // Wait on the RPC count (not queue size) so no in-flight ship is missed.
+  constexpr int kExpectedChunks = 3; // ceil(10 / 4)
+  for (int i = 0; i < 1000 && rpc_count.load() < kExpectedChunks; ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  EXPECT_EQ(rpc_count.load(), kExpectedChunks);
+  streamer->join_weights_stream_thread();
 }
 
 TEST(RawEmbeddingStreamerTest, TestTensorStream) {
@@ -899,5 +920,267 @@ TEST(RawEmbeddingStreamerTest, TestStreamWithCopyDoneFlagNonBlockingCopy) {
   // poll_flag() must have observed the flag (1) and reset it to 0; without the
   // reset the next iteration would stream before the D2H copy finished.
   EXPECT_EQ(copy_done_flag.item<int32_t>(), 0);
+}
+
+TEST(RawEmbeddingStreamerTest, TestStreamHbmLaneE2E) {
+  // The blocking copy path is lane-agnostic: passing use_hbm=true
+  // still ships through the SAME consumer_executor_ as the main path (blocking
+  // never branches on the lane), so co_setEmbeddings fires once per shard --
+  // identical to TestStreamE2E. Confirms use_hbm is inert on the
+  // blocking path; the per-lane HBM dispatch future is covered by
+  // TestStreamHbmLaneNonBlockingCopy.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto mock_service = std::make_shared<MockTrainingParameterServerService>();
+  auto mock_server =
+      std::make_shared<apache::thrift::ScopedServerInterfaceThread>(
+          mock_service,
+          "::1",
+          0,
+          facebook::services::TLSConfig::applyDefaultsToThriftServer);
+  auto& mock_client_factory =
+      facebook::servicerouter::getMockSRClientFactory(false /* strict */);
+  mock_client_factory.registerMockService(
+      "realtime.delta.publish.esr", mock_server);
+
+  auto default_response =
+      [](std::unique_ptr<
+          aiplatform::gmpp::experimental::training_ps::SetEmbeddingsRequest>
+             request)
+      -> folly::coro::Task<std::unique_ptr<
+          aiplatform::gmpp::experimental::training_ps::SetEmbeddingsResponse>> {
+    co_return std::make_unique<
+        aiplatform::gmpp::experimental::training_ps::SetEmbeddingsResponse>();
+  };
+
+  EXPECT_CALL(*mock_service, co_setEmbeddings(_))
+      .Times(3) // 3 shards with consistent hashing
+      .WillRepeatedly(folly::coro::gmock_helpers::CoInvoke(default_response));
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_hbm_e2e", true, table_names, table_offsets, table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2, 1, 150, 170, 230, 280},
+      at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  streamer->stream(
+      indices,
+      weights,
+      std::nullopt,
+      std::nullopt,
+      count,
+      /*require_tensor_copy=*/true,
+      /*blocking_tensor_copy=*/true,
+      /*copy_done_flag=*/std::nullopt,
+      /*use_hbm=*/true);
+  // Bounded wait for the consumer to drain the enqueued item (so
+  // co_setEmbeddings has run) before dropping the ship workers -- waiting on
+  // the actual queue size avoids a fixed-sleep flake.
+  for (int i = 0; i < 1000 && streamer->get_weights_to_stream_queue_size() > 0;
+       ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  streamer->join_weights_stream_thread();
+}
+
+TEST(RawEmbeddingStreamerTest, TestStreamHbmLaneNonBlockingCopy) {
+  // A non-blocking HBM stream dispatches its copy onto the shared
+  // copy_executor_, so join_hbm_dispatch_and_workers() must drain the HBM
+  // path's dispatch future before the queue is read -- asserting before the
+  // join would race the background copy. One item lands in the shared queue.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_hbm_nonblocking", true, table_names, table_offsets, table_sizes);
+
+  auto mock_service = std::make_shared<MockTrainingParameterServerService>();
+  auto mock_server =
+      std::make_shared<apache::thrift::ScopedServerInterfaceThread>(
+          mock_service,
+          "::1",
+          0,
+          facebook::services::TLSConfig::applyDefaultsToThriftServer);
+  auto& mock_client_factory =
+      facebook::servicerouter::getMockSRClientFactory(false /* strict */);
+  mock_client_factory.registerMockService(
+      "realtime.delta.publish.esr", mock_server);
+
+  auto indices = at::tensor(
+      {10, 2, 1, 150, 170, 230, 280},
+      at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  // Stop the dequeue thread to get an accurate, stable queue size.
+  streamer->join_weights_stream_thread();
+
+  streamer->stream(
+      indices,
+      weights,
+      std::nullopt,
+      std::nullopt,
+      count,
+      /*require_tensor_copy=*/true,
+      /*blocking_tensor_copy=*/false,
+      /*copy_done_flag=*/std::nullopt,
+      /*use_hbm=*/true);
+  streamer->join_hbm_dispatch_and_workers();
+  EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 1);
+}
+
+TEST(RawEmbeddingStreamerTest, TestStreamMainAndHbmLanesIndependent) {
+  // A blocking main-lane stream (use_hbm=false) and a blocking
+  // HBM-path stream (use_hbm=true) each enqueue one item into the
+  // shared consumer queue: two items total. Both lanes feed the same shared
+  // ship path (consumer_executor_) and copy pool (copy_executor_); the blocking
+  // path is lane-agnostic, so this exercises the shared plumbing, not the
+  // per-lane dispatch futures (those are covered by
+  // TestStreamHbmLaneNonBlockingCopy and TestStreamHbmLaneDestructorJoins).
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_lanes_independent", true, table_names, table_offsets, table_sizes);
+
+  auto mock_service = std::make_shared<MockTrainingParameterServerService>();
+  auto mock_server =
+      std::make_shared<apache::thrift::ScopedServerInterfaceThread>(
+          mock_service,
+          "::1",
+          0,
+          facebook::services::TLSConfig::applyDefaultsToThriftServer);
+  auto& mock_client_factory =
+      facebook::servicerouter::getMockSRClientFactory(false /* strict */);
+  mock_client_factory.registerMockService(
+      "realtime.delta.publish.esr", mock_server);
+
+  auto indices = at::tensor(
+      {10, 2, 1, 150, 170, 230, 280},
+      at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  // Stop the dequeue thread to get an accurate, stable queue size.
+  streamer->join_weights_stream_thread();
+
+  // Main lane (blocking).
+  streamer->stream(
+      indices,
+      weights,
+      std::nullopt,
+      std::nullopt,
+      count,
+      /*require_tensor_copy=*/true,
+      /*blocking_tensor_copy=*/true,
+      /*copy_done_flag=*/std::nullopt,
+      /*use_hbm=*/false);
+  EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 1);
+
+  // HBM path (blocking).
+  streamer->stream(
+      indices,
+      weights,
+      std::nullopt,
+      std::nullopt,
+      count,
+      /*require_tensor_copy=*/true,
+      /*blocking_tensor_copy=*/true,
+      /*copy_done_flag=*/std::nullopt,
+      /*use_hbm=*/true);
+  EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 2);
+}
+
+TEST(RawEmbeddingStreamerTest, TestStreamHbmLaneDestructorJoins) {
+  // A non-blocking stream on BOTH lanes leaves a pending dispatch future on
+  // each lane. The destructor must join both futures -- and the shared
+  // dispatch_executor_ / copy_executor_ / consumer_executor_ -- without hanging
+  // or leaking. Reaching the end is the assertion.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto mock_service = std::make_shared<MockTrainingParameterServerService>();
+  auto mock_server =
+      std::make_shared<apache::thrift::ScopedServerInterfaceThread>(
+          mock_service,
+          "::1",
+          0,
+          facebook::services::TLSConfig::applyDefaultsToThriftServer);
+  auto& mock_client_factory =
+      facebook::servicerouter::getMockSRClientFactory(false /* strict */);
+  mock_client_factory.registerMockService(
+      "realtime.delta.publish.esr", mock_server);
+
+  auto default_response =
+      [](std::unique_ptr<
+          aiplatform::gmpp::experimental::training_ps::SetEmbeddingsRequest>
+             request)
+      -> folly::coro::Task<std::unique_ptr<
+          aiplatform::gmpp::experimental::training_ps::SetEmbeddingsResponse>> {
+    co_return std::make_unique<
+        aiplatform::gmpp::experimental::training_ps::SetEmbeddingsResponse>();
+  };
+
+  // The running consumers may ship whatever the dispatch copies enqueue; the
+  // count is timing-dependent, so allow any number of shard RPCs.
+  EXPECT_CALL(*mock_service, co_setEmbeddings(_))
+      .Times(AnyNumber())
+      .WillRepeatedly(folly::coro::gmock_helpers::CoInvoke(default_response));
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_hbm_dtor", true, table_names, table_offsets, table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2, 1, 150, 170, 230, 280},
+      at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  // Main lane (non-blocking).
+  streamer->stream(
+      indices,
+      weights,
+      std::nullopt,
+      std::nullopt,
+      count,
+      /*require_tensor_copy=*/true,
+      /*blocking_tensor_copy=*/false,
+      /*copy_done_flag=*/std::nullopt,
+      /*use_hbm=*/false);
+  // HBM path (non-blocking).
+  streamer->stream(
+      indices,
+      weights,
+      std::nullopt,
+      std::nullopt,
+      count,
+      /*require_tensor_copy=*/true,
+      /*blocking_tensor_copy=*/false,
+      /*copy_done_flag=*/std::nullopt,
+      /*use_hbm=*/true);
+
+  streamer
+      .reset(); // ~RawEmbeddingStreamer must join both lanes without hanging
+  SUCCEED() << "destructor joined both lanes without hanging";
 }
 #endif

--- a/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
@@ -612,8 +612,8 @@ TEST(RawEmbeddingStreamerTest, TestStreamE2E) {
   streamer->stream(
       indices, weights, std::nullopt, std::nullopt, count, true, true);
   // Bounded wait for the consumer to drain the enqueued item (so
-  // co_setEmbeddings has run) before stopping the thread -- avoids a
-  // fixed-sleep flake and the stop_-between-peek-and-process race.
+  // co_setEmbeddings has run) before dropping the ship workers -- waiting on
+  // the actual queue size avoids a fixed-sleep flake.
   for (int i = 0; i < 1000 && streamer->get_weights_to_stream_queue_size() > 0;
        ++i) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -623,9 +623,9 @@ TEST(RawEmbeddingStreamerTest, TestStreamE2E) {
 
 TEST(RawEmbeddingStreamerTest, TestNoCopyMultiItemConsumerDrain) {
   // require_tensor_copy=false enqueues one raw item per stream() call (no D2H
-  // copy, no chunking). Enqueue several and let the N-thread consumer pool
-  // drain them concurrently through the UMPMC queue: every item must be
-  // shipped, so co_setEmbeddings runs (kNumItems * shards-per-item) times.
+  // copy, no chunking). Enqueue several and let the N-worker consumer executor
+  // drain them concurrently: every item must be shipped, so co_setEmbeddings
+  // runs (kNumItems * shards-per-item) times.
   // Exercises the raw-enqueue (require_tensor_copy=false) branch and multi-item
   // concurrent drain. Wait on the RPC count BEFORE stopping so no in-flight
   // item is dropped.
@@ -689,8 +689,8 @@ TEST(RawEmbeddingStreamerTest, TestNoCopyMultiItemConsumerDrain) {
         /*require_tensor_copy=*/false);
   }
   // Bounded wait until every item has been shipped, then stop -- waiting on the
-  // count (not queue size) guarantees no dequeued-but-unprocessed item is
-  // dropped by stop_.
+  // count (not queue size) guarantees no submitted-but-unshipped item is
+  // dropped when join_weights_stream_thread() drops the ship workers.
   for (int i = 0; i < 1000 && rpc_count.load() < kNumItems * kShardsPerItem;
        ++i) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
@@ -512,11 +512,11 @@ TEST(RawEmbeddingStreamerTest, TestStreamWithCopy) {
   EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 1);
 
   // Test non-blocking tensor copy. The copy runs on the dispatcher, so we must
-  // join_stream_tensor_copy_thread() before checking the queue -- asserting the
-  // size before the join would race the background copy.
+  // join_dispatch_and_workers() before checking the queue -- asserting the size
+  // before the join would race the background copy.
   streamer->stream(
       indices, weights, std::nullopt, std::nullopt, count, true, false);
-  streamer->join_stream_tensor_copy_thread();
+  streamer->join_dispatch_and_workers();
   EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 2);
 }
 
@@ -894,7 +894,7 @@ TEST(RawEmbeddingStreamerTest, TestStreamWithCopyDoneFlagNonBlockingCopy) {
       copy_done_flag);
 
   // Wait for the async thread to complete
-  streamer->join_stream_tensor_copy_thread();
+  streamer->join_dispatch_and_workers();
   EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 1);
   // poll_flag() must have observed the flag (1) and reset it to 0; without the
   // reset the next iteration would stream before the D2H copy finished.

--- a/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
@@ -494,6 +494,80 @@ TEST(RawEmbeddingStreamerTest, TestTensorStream) {
       valid_indices, weights, std::nullopt, std::nullopt));
 }
 
+TEST(
+    RawEmbeddingStreamerTest,
+    TestTensorStreamPartialShardFailureShipsSiblings) {
+  // The shards ship in parallel and each isolates its own failure: when one
+  // shard's RPC throws, the other shards must still ship (per-shard isolation)
+  // and no exception escapes tensor_stream.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_partial_shard_failure",
+      true,
+      table_names,
+      table_offsets,
+      table_sizes);
+
+  auto mock_service = std::make_shared<MockTrainingParameterServerService>();
+  auto mock_server =
+      std::make_shared<apache::thrift::ScopedServerInterfaceThread>(
+          mock_service,
+          "::1",
+          0,
+          facebook::services::TLSConfig::applyDefaultsToThriftServer);
+  auto& mock_client_factory =
+      facebook::servicerouter::getMockSRClientFactory(false /* strict */);
+  mock_client_factory.registerMockService(
+      "realtime.delta.publish.esr", mock_server);
+
+  // Same indices as TestTensorStream: consistent hashing populates all 3
+  // shards.
+  auto valid_indices = at::tensor(
+      {10, 2, 1, 150, 170, 230, 280},
+      at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {valid_indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+
+  // Exactly one of the three shard RPCs throws; the other two succeed. gmock
+  // serializes action selection, so this holds regardless of which shard maps
+  // where or the order the parallel RPCs arrive.
+  std::atomic<int> succeeded{0};
+  EXPECT_CALL(*mock_service, co_setEmbeddings(_))
+      .Times(3)
+      .WillOnce(
+          folly::coro::gmock_helpers::CoInvoke(
+              [](std::unique_ptr<aiplatform::gmpp::experimental::training_ps::
+                                     SetEmbeddingsRequest>)
+                  -> folly::coro::Task<
+                      std::unique_ptr<aiplatform::gmpp::experimental::
+                                          training_ps::SetEmbeddingsResponse>> {
+                throw std::runtime_error("one shard down");
+              }))
+      .WillRepeatedly(
+          ::testing::DoAll(
+              ::testing::InvokeWithoutArgs([&succeeded]() { ++succeeded; }),
+              folly::coro::gmock_helpers::CoInvoke(
+                  [](std::unique_ptr<aiplatform::gmpp::experimental::
+                                         training_ps::SetEmbeddingsRequest>)
+                      -> folly::coro::Task<std::unique_ptr<
+                          aiplatform::gmpp::experimental::training_ps::
+                              SetEmbeddingsResponse>> {
+                    co_return std::make_unique<
+                        aiplatform::gmpp::experimental::training_ps::
+                            SetEmbeddingsResponse>();
+                  })));
+
+  // One shard throwing must not cancel the siblings nor escape tensor_stream.
+  EXPECT_NO_THROW(
+      folly::coro::blockingWait(streamer->tensor_stream(
+          valid_indices, weights, std::nullopt, std::nullopt)));
+  EXPECT_EQ(succeeded.load(), 2); // the two healthy shards still shipped
+}
+
 TEST(RawEmbeddingStreamerTest, TestStreamWithCopy) {
   std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
   std::vector<int64_t> table_offsets = {0, 100, 300};

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -98,11 +98,12 @@ EmbeddingKVDB::EmbeddingKVDB(
               // SSD/kv_db TBEs are intentionally left on the default RES ship/
               // copy knobs: the config layer that makes these tunable is not
               // threaded through the kv_db ctor. Plumb res_chunk_size/
-              // res_num_consumers/res_num_copy_threads here if SSD-backed
-              // tables ever need to tune them.
+              // res_num_consumers/res_num_copy_threads/res_num_hbm_copy_threads
+              // here if SSD-backed tables ever need to tune them.
               /*res_chunk_size=*/500000,
               /*res_num_consumers=*/8,
-              /*res_num_copy_threads=*/4)) {
+              /*res_num_copy_threads=*/4,
+              /*res_num_hbm_copy_threads=*/4)) {
   CHECK(num_shards > 0);
   if (cache_size_gb > 0) {
     l2_cache::CacheLibCache::CacheConfig cache_config;

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -340,9 +340,8 @@ void EmbeddingKVDB::stream_sync_cuda() {
       "## EmbeddingKVDB::stream_sync_cuda ##");
   // take reference to self to avoid lifetime issues.
   auto self = shared_from_this();
-  std::function<void()>* functor = new std::function<void()>([=]() {
-    self->raw_embedding_streamer_->join_stream_tensor_copy_thread();
-  });
+  std::function<void()>* functor = new std::function<void()>(
+      [=]() { self->raw_embedding_streamer_->join_dispatch_and_workers(); });
   AT_CUDA_CHECK(cudaLaunchHostFunc(
       at::cuda::getCurrentCUDAStream(), kv_db_utils::cuda_host_func, functor));
   rec->record.end();


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3059

Ship all shard co_setEmbeddings RPCs concurrently via collectAllRange instead of serially in a for loop; each shard isolates its own RPC failure so one dead shard does not cancel its siblings.

----

Note this is the final behavioral changes for streamer, the new architecture is described here P2447227530

Reviewed By: chouxi

Differential Revision: D113917793


