### PR TITLE
Skip TransposedRequantizeTest on arm instead of asserting against an empty buffer

### DIFF
--- a/test/TransposedRequantizeTest.cc
+++ b/test/TransposedRequantizeTest.cc
@@ -48,6 +48,13 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::ValuesIn(qGranularityVals))); // requantization granularity
 
 TEST_P(RequantizeTest, reqTest) {
+#ifdef __aarch64__
+  // The implementation under test, trRequantizeOpt, is written entirely in AVX2
+  // intrinsics (src/spmmUtilsAvx2.cc) and has no portable or arm counterpart.
+  // Skip rather than run: the test cannot compare against something that does
+  // not exist here.
+  GTEST_SKIP() << "trRequantizeOpt is AVX2-only; no aarch64 implementation";
+#endif
   auto [rows, cols, fuse_relu, use_bias, q_gran] = GetParam();
 
   int numElements = rows * cols;
@@ -123,6 +130,9 @@ TEST_P(RequantizeTest, reqTest) {
 
 #ifdef __aarch64__
 
+// Unreachable at run time (the GTEST_SKIP above returns first), but this body
+// still has to compile: trRequantizeOpt is declared and defined only for x86,
+// so it must not be referenced here.
 #define TESTCODE(FUSE_RELU, ACT_SYMMETRIC, WEIGHT_SYMMETRIC, HAS_BIAS, Q_GRAN) \
   trRequantizeRef<FUSE_RELU, Q_GRAN>(                                          \
       output_ref.data(), input.data(), block, cols, cols, reqParams);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3060

On aarch64 `TransposedRequantizeTest` reports 821 of 841 cases as FAILING. None
of them is a real numeric defect -- the test is comparing against a buffer that
was never written.

The implementation under test, `trRequantizeOpt`, is written entirely in AVX2
intrinsics (`src/spmmUtilsAvx2.cc`: `__m256`, `_mm256_*`) and has no portable or
arm counterpart. To keep the arm build compiling, the `TESTCODE` macro is split
on `#ifdef __aarch64__` so the arm variant computes only the reference and never
calls `trRequantizeOpt`. But the test body still ends in an unconditional

    ASSERT_EQ(output_ref, output_test) << "reference doesn't match with test";

so on arm it compares a correctly-computed reference against a zero-initialized
`output_test`. That fails for every parameterization whose reference output is
not all zeros -- hence 821, with the ~20 "passes" being the cases that happen to
requantize to all zeros. A representative failure:

    TransposedRequantizeTest.cc:300: Failure
    Expected equality of these values:
      output_ref    Which is: { 169, 179, 74, 136 }
      output_test   Which is: { 0, 0, 0, 0 }

This adds a `GTEST_SKIP()` at the top of the test body on aarch64, so the suite
reports what is actually true: the kernel is unported on this architecture, not
broken. The `#ifdef` split in `TESTCODE` stays -- the body after `GTEST_SKIP()`
is still compiled, so `trRequantizeOpt` must remain unreferenced on arm -- and
now carries a comment saying why it exists.

This is deliberately a truth-in-reporting fix, not a port. Actually running this
suite on arm requires a portable `trRequantizeOpt`, which is a substantial piece
of work (a full requantization kernel with per-tensor and per-out-channel
granularity, symmetric/asymmetric act and weight, optional bias and relu) and is
left for a follow-up.

Differential Revision: D116385150


