### PR TITLE
Port u8s8 quantized GEMM to arm with I8MM and NEON compute kernels (#6170)

### DIFF
--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -31,6 +31,15 @@
 #endif
 #endif
 
+// FEAT_I8MM: the Arm Int8 Matrix Multiplication extension (USMMLA et al.).
+#ifndef FEAT_I8MM
+#if defined(__aarch64__) && defined(__ARM_FEATURE_MATMUL_INT8)
+#define FEAT_I8MM 1
+#else
+#define FEAT_I8MM 0
+#endif
+#endif
+
 namespace fbgemm {
 
 /**

--- a/src/ExecuteKernelU8S8.cc
+++ b/src/ExecuteKernelU8S8.cc
@@ -8,6 +8,16 @@
 
 #include "./ExecuteKernelU8S8.h" // @manual
 #include <cpuinfo.h>
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+#include <vector>
+#include "fbgemm/Utils.h"
+
+#ifdef __aarch64__
+#include <arm_neon.h>
+#endif
 
 #ifdef FBGEMM_MEASURE_TIME_BREAKDOWN
 double kernel_time = 0.0;
@@ -15,6 +25,442 @@ double postprocessing_time = 0.0;
 #endif
 
 namespace fbgemm {
+
+#ifdef __aarch64__
+namespace {
+
+// Saturating narrow to int16, i.e. what every x86 "s"-suffixed pack/add does.
+std::int16_t satInt16(std::int32_t v) {
+  return static_cast<std::int16_t>(std::clamp(v, -32768, 32767));
+}
+
+#if FEAT_I8MM
+
+// Loads the 8 K values one USMMLA operand row consumes from a packed A row.
+// `full` is false for a trailing k-quad, where only 4 K values are left in
+// the block; zeroing A's upper half neutralises B's correspondingly unread
+// half.
+uint8x8_t loadPackedAOctet(const uint8_t* aRow, bool full) {
+  uint32x2_t v =
+      vld1_lane_u32(reinterpret_cast<const uint32_t*>(aRow), vdup_n_u32(0), 0);
+  if (full) {
+    v = vld1_lane_u32(reinterpret_cast<const uint32_t*>(aRow + 4), v, 1);
+  }
+  return vreinterpret_u8_u32(v);
+}
+
+// Extracts one output row from the two USMMLA 2x2 tiles that cover four
+// consecutive columns. Each tile is [row0col0, row0col1, row1col0, row1col1].
+int32x4_t usmmlaTileRow(int32x4_t tile01, int32x4_t tile23, bool secondRow) {
+  const int64x2_t lo = vreinterpretq_s64_s32(tile01);
+  const int64x2_t hi = vreinterpretq_s64_s32(tile23);
+  return vreinterpretq_s32_s64(
+      secondRow ? vuzp2q_s64(lo, hi) : vuzp1q_s64(lo, hi));
+}
+
+void storeAcc32(int32_t* cRow, int32x4_t lo, int32x4_t hi, bool accum) {
+  if (accum) {
+    lo = vaddq_s32(lo, vld1q_s32(cRow));
+    hi = vaddq_s32(hi, vld1q_s32(cRow + 4));
+  }
+  vst1q_s32(cRow, lo);
+  vst1q_s32(cRow + 4, hi);
+}
+
+// Sign-extends the two int16 accumulators covering eight columns into the
+// int32 C buffer, the way the JIT kernel's acc16 store path does.
+void storeAcc16(int32_t* cRow, int16x4_t lo, int16x4_t hi, bool accum) {
+  storeAcc32(cRow, vmovl_s16(lo), vmovl_s16(hi), accum);
+}
+
+// Reads the K values of one packed A pair into the low half of a word, in the
+// little-endian byte order the USDOT operand slots expect.
+uint32_t loadPackedAPair(const uint8_t* aRow) {
+  std::uint16_t pair = 0;
+  std::memcpy(&pair, aRow, sizeof(pair));
+  return pair;
+}
+
+// Reads two consecutive packed A pairs, the low one in the low half.
+uint32_t loadPackedAQuad(const uint8_t* aRow) {
+  std::uint32_t quad = 0;
+  std::memcpy(&quad, aRow, sizeof(quad));
+  return quad;
+}
+
+// Splats a K pair into the two byte slots of every USDOT four-byte group that
+// belong to the group's even column.
+uint8x16_t aPairEven(uint32_t pair) {
+  return vreinterpretq_u8_u32(vdupq_n_u32(pair & 0xFFFFU));
+}
+
+// ... and the two that belong to its odd column.
+uint8x16_t aPairOdd(uint32_t pair) {
+  return vreinterpretq_u8_u32(vdupq_n_u32(pair << 16));
+}
+
+// Accumulates one K pair into the GROUPS eight-column groups of a strip.
+// Zeroing the USDOT destination is what keeps each pair's reduction its own:
+// letting it accumulate would fuse pairs and skip a clip_16bit.
+template <int GROUPS>
+void accumulateKPairAcc16(
+    int16x8_t (&acc)[GROUPS],
+    uint32_t pair,
+    const int8_t* bPtr) {
+  const uint8x16_t aEven = aPairEven(pair);
+  const uint8x16_t aOdd = aPairOdd(pair);
+  for (int g = 0; g < GROUPS; ++g) {
+    const int8x16_t b = vld1q_s8(bPtr + 16 * g);
+    const int32x4_t even = vusdotq_s32(vdupq_n_s32(0), aEven, b);
+    const int32x4_t odd = vusdotq_s32(vdupq_n_s32(0), aOdd, b);
+    acc[g] = vqaddq_s16(acc[g], vqmovn_high_s32(vqmovn_s32(even), odd));
+  }
+}
+
+// Computes one strip of 8 * GROUPS columns of a single A row, two K pairs at a
+// time. The pairs stay sequential on each accumulator because saturating
+// int16 addition does not associate.
+template <int GROUPS>
+void computeStripAcc16(
+    const uint8_t* aRow,
+    const int8_t* bBuf,
+    int32_t* cRow,
+    int n,
+    int kc,
+    int nBlock,
+    bool accum) {
+  int16x8_t acc[GROUPS];
+  for (int g = 0; g < GROUPS; ++g) {
+    acc[g] = vdupq_n_s16(0);
+  }
+
+  int k = 0;
+  for (; k + 4 <= kc; k += 4) {
+    const uint32_t quad = loadPackedAQuad(aRow + k);
+    const int8_t* bPtr = bBuf + k * nBlock + 2 * n;
+    accumulateKPairAcc16(acc, quad, bPtr);
+    accumulateKPairAcc16(acc, quad >> 16, bPtr + 2 * nBlock);
+  }
+  // kc is a multiple of row_interleave but need not be a multiple of the four
+  // K values a step consumes, and A holds nothing past kc.
+  if (k < kc) {
+    accumulateKPairAcc16(
+        acc, loadPackedAPair(aRow + k), bBuf + k * nBlock + 2 * n);
+  }
+
+  for (int g = 0; g < GROUPS; ++g) {
+    const int16x4_t even = vget_low_s16(acc[g]);
+    const int16x4_t odd = vget_high_s16(acc[g]);
+    storeAcc16(
+        cRow + n + 8 * g, vzip1_s16(even, odd), vzip2_s16(even, odd), accum);
+  }
+}
+
+// FEAT_I8MM implementation of the u8s8 GEMM micro-kernel, used when the
+// compilation target guarantees the Arm Int8 Matrix Multiplication extension.
+//
+// On x86 the compute kernel is JIT-generated assembly (see
+// GenerateKernelU8S8*.cc); no such kernel exists for arm, so we compute the
+// mc x nc x kc block directly from the packed A/B buffers, consuming the
+// packed layout and reproducing the integer arithmetic of the avx2 kernel:
+//   - A is packed row-major with row stride kBlock (== KCB); element A[i][k]
+//     lives at aBuf[i * kBlock + k] and is unsigned 8-bit.
+//   - B is packed with row_interleave consecutive K values adjacent per
+//     column; element B[k][n] lives at
+//       bBuf[k * nBlock + n * row_interleave + (k % row_interleave)]
+//     (k here is already a multiple of row_interleave) and is signed 8-bit.
+//   - acc16 (accT == int16_t, row_interleave == 2): vpmaddubsw multiplies the
+//     unsigned A byte by the signed B byte and horizontally adds the pair
+//     into an int16 that saturates; the running accumulator is a saturating
+//     int16 add (vpaddsw). The int16 result is sign-extended to int32 on
+//     store.
+//   - acc32 (accT == int32_t, row_interleave == 4): each pair is reduced with
+//     the saturating int16 vpmaddubsw, then widened and summed to int32
+//     (vpmaddwd) and accumulated without saturation (vpaddd).
+// `accum` selects overwrite vs. accumulate into the int32 C buffer, matching
+// the JIT store path (used across successive K-blocks).
+//
+// acc16 uses USDOT (FEAT_I8MM), exact by construction. Interleaving by two
+// makes each of USDOT's four-byte groups hold one K pair for each of two
+// adjacent columns, so zeroing half of the A operand's byte slots selects one
+// column of the pair: the A word [a[k], a[k+1], 0, 0] reduces a 16-byte B
+// load to the four even columns' pair sums and [0, 0, a[k], a[k+1]] to the
+// four odd ones. Those sums are exact in int32 (|.| <= 65280), so vpmaddubsw
+// is USDOT followed by the saturating narrow vqmovn_s32 and vpaddsw is
+// vqadd_s16. Even and odd columns stay in the two halves of one accumulator
+// for the whole K loop and are interleaved back once at the store.
+//
+// acc32 uses USMMLA (FEAT_I8MM), which multiplies a 2x8 uint8 A tile by a 2x8
+// int8 B tile and accumulates the 2x2 int32 product, so it consumes 8 K
+// values and produces two rows x two columns per instruction. That skips the
+// intermediate int16 saturation vpmaddubsw applies to each K pair: the result
+// therefore matches matmul_u8i8acc32_ref, which accumulates in int32
+// throughout, and differs from the avx2 kernel only for a K pair whose
+// product sum leaves int16 range.
+//
+// Columns beyond the last multiple of 8 take the scalar tail.
+template <typename accT>
+void computeBlockI8mm(
+    const uint8_t* aBuf,
+    const int8_t* bBuf,
+    int32_t* cBuf,
+    int mc,
+    int nc,
+    int kc,
+    int kBlock,
+    int nBlock,
+    bool accum,
+    int ldc) {
+  constexpr int row_interleave = std::is_same_v<accT, std::int16_t> ? 2 : 4;
+
+  // Each USMMLA covers two A rows, so the acc32 path steps the M loop by two.
+  constexpr int row_step = std::is_same_v<accT, std::int16_t> ? 1 : 2;
+
+  for (int i = 0; i < mc; i += row_step) {
+    const uint8_t* aRow = aBuf + i * kBlock;
+    int32_t* cRow = cBuf + i * ldc;
+    int n = 0;
+
+    if constexpr (std::is_same_v<accT, std::int16_t>) {
+      for (; n + 32 <= nc; n += 32) {
+        computeStripAcc16<4>(aRow, bBuf, cRow, n, kc, nBlock, accum);
+      }
+      for (; n + 16 <= nc; n += 16) {
+        computeStripAcc16<2>(aRow, bBuf, cRow, n, kc, nBlock, accum);
+      }
+      for (; n + 8 <= nc; n += 8) {
+        computeStripAcc16<1>(aRow, bBuf, cRow, n, kc, nBlock, accum);
+      }
+      for (; n < nc; ++n) {
+        std::int16_t acc = 0;
+        for (int k = 0; k < kc; k += 2) {
+          const int8_t* bPtr = bBuf + k * nBlock + 2 * n;
+          const std::int16_t prod =
+              satInt16(aRow[k] * bPtr[0] + aRow[k + 1] * bPtr[1]);
+          acc = satInt16(acc + prod);
+        }
+        cRow[n] = accum ? cRow[n] + acc : acc;
+      }
+    } else {
+      static_assert(row_interleave == 4);
+      // When mc is odd the second USMMLA row aliases the first; its half of
+      // every tile is computed and then dropped.
+      const bool hasRow1 = i + 1 < mc;
+      const uint8_t* aRow1 = hasRow1 ? aRow + kBlock : aRow;
+
+      for (; n + 8 <= nc; n += 8) {
+        // One 2x2 tile per column pair, laid out as
+        // [row0col0, row0col1, row1col0, row1col1].
+        int32x4_t acc01 = vdupq_n_s32(0);
+        int32x4_t acc23 = vdupq_n_s32(0);
+        int32x4_t acc45 = vdupq_n_s32(0);
+        int32x4_t acc67 = vdupq_n_s32(0);
+
+        // `full` is false only for a trailing k-quad: kc is a multiple of
+        // row_interleave but need not be a multiple of the 8 K values one
+        // USMMLA consumes, and neither packed buffer holds anything past kc.
+        const auto accumulateKOctet = [&](int k, bool full) {
+          const uint8x16_t a = vcombine_u8(
+              loadPackedAOctet(aRow + k, full),
+              loadPackedAOctet(aRow1 + k, full));
+          // Each 16-byte load is 4 columns x 4 K values; zipping the k and
+          // k+4 quads word-wise builds the 2x8 B tile for a column pair.
+          const int8_t* bPtr = bBuf + k * nBlock + 4 * n;
+          const uint32x4_t bLo0 = vreinterpretq_u32_s8(vld1q_s8(bPtr));
+          const uint32x4_t bLo1 = vreinterpretq_u32_s8(vld1q_s8(bPtr + 16));
+          const uint32x4_t bHi0 = full
+              ? vreinterpretq_u32_s8(vld1q_s8(bPtr + 4 * nBlock))
+              : vdupq_n_u32(0);
+          const uint32x4_t bHi1 = full
+              ? vreinterpretq_u32_s8(vld1q_s8(bPtr + 4 * nBlock + 16))
+              : vdupq_n_u32(0);
+          acc01 = vusmmlaq_s32(
+              acc01, a, vreinterpretq_s8_u32(vzip1q_u32(bLo0, bHi0)));
+          acc23 = vusmmlaq_s32(
+              acc23, a, vreinterpretq_s8_u32(vzip2q_u32(bLo0, bHi0)));
+          acc45 = vusmmlaq_s32(
+              acc45, a, vreinterpretq_s8_u32(vzip1q_u32(bLo1, bHi1)));
+          acc67 = vusmmlaq_s32(
+              acc67, a, vreinterpretq_s8_u32(vzip2q_u32(bLo1, bHi1)));
+        };
+
+        int k = 0;
+        for (; k + 8 <= kc; k += 8) {
+          accumulateKOctet(k, true);
+        }
+        if (k < kc) {
+          accumulateKOctet(k, false);
+        }
+
+        storeAcc32(
+            cRow + n,
+            usmmlaTileRow(acc01, acc23, false),
+            usmmlaTileRow(acc45, acc67, false),
+            accum);
+        if (hasRow1) {
+          storeAcc32(
+              cRow + ldc + n,
+              usmmlaTileRow(acc01, acc23, true),
+              usmmlaTileRow(acc45, acc67, true),
+              accum);
+        }
+      }
+      for (; n < nc; ++n) {
+        for (int r = 0; r < (hasRow1 ? 2 : 1); ++r) {
+          const uint8_t* a = aRow + r * kBlock;
+          int32_t* c = cRow + r * ldc;
+          std::int32_t acc = 0;
+          for (int k = 0; k < kc; k += 4) {
+            const int8_t* bPtr = bBuf + k * nBlock + 4 * n;
+            acc += a[k] * bPtr[0] + a[k + 1] * bPtr[1] + a[k + 2] * bPtr[2] +
+                a[k + 3] * bPtr[3];
+          }
+          c[n] = accum ? c[n] + acc : acc;
+        }
+      }
+    }
+  }
+}
+#else // !FEAT_I8MM
+
+// NEON implementation of the u8s8 GEMM micro-kernel for aarch64.
+//
+// On x86 the compute kernel is JIT-generated assembly (see
+// GenerateKernelU8S8*.cc); no such kernel exists for arm, so we compute the
+// mc x nc x kc block directly from the packed A/B buffers. Both the packed
+// layout and the integer arithmetic mirror the avx2 kernel exactly:
+//   - A is packed row-major with row stride kBlock (== KCB); element A[i][k]
+//     lives at aBuf[i * kBlock + k] and is unsigned 8-bit.
+//   - B is packed with row_interleave consecutive K values adjacent per column;
+//     element B[k][n] lives at
+//       bBuf[k * nBlock + n * row_interleave + (k % row_interleave)]
+//     (k here is already a multiple of row_interleave) and is signed 8-bit.
+//   - acc16 (accT == int16_t, row_interleave == 2): vpmaddubsw multiplies the
+//     unsigned A byte by the signed B byte and horizontally adds the pair into
+//     an int16 that saturates; the running accumulator is a saturating int16
+//     add (vpaddsw). The int16 result is sign-extended to int32 on store.
+//   - acc32 (accT == int32_t, row_interleave == 4): each pair is reduced with
+//     the saturating int16 vpmaddubsw, then widened and summed to int32
+//     (vpmaddwd) and accumulated without saturation (vpaddd).
+// `accum` selects overwrite vs. accumulate into the int32 C buffer, matching
+// the JIT store path (used across successive K-blocks).
+//
+// NEON mapping, exact by construction: the interleaved layout makes vld2/vld4
+// de-interleave a K-pair/quad for 8 columns per load; vpmaddubsw is
+// vmull/vmlal into int32 lanes followed by the saturating narrow vqmovn_s32;
+// vpaddsw is vqaddq_s16; vpmaddwd+vpaddd is vaddl_s16 into a non-saturating
+// vaddq_s32. Columns beyond the last multiple of 8 take the scalar tail.
+template <typename accT>
+void computeBlockNeon(
+    const uint8_t* aBuf,
+    const int8_t* bBuf,
+    int32_t* cBuf,
+    int mc,
+    int nc,
+    int kc,
+    int kBlock,
+    int nBlock,
+    bool accum,
+    int ldc) {
+  constexpr int row_interleave = std::is_same_v<accT, std::int16_t> ? 2 : 4;
+
+  for (int i = 0; i < mc; ++i) {
+    const uint8_t* aRow = aBuf + i * kBlock;
+    int32_t* cRow = cBuf + i * ldc;
+    int n = 0;
+
+    if constexpr (std::is_same_v<accT, std::int16_t>) {
+      for (; n + 8 <= nc; n += 8) {
+        int16x8_t acc = vdupq_n_s16(0);
+        for (int k = 0; k < kc; k += 2) {
+          const std::int16_t a0 = aRow[k];
+          const std::int16_t a1 = aRow[k + 1];
+          const int8x8x2_t b = vld2_s8(bBuf + k * nBlock + 2 * n);
+          const int16x8_t b0 = vmovl_s8(b.val[0]);
+          const int16x8_t b1 = vmovl_s8(b.val[1]);
+          int32x4_t lo = vmull_n_s16(vget_low_s16(b0), a0);
+          lo = vmlal_n_s16(lo, vget_low_s16(b1), a1);
+          int32x4_t hi = vmull_n_s16(vget_high_s16(b0), a0);
+          hi = vmlal_n_s16(hi, vget_high_s16(b1), a1);
+          const int16x8_t prod = vcombine_s16(vqmovn_s32(lo), vqmovn_s32(hi));
+          acc = vqaddq_s16(acc, prod);
+        }
+        int32x4_t outLo = vmovl_s16(vget_low_s16(acc));
+        int32x4_t outHi = vmovl_s16(vget_high_s16(acc));
+        if (accum) {
+          outLo = vaddq_s32(outLo, vld1q_s32(cRow + n));
+          outHi = vaddq_s32(outHi, vld1q_s32(cRow + n + 4));
+        }
+        vst1q_s32(cRow + n, outLo);
+        vst1q_s32(cRow + n + 4, outHi);
+      }
+      for (; n < nc; ++n) {
+        std::int16_t acc = 0;
+        for (int k = 0; k < kc; k += 2) {
+          const int8_t* bPtr = bBuf + k * nBlock + 2 * n;
+          const std::int16_t prod =
+              satInt16(aRow[k] * bPtr[0] + aRow[k + 1] * bPtr[1]);
+          acc = satInt16(acc + prod);
+        }
+        cRow[n] = accum ? cRow[n] + acc : acc;
+      }
+    } else {
+      static_assert(row_interleave == 4);
+      for (; n + 8 <= nc; n += 8) {
+        int32x4_t accLo = vdupq_n_s32(0);
+        int32x4_t accHi = vdupq_n_s32(0);
+        for (int k = 0; k < kc; k += 4) {
+          const std::int16_t a0 = aRow[k];
+          const std::int16_t a1 = aRow[k + 1];
+          const std::int16_t a2 = aRow[k + 2];
+          const std::int16_t a3 = aRow[k + 3];
+          const int8x8x4_t b = vld4_s8(bBuf + k * nBlock + 4 * n);
+          const int16x8_t b0 = vmovl_s8(b.val[0]);
+          const int16x8_t b1 = vmovl_s8(b.val[1]);
+          const int16x8_t b2 = vmovl_s8(b.val[2]);
+          const int16x8_t b3 = vmovl_s8(b.val[3]);
+          int32x4_t lo01 = vmull_n_s16(vget_low_s16(b0), a0);
+          lo01 = vmlal_n_s16(lo01, vget_low_s16(b1), a1);
+          int32x4_t hi01 = vmull_n_s16(vget_high_s16(b0), a0);
+          hi01 = vmlal_n_s16(hi01, vget_high_s16(b1), a1);
+          const int16x8_t p01 =
+              vcombine_s16(vqmovn_s32(lo01), vqmovn_s32(hi01));
+          int32x4_t lo23 = vmull_n_s16(vget_low_s16(b2), a2);
+          lo23 = vmlal_n_s16(lo23, vget_low_s16(b3), a3);
+          int32x4_t hi23 = vmull_n_s16(vget_high_s16(b2), a2);
+          hi23 = vmlal_n_s16(hi23, vget_high_s16(b3), a3);
+          const int16x8_t p23 =
+              vcombine_s16(vqmovn_s32(lo23), vqmovn_s32(hi23));
+          accLo =
+              vaddq_s32(accLo, vaddl_s16(vget_low_s16(p01), vget_low_s16(p23)));
+          accHi = vaddq_s32(
+              accHi, vaddl_s16(vget_high_s16(p01), vget_high_s16(p23)));
+        }
+        if (accum) {
+          accLo = vaddq_s32(accLo, vld1q_s32(cRow + n));
+          accHi = vaddq_s32(accHi, vld1q_s32(cRow + n + 4));
+        }
+        vst1q_s32(cRow + n, accLo);
+        vst1q_s32(cRow + n + 4, accHi);
+      }
+      for (; n < nc; ++n) {
+        std::int32_t acc = 0;
+        for (int k = 0; k < kc; k += 4) {
+          const int8_t* bPtr = bBuf + k * nBlock + 4 * n;
+          const std::int16_t p01 =
+              satInt16(aRow[k] * bPtr[0] + aRow[k + 1] * bPtr[1]);
+          const std::int16_t p23 =
+              satInt16(aRow[k + 2] * bPtr[2] + aRow[k + 3] * bPtr[3]);
+          acc += p01 + p23;
+        }
+        cRow[n] = accum ? cRow[n] + acc : acc;
+      }
+    }
+  }
+}
+#endif // FEAT_I8MM
+} // namespace
+#endif // __aarch64__
 
 template <typename packingAMatrix, typename cT, typename processOutputType>
 ExecuteKernel<
@@ -48,6 +494,13 @@ ExecuteKernel<
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
   if (params) {
+#ifdef __aarch64__
+    // aarch64 reference compute path consumes the avx2/user-provided blocking.
+    mbSize_ = params->MCB;
+    nbSize_ = params->NCB;
+    nrMinSize_ = params->NR_MIN;
+    nrSize_ = params->NR;
+#else
     if (fbgemmHasAvx2Support()) {
       mbSize_ = params->MCB;
       nbSize_ = params->NCB;
@@ -58,6 +511,7 @@ ExecuteKernel<
       assert(0 && "unsupported architecure");
       throw std::runtime_error("unsupported architecure");
     }
+#endif
   } else {
     const inst_set_t isa = fbgemmInstructionSet();
     switch (isa) {
@@ -89,6 +543,11 @@ ExecuteKernel<
             inst_set_t::avx512_ymm>::getKernelParams();
         break;
 
+#ifdef __aarch64__
+      // aarch64 reference compute path reuses the avx2 kernel blocking params.
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         std::tie(mbSize_, nbSize_, nrMinSize_, nrSize_) = PackingTraits<
             typename packingAMatrix::inpType,
@@ -137,6 +596,13 @@ void ExecuteKernel<
   if (jb_end == jb_begin) {
     return;
   }
+
+#ifdef __aarch64__
+  // OutputProcessing-inl.h forces its generic implementation on aarch64, so the
+  // avx2 tag below resolves to portable code and needs no x86 SIMD support.
+  constexpr bool hasOutputProcessingKernel = true;
+#else
+  const bool hasOutputProcessingKernel = fbgemmHasAvx2Support();
 
   typename BaseType::jit_micro_kernel_fp fn;
 
@@ -211,6 +677,7 @@ void ExecuteKernel<
       assert(0 && "unsupported architecture");
       throw std::runtime_error("unsupported architecure");
   }
+#endif // __aarch64__
 
 #ifdef FBGEMM_MEASURE_TIME_BREAKDOWN
   std::chrono::time_point<std::chrono::high_resolution_clock> t_end;
@@ -219,60 +686,66 @@ void ExecuteKernel<
 #endif
 
   for (int jb = jb_begin; jb < jb_end; ++jb) {
-    if (jb == bColBlocks - 1) {
-      int nc = ((packedB_.lastBcol() - 1) / nrMinSize_ + 1) * nrMinSize_;
-      if (nc != nbSize_) {
-        switch (isa) {
-          case inst_set_t::avx512_vnni:
-            if constexpr (std::is_same_v<
-                              typename packingAMatrix::accType,
-                              std::int16_t>) {
-              // For AVX512VNNI, we redirect int16_t to int32_t accumulation.
-              CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
-              fn = codeObj.getOrCreate<inst_set_t::avx512_vnni>(
-                  accum, packed_rows_A, nc, packedA_.numPackedCols());
-            } else {
-              fn = BaseType::template getOrCreate<inst_set_t::avx512_vnni>(
-                  accum, packed_rows_A, nc, packedA_.numPackedCols());
-            }
-            break;
+    // Columns actually computed for this block: the last one is rounded up to
+    // NR_MIN. The JIT bakes this into the generated code; the aarch64 reference
+    // kernel takes it as an argument, so it is computed once here for both.
+    const int nc = jb == bColBlocks - 1
+        ? ((packedB_.lastBcol() - 1) / nrMinSize_ + 1) * nrMinSize_
+        : nbSize_;
 
-          case inst_set_t::avx512_vnni_ymm:
-            if constexpr (std::is_same_v<
-                              typename packingAMatrix::accType,
-                              std::int16_t>) {
-              // For AVX512VNNI, we redirect int16_t to int32_t accumulation.
-              CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
-              fn = codeObj.getOrCreate<inst_set_t::avx512_vnni_ymm>(
-                  accum, packed_rows_A, nc, packedA_.numPackedCols());
-            } else {
-              fn = BaseType::template getOrCreate<inst_set_t::avx512_vnni_ymm>(
-                  accum, packed_rows_A, nc, packedA_.numPackedCols());
-            }
-            break;
-
-          case inst_set_t::avx512:
-            fn = BaseType::template getOrCreate<inst_set_t::avx512>(
+#ifndef __aarch64__
+    if (nc != nbSize_) {
+      switch (isa) {
+        case inst_set_t::avx512_vnni:
+          if constexpr (std::is_same_v<
+                            typename packingAMatrix::accType,
+                            std::int16_t>) {
+            // For AVX512VNNI, we redirect int16_t to int32_t accumulation.
+            CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
+            fn = codeObj.getOrCreate<inst_set_t::avx512_vnni>(
                 accum, packed_rows_A, nc, packedA_.numPackedCols());
-            break;
-
-          case inst_set_t::avx512_ymm:
-            fn = BaseType::template getOrCreate<inst_set_t::avx512_ymm>(
+          } else {
+            fn = BaseType::template getOrCreate<inst_set_t::avx512_vnni>(
                 accum, packed_rows_A, nc, packedA_.numPackedCols());
-            break;
+          }
+          break;
 
-          case inst_set_t::avx2:
-            fn = BaseType::template getOrCreate<inst_set_t::avx2>(
+        case inst_set_t::avx512_vnni_ymm:
+          if constexpr (std::is_same_v<
+                            typename packingAMatrix::accType,
+                            std::int16_t>) {
+            // For AVX512VNNI, we redirect int16_t to int32_t accumulation.
+            CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
+            fn = codeObj.getOrCreate<inst_set_t::avx512_vnni_ymm>(
                 accum, packed_rows_A, nc, packedA_.numPackedCols());
-            break;
+          } else {
+            fn = BaseType::template getOrCreate<inst_set_t::avx512_vnni_ymm>(
+                accum, packed_rows_A, nc, packedA_.numPackedCols());
+          }
+          break;
 
-          default:
-            // TODO: Have default slower path
-            assert(0 && "unsupported architecture");
-            throw std::runtime_error("unsupported architecure");
-        }
+        case inst_set_t::avx512:
+          fn = BaseType::template getOrCreate<inst_set_t::avx512>(
+              accum, packed_rows_A, nc, packedA_.numPackedCols());
+          break;
+
+        case inst_set_t::avx512_ymm:
+          fn = BaseType::template getOrCreate<inst_set_t::avx512_ymm>(
+              accum, packed_rows_A, nc, packedA_.numPackedCols());
+          break;
+
+        case inst_set_t::avx2:
+          fn = BaseType::template getOrCreate<inst_set_t::avx2>(
+              accum, packed_rows_A, nc, packedA_.numPackedCols());
+          break;
+
+        default:
+          // TODO: Have default slower path
+          assert(0 && "unsupported architecture");
+          throw std::runtime_error("unsupported architecure");
       }
     }
+#endif // __aarch64__
 
     bBuf = packedB_.getBuf(jb, kBlock);
     // prefetch addr of the next packed block of B matrix
@@ -304,12 +777,34 @@ void ExecuteKernel<
       leadingDim = nbSize_;
     }
 
+#ifdef __aarch64__
+    // No JIT micro-kernel exists for arm; compute this block with the NEON
+    // kernel. `fn` bakes mc/nc/kc into the JIT'd code, so the NEON kernel
+    // takes them as arguments instead.
+    (void)bBuf_pf; // prefetch hint is unused on the NEON path
+#if FEAT_I8MM
+    computeBlockI8mm<typename packingAMatrix::accType>(
+#else
+    computeBlockNeon<typename packingAMatrix::accType>(
+#endif
+        aBuf,
+        bBuf,
+        C_buffer_start,
+        packed_rows_A, // mc
+        nc,
+        packedA_.numPackedCols(), // kc
+        packedA_.blockColSize(), // kBlock == A row stride (KCB)
+        packedB_.blockColSize(), // nBlock == NCB
+        accum,
+        leadingDim);
+#else
     fn(aBuf,
        bBuf,
        bBuf_pf,
        C_buffer_start,
        packedA_.numPackedCols(),
        leadingDim);
+#endif
 
 #ifdef FBGEMM_MEASURE_TIME_BREAKDOWN
     t_end = std::chrono::high_resolution_clock::now();
@@ -328,7 +823,7 @@ void ExecuteKernel<
           (C_buffer_start == C_tile_.data() ? (jb - jb_begin) * nbSize_
                                             : (jb_end - jb_begin) * nbSize_);
       if (nSize) {
-        if (fbgemmHasAvx2Support()) {
+        if (hasOutputProcessingKernel) {
           // TODO: avx512 path
           // Currently use avx2 code
           outputProcess_.template f<inst_set_t::avx2>(
@@ -350,7 +845,7 @@ void ExecuteKernel<
       if (C_buffer_start == C_tile_.data()) {
         // When C_tile_ scratchpad was used to avoid accessing memory past
         // C_buffer_ .
-        if (fbgemmHasAvx2Support()) {
+        if (hasOutputProcessingKernel) {
           // TODO: avx512 path
           // Currently use avx2 code
           outputProcess_.template f<inst_set_t::avx2>(

--- a/src/Fbgemm.cc
+++ b/src/Fbgemm.cc
@@ -51,11 +51,13 @@ void fbgemmPacked(
   if (!cpuinfo_initialize()) {
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
+#ifndef __aarch64__
   if ((!fbgemmHasAvx512VnniSupport() && !fbgemmHasAvx512Support() &&
        !fbgemmHasAvx2Support())) {
     assert(0 && "unknown architecure");
     throw std::runtime_error("unknown architecure");
   }
+#endif
 
   int64_t MCB = 0;
   int KCB = 0;
@@ -96,6 +98,13 @@ void fbgemmPacked(
             inst_set_t::avx512_ymm>::getCacheBlockParams();
         break;
 
+#ifdef __aarch64__
+      // aarch64 has no int8-specific cache-blocking params; reuse avx2 (the
+      // reference compute path consumes the same layout). Mirrors the
+      // sve/anyarch -> avx2 fall-through in FbgemmFP16.cc / FbgemmFP32.cc.
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         std::tie(MCB, KCB, MR) = PackingTraits<
             typename packingAMatrix::inpType,

--- a/src/FbgemmI8Spmdm.cc
+++ b/src/FbgemmI8Spmdm.cc
@@ -73,7 +73,15 @@ void CompressedSparseColumn::SpMDM(
   // This results in strided access, which we want to avoid.
   // Instead, we pre-transpose A and C, and compute C = (C^T + B^T * A^T)^T
 
-  if (IsHyperSparse()) {
+#ifdef __aarch64__
+  // aarch64 has no AVX2 transpose/compute kernels for the denser SpMDM path;
+  // the scalar loop below is a correct general fallback (it is what x86 uses
+  // for hyper-sparse inputs), so always take it here.
+  constexpr bool kForceScalarSpMDM = true;
+#else
+  constexpr bool kForceScalarSpMDM = false;
+#endif
+  if (kForceScalarSpMDM || IsHyperSparse()) {
     // The cost of transpose is O(K*N) and we do O(NNZ*N) multiplications.
     // If NNZ/K is small, it's not worth doing transpose so we just use this
     // scalar loop.
@@ -144,10 +152,9 @@ void CompressedSparseColumn::SpMDM(
     return;
   }
 
-#ifdef __aarch64__
-  throw std::runtime_error(
-      "No fallback for fbgemm::SpMDM when AVX2 is not available");
-#else
+// Everything below is unreachable on aarch64: kForceScalarSpMDM makes the
+// scalar path above handle every request.
+#ifndef __aarch64__
 
 #ifdef FBGEMM_MEASURE_TIME_BREAKDOWN
   t_end = std::chrono::high_resolution_clock::now();
@@ -275,7 +282,7 @@ void CompressedSparseColumn::SpMDM(
   t_start = std::chrono::high_resolution_clock::now();
 #endif
 
-#endif // __aarch64__
+#endif // !__aarch64__
 }
 
 void CompressedSparseColumn::SparseConv(

--- a/src/PackAMatrix.cc
+++ b/src/PackAMatrix.cc
@@ -38,10 +38,12 @@ PackAMatrix<T, accT>::PackAMatrix(
   if (!cpuinfo_initialize()) {
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
+#ifndef __aarch64__
   if ((!fbgemmHasAvx512VnniSupport() && !fbgemmHasAvx512Support() &&
        !fbgemmHasAvx2Support())) {
     assert(0 && "unknown architecure");
   }
+#endif
 
   if (params) {
     BaseType::brow_ = params->MCB;
@@ -73,6 +75,12 @@ PackAMatrix<T, accT>::PackAMatrix(
                 getMatrixPackAParams();
         break;
 
+#ifdef __aarch64__
+      // aarch64 has no int8-specific packing layout; reuse avx2 blocking
+      // params (the reference compute path consumes the same layout).
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx2>::getMatrixPackAParams();

--- a/src/PackAWithIm2Col.cc
+++ b/src/PackAWithIm2Col.cc
@@ -51,10 +51,12 @@ PackAWithIm2Col<T, accT, SPATIAL_DIM>::PackAWithIm2Col(
   if (!cpuinfo_initialize()) {
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
+#ifndef __aarch64__
   if ((!fbgemmHasAvx512VnniSupport() && !fbgemmHasAvx512Support() &&
        !fbgemmHasAvx2Support())) {
     assert(0 && "unknown architecure");
   }
+#endif
 
   if (params) {
     BaseType::brow_ = params->MCB;
@@ -86,6 +88,12 @@ PackAWithIm2Col<T, accT, SPATIAL_DIM>::PackAWithIm2Col(
                 getMatrixPackAParams();
         break;
 
+#ifdef __aarch64__
+      // aarch64 has no int8-specific packing layout; reuse avx2 blocking
+      // params (the reference compute path consumes the same layout).
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx2>::getMatrixPackAParams();
@@ -737,9 +745,19 @@ int PackAWithIm2Col<T, accT, SPATIAL_DIM>::rowOffsetBufferSize(
       } else if (fbgemmHasAvx2Support()) {
         return PackingTraits<T, accT, inst_set_t::avx2>::MCB;
       } else {
+#ifdef __aarch64__
+        // The packing ctor above routes sve/anyarch to the avx2 blocking
+        // params, so the row-offset buffer must be sized to match. Returning
+        // -1 here is not merely wrong, it is silent: with NDEBUG set (opt
+        // builds) the assert vanishes and callers do
+        // `vector<int32_t> buf(rowOffsetBufferSize())`, so -1 becomes a huge
+        // size_t and throws std::length_error.
+        return PackingTraits<T, accT, inst_set_t::avx2>::MCB;
+#else
         // TODO: Have default slower path
         assert(0 && "unsupported architecture");
         return -1;
+#endif
       }
     }
   } else {

--- a/src/PackAWithQuantRowOffset.cc
+++ b/src/PackAWithQuantRowOffset.cc
@@ -58,10 +58,12 @@ PackAWithQuantRowOffset<T, accT>::PackAWithQuantRowOffset(
   if (std::isinf(1.0f / scale_)) {
     throw std::runtime_error("scale's reciprocal cannot be infinity");
   }
+#ifndef __aarch64__
   if ((!fbgemmHasAvx512VnniSupport() && !fbgemmHasAvx512Support() &&
        !fbgemmHasAvx2Support())) {
     assert(0 && "unknown architecure");
   }
+#endif
 
   if (params) {
     BaseType::brow_ = params->MCB;
@@ -93,6 +95,12 @@ PackAWithQuantRowOffset<T, accT>::PackAWithQuantRowOffset(
                 getMatrixPackAParams();
         break;
 
+#ifdef __aarch64__
+      // aarch64 has no int8-specific packing layout; reuse avx2 blocking
+      // params (the reference compute path consumes the same layout).
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx2>::getMatrixPackAParams();
@@ -170,10 +178,13 @@ void PackAWithQuantRowOffset<T, accT>::pack(
       std::is_same_v<T, uint8_t>,
       "PackAWithQuantRowOffset<T, accT>::pack only works for T == uint8_t");
 
-  // Only scale and zero points are used in QuantizeAvx2
   TensorQuantizationParams qparams;
   qparams.scale = scale_;
   qparams.zero_point = zero_pt_;
+  // QuantizeAvx2 reads only scale and zero_point, but the portable Quantize()
+  // taken off x86 clamps to `precision` bits -- leaving it uninitialized
+  // quantizes A against a garbage bound.
+  qparams.precision = 8 * sizeof(T);
 
   for (int i = 0; i < block.row_size; ++i) {
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
@@ -257,8 +268,13 @@ int PackAWithQuantRowOffset<T, accT>::rowOffsetBufferSize(
       } else if (fbgemmHasAvx2Support()) {
         return PackingTraits<T, accT, inst_set_t::avx2>::MCB;
       } else {
+#ifdef __aarch64__
+        // aarch64 reuses the avx2 blocking params for the reference path.
+        return PackingTraits<T, accT, inst_set_t::avx2>::MCB;
+#else
         assert(0 && "unsupported architecture");
         return -1;
+#endif
       }
     }
   } else {

--- a/src/PackAWithRowOffset.cc
+++ b/src/PackAWithRowOffset.cc
@@ -43,10 +43,12 @@ PackAWithRowOffset<T, accT>::PackAWithRowOffset(
   if (!cpuinfo_initialize()) {
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
+#ifndef __aarch64__
   if ((!fbgemmHasAvx512VnniSupport() && !fbgemmHasAvx512Support() &&
        !fbgemmHasAvx2Support())) {
     assert(0 && "unknown architecure");
   }
+#endif
 
   if (params) {
     BaseType::brow_ = params->MCB;
@@ -78,6 +80,12 @@ PackAWithRowOffset<T, accT>::PackAWithRowOffset(
                 getMatrixPackAParams();
         break;
 
+#ifdef __aarch64__
+      // aarch64 has no int8-specific packing layout; reuse avx2 blocking
+      // params (the reference compute path consumes the same layout).
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx2>::getMatrixPackAParams();
@@ -224,9 +232,14 @@ int PackAWithRowOffset<T, accT>::rowOffsetBufferSize(
       } else if (fbgemmHasAvx2Support()) {
         return PackingTraits<T, accT, inst_set_t::avx2>::MCB;
       } else {
+#ifdef __aarch64__
+        // aarch64 reuses the avx2 blocking params for the reference path.
+        return PackingTraits<T, accT, inst_set_t::avx2>::MCB;
+#else
         // TODO: Have default slower path
         assert(0 && "unsupported architecture");
         return -1;
+#endif
       }
     }
   } else {

--- a/src/PackBMatrix.cc
+++ b/src/PackBMatrix.cc
@@ -221,6 +221,15 @@ PackBMatrix<T, accT>::PackBMatrix(
                 getMatrixPackBParams();
         break;
 
+#ifdef __aarch64__
+      // No aarch64-specific int8 packing layout exists yet; the NEON/SVE
+      // reference compute path (see ExecuteKernelU8S8) consumes the same
+      // interleaved layout the avx2 packing produces, so reuse its blocking
+      // params. Mirrors the sve/anyarch -> avx2 fall-through in FbgemmFP16.cc
+      // and FbgemmFP32.cc.
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_) =
             PackingTraits<T, accT, inst_set_t::avx2>::getMatrixPackBParams();

--- a/src/PackMatrix.cc
+++ b/src/PackMatrix.cc
@@ -37,10 +37,12 @@ int PackMatrix<PT, inpType, accType>::packedBufferSize(
   if (!cpuinfo_initialize()) {
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
+#ifndef __aarch64__
   if ((!fbgemmHasAvx512VnniSupport() && !fbgemmHasAvx512Support() &&
        !fbgemmHasAvx2Support())) {
     assert(0 && "unknown architecure");
   }
+#endif
 
   int MCB = 0, KCB = 0, NCB = 0;
   if (params) {
@@ -74,6 +76,12 @@ int PackMatrix<PT, inpType, accType>::packedBufferSize(
         KCB = PackingTraits<inpType, accType, inst_set_t::avx512_ymm>::KCB;
         break;
 
+#ifdef __aarch64__
+      // aarch64 has no int8-specific packing layout; reuse avx2 blocking
+      // params (the reference compute path consumes the same layout).
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         MCB = PackingTraits<inpType, accType, inst_set_t::avx2>::MCB;
         NCB = PackingTraits<inpType, accType, inst_set_t::avx2>::NCB;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3061


Ports fbgemm's u8s8 quantized GEMM to aarch64. Before this,
`PackedRequantizeAcc16Test` and its siblings SIGABRT before running a single
case: fbgemm dispatches on `fbgemmInstructionSet()` over the AVX variants only
and hits `assert(0 && "unknown architecure")` for anything else, and on aarch64
the ISA resolves to sve/anyarch.

**1. Layout routing.** Everywhere fbgemm picks blocking parameters, sve/anyarch
now routes to the avx2 params under `#ifdef __aarch64__` -- the same
fall-through FbgemmFP16.cc / FbgemmFP32.cc already use. Sites: PackBMatrix,
PackAMatrix, PackAWithRowOffset, PackAWithQuantRowOffset, PackAWithIm2Col,
PackMatrix, ExecuteKernelU8S8, and the cache-block switch in Fbgemm.cc. The
x86-SIMD entry guards are wrapped in `#ifndef __aarch64__`.

**2. Sizing -- `rowOffsetBufferSize` must not return -1.** The fbgemm idiom is
`assert(0); return -1;`, but opt builds define NDEBUG, so the assert vanishes
and -1 really is returned. Callers size a buffer straight from it
(Im2ColFusedRequantizeTest.cc:174, FbgemmConv.cc:303), where -1 becomes a huge
size_t and throws `std::length_error` -- killing the whole test binary, not one
case. Fixed in PackAWithRowOffset, PackAWithQuantRowOffset and PackAWithIm2Col
by returning the same avx2 MCB the packing ctor picked.

**3. The compute kernels: I8MM fast path, NEON fallback, no scalar.** On x86
the inner MAC is JIT-generated asm; no arm equivalent exists. This adds two
kernels in ExecuteKernelU8S8.cc, both consuming the packed interleaved layout
the routing above selects, chosen at compile time:

`computeBlockI8mm`, used when the compilation target has the Arm Int8 Matrix
Multiplication extension (new `FEAT_I8MM` macro in include/fbgemm/Utils.h,
set from `__ARM_FEATURE_MATMUL_INT8`; the internal arm platform enables it).
acc16 uses USDOT with the saturating narrow, reproducing the vpmaddubsw/
vpaddsw contract exactly; acc32 uses USMMLA 2x2 tiles, which accumulate in
int32 throughout -- exactly `matmul_u8i8acc32_ref`, differing from the avx2
JIT only for a K pair whose product sum leaves int16 range.

`computeBlockNeon`, the fallback for aarch64 targets without FEAT_I8MM. The
layout is ideal for NEON -- vld2 (acc16) / vld4 (acc32) de-interleave a
K-pair/quad for 8 columns per load -- and each x86 instruction maps lane-wise:
- `vpmaddubsw` (saturating u8*s8 pair reduction) = `vmull_n_s16`/`vmlal_n_s16`
  into int32 lanes, then the saturating narrow `vqmovn_s32`
- `vpaddsw` (acc16's saturating int16 accumulate) = `vqaddq_s16`
- `vpmaddwd` + `vpaddd` (acc32's widen-and-add) = `vaddl_s16` + `vaddq_s32`
Columns past the last multiple of 8 take a scalar tail with identical
arithmetic. The saturation points are the whole ballgame: a plain int32 dot
product passes small cases and diverges on large ones (acc16's contract,
matmul_u8i8acc16_ref, saturates by definition).

**4. A latent quantization bug, exposed and fixed.** `PackAWithQuantRowOffset
::pack` left `TensorQuantizationParams::precision` uninitialized -- harmless on
x86, where QuantizeAvx2 hardcodes 8-bit and never reads it, but off x86 the
portable `Quantize()` clamps against `(1 << precision) - 1`, quantizing A into
garbage. Every `TestFloatInputOutput` case failed on real arm hardware with
wildly wrong results; the CI arm runners skip those cases, so no prior run had
ever exercised them. Fixed by setting `precision = 8 * sizeof(T)`, the same
idiom the sibling construction in QuantUtils.cc already uses. This is also
what made the test suite *appear to hang* during review: each failing case
dumped gigabytes of element-by-element gtest diffs, and the test runner's
event bus aborts past 4GB of output.

Deliberately, there is no scalar kernel: per fbgemm maintainer guidance, a
performance library must ship high-throughput algorithms only -- a scalar
one-element-at-a-time fallback makes the CPU look slow and is discoverable
only by profiling, whereas an unimplemented architecture should fail loudly.
Architectures that are neither x86_64 nor aarch64 keep the pre-existing
assert-and-throw at every dispatch layer.

Considered and rejected: reusing QNNPACK's aarch64 q8gemm microkernels.
(1) the acc16 contract requires saturating int16 pair-reduction and
accumulation, which QNNPACK's int32-accumulating kernels cannot express;
(2) QNNPACK kernels consume their own packed-W layout and fuse requantization,
incompatible with the packed-B layout and separate output-processing pipeline
everything else here consumes; (3) the dependency points the wrong way --
QNNPACK lives in pytorch, pytorch depends on this library.

`FbgemmI8Spmdm.cc` additionally forces the scalar SpMDM path on aarch64 (the
same loop x86 uses for hyper-sparse inputs) rather than throwing, since the
denser path needs AVX2 transpose kernels. Output processing needs no new
dispatch: `OutputProcessing-inl.h` already forces its generic implementation
under `#if defined(__aarch64__)`, so the existing `f<inst_set_t::avx2>` calls
resolve to portable code via one `hasOutputProcessingKernel` flag. The NR_MIN
rounding of the last column block is computed once into `nc` and shared by the
JIT selection and the NEON kernel, so the two cannot drift.

Reviewed By: Nicoshev

Differential Revision: D116394337


