### PR TITLE
Remove unused type error suppressions

### DIFF
--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -75,7 +75,6 @@ def benchmark_torch_function(  # noqa: C901
             f_list.append(copy.deepcopy(f) if copy_f_for_multi_thread_test else f)
 
         @torch.inference_mode()
-        # pyre-ignore[53]
         def forward(idx: int) -> None:
             stream = torch.cuda.Stream()
             f_temp = f_list[idx]

--- a/fbgemm_gpu/experimental/example/example/__init__.py
+++ b/fbgemm_gpu/experimental/example/example/__init__.py
@@ -18,7 +18,6 @@ try:
 except Exception:
     open_source: bool = False
 
-# pyre-ignore[16]
 if open_source:
     torch.ops.load_library(
         os.path.join(os.path.dirname(__file__), "fbgemm_gpu_experimental_example_py.so")

--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp4_quantize.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp4_quantize.py
@@ -5615,15 +5615,12 @@ def get_nvfp4_global_scales_naive(
     w_global_scales = []
 
     for x, w in zip(xs, ws):
-        # pyre-ignore
         x_global_scale: torch.Tensor = (448.0 * 6.0) / torch.amax(
             torch.abs(x.flatten()), dim=-1
         ).to(torch.float32)
-        # pyre-ignore
         w_global_scale: torch.Tensor = (448.0 * 6.0) / torch.amax(
             torch.abs(w.flatten()), dim=-1
         ).to(torch.float32)
-        # pyre-ignore
         global_scale: torch.Tensor = 1 / (x_global_scale * w_global_scale)
 
         global_scales.append(global_scale)

--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
@@ -30,7 +30,6 @@ logger: logging.Logger = logging.getLogger(__name__)
 running_on_github: bool = os.getenv("GITHUB_ENV") is not None
 
 try:
-    # pyre-ignore[21]
     from triton.fb.compat import disable_bufferops  # @manual
 except ModuleNotFoundError:
     # Ensure we can call disable_bufferops if compat is not included (e.g. opensource)
@@ -1134,7 +1133,6 @@ def _kernel_matmul_fp8_row_tma_persistent_ws_cooperative(
         # pyre-ignore
         tl.assume(tl.cdiv(K, BLOCK_K) > 0)
         for _ in range(0, tl.cdiv(K, BLOCK_K)):
-            # pyre-ignore
             with tl.async_task([0]):
                 a = tl._experimental_descriptor_load(
                     A_ptr,
@@ -1155,7 +1153,6 @@ def _kernel_matmul_fp8_row_tma_persistent_ws_cooperative(
 
             offs_k += BLOCK_K
 
-        # pyre-ignore
         with tl.async_task([1, NUM_CONSUMER_GROUPS]):
             # Invert scaling.
             rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
@@ -1420,7 +1417,6 @@ def matmul_fp8_row(
         if bias is not None:
             bias_dtype_triton = map_dtype_to_triton(bias.dtype)
 
-        # pyre-ignore
         torch._library.capture_triton(
             _kernel_matmul_fp8_row_tma_persistent_ws_cooperative
         )[persistent_grid_tma_ws](
@@ -2882,17 +2878,16 @@ def quantize_fp8_packed_row(
     if scale_ub is not None:
         row_max = torch.clamp(row_max, min=eps, max=scale_ub.item())
     else:
-        # pyre-ignore[6]: Incompatible parameter type [6]
         row_max = torch.clamp(row_max, min=eps)
     a_scale = torch.empty((a.shape[:-1]), dtype=torch.float32, device=output_device)
-    a_scale = max_fp8 / row_max.to(torch.float32)  # pyre-ignore
-    a_scale[a_scale == float("inf")] = 1.0  # pyre-ignore
-    a_fp8 = a * a_scale[..., None]  # pyre-ignore
+    a_scale = max_fp8 / row_max.to(torch.float32)
+    a_scale[a_scale == float("inf")] = 1.0
+    a_fp8 = a * a_scale[..., None]
     # Cast and move data to output device (for cpu weight loading).
     a_fp8 = a_fp8.to(device=output_device, dtype=pt_dtype)
-    a_scale = a_scale.to(output_device)  # pyre-ignore
+    a_scale = a_scale.to(output_device)
     del a
-    return a_fp8, (1 / a_scale).view(a_shape[:-1])  # pyre-ignore
+    return a_fp8, (1 / a_scale).view(a_shape[:-1])
 
 
 @torch.library.custom_op("triton::quantize_fp8_packed_row_raw", mutates_args=())
@@ -2981,17 +2976,16 @@ def quantize_fp8_row(
     if scale_ub is not None:
         row_max = torch.clamp(row_max, min=eps, max=scale_ub.item())
     else:
-        # pyre-ignore[6]: Incompatible parameter type [6]
         row_max = torch.clamp(row_max, min=eps)
     a_scale = torch.empty((a.shape[:-1]), dtype=torch.float32, device=output_device)
-    a_scale = max_fp8 / row_max.to(torch.float32)  # pyre-ignore
-    a_scale[a_scale == float("inf")] = 1.0  # pyre-ignore
-    a_fp8 = a * a_scale[..., None]  # pyre-ignore
+    a_scale = max_fp8 / row_max.to(torch.float32)
+    a_scale[a_scale == float("inf")] = 1.0
+    a_fp8 = a * a_scale[..., None]
     # Cast and move data to output device (for cpu weight loading).
     a_fp8 = a_fp8.to(device=output_device, dtype=pt_dtype)
-    a_scale = a_scale.to(output_device)  # pyre-ignore
+    a_scale = a_scale.to(output_device)
     del a
-    return a_fp8, (1 / a_scale).view(a_shape[:-1])  # pyre-ignore
+    return a_fp8, (1 / a_scale).view(a_shape[:-1])
 
 
 @quantize_fp8_row.register_fake
@@ -3355,22 +3349,20 @@ def quantize_fp8_block(
     else:
         block_max = torch.clamp(block_max, min=eps)
     x_scale = torch.empty((grid_m, grid_k), dtype=torch.float32, device=output_device)
-    x_scale = max_fp8 / block_max.to(torch.float32)  # pyre-ignore
-    # pyre-ignore[16]: Undefined attribute [16]
+    x_scale = max_fp8 / block_max.to(torch.float32)
     x_scale[x_scale == float("inf")] = 1.0
     x_fp8 = (
         x_padded
-        # pyre-ignore[16]: Undefined attribute [16]
         * x_scale.repeat_interleave(block_m, dim=0).repeat_interleave(block_k, dim=1)
     )[:M, :K]
 
     # Cast and move data to output device (for cpu weight loading).
     x_fp8 = x_fp8.to(device=output_device, dtype=pt_dtype)
-    x_scale = x_scale.to(output_device)  # pyre-ignore
+    x_scale = x_scale.to(output_device)
     del x, x_padded
     if not k_major:
         x_scale = x_scale.t().contiguous()
-    return x_fp8.view(x_shape), 1 / x_scale  # pyre-ignore
+    return x_fp8.view(x_shape), 1 / x_scale
 
 
 @triton.autotune(
@@ -3656,17 +3648,16 @@ def quantize_fp8_group(
         else torch.clamp(group_max, min=eps)
     )
     x_scale = torch.empty((M, k_groups), dtype=torch.float32, device=output_device)
-    x_scale = max_fp8 / group_max  # pyre-ignore
-    # pyre-ignore[16]: Undefined attribute [16]
+    x_scale = max_fp8 / group_max
     x_scale[x_scale == float("inf")] = 1.0
     # pyre-ignore[16]: Undefined attribute [16]
     x_fp8 = x.view(-1, k_groups, group_size) * x_scale.unsqueeze(2)
     # Cast and move data to output device (for cpu weight loading).
     x_fp8 = x_fp8.to(device=output_device, dtype=pt_dtype)
-    x_scale = x_scale.to(output_device)  # pyre-ignore
+    x_scale = x_scale.to(output_device)
     if not k_major:
         x_scale = x_scale.t().contiguous()
-    return x_fp8.view(x_shape), 1 / x_scale  # pyre-ignore
+    return x_fp8.view(x_shape), 1 / x_scale
 
 
 def need_split_k(SIZE_M, SIZE_N, SIZE_K):

--- a/fbgemm_gpu/experimental/hstu/hstu/cuda_hstu_attention.py
+++ b/fbgemm_gpu/experimental/hstu/hstu/cuda_hstu_attention.py
@@ -643,7 +643,6 @@ class HstuAttnVarlenFunc(torch.autograd.Function):
             )
 
         # q & k grad shape
-        # pyrefly: ignore [bad-return]
         return (
             dq,
             dk,

--- a/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
@@ -25,12 +25,10 @@ except Exception:
 
 
 try:
-    # pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
     open_source = bool(getattr(fbgemm_gpu, "open_source", False))
 except NotImplementedError:
     open_source = False
 
-# pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
 if not open_source:
     # The MTIA mx4 kernels dep is gated to MTIA builds (see BUCK), so on
     # non-MTIA builds the module is entirely absent and the import raises

--- a/fbgemm_gpu/fbgemm_gpu/sll/cpu/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/cpu/__init__.py
@@ -25,7 +25,6 @@ from fbgemm_gpu.sll.cpu.cpu_sll import (  # noqa F401
     cpu_jagged_softmax,
 )
 
-# pyre-ignore[5]
 op_registrations = {
     "sll_jagged_dense_bmm": {
         "CPU": cpu_jagged_dense_bmm,

--- a/fbgemm_gpu/fbgemm_gpu/sll/meta/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/meta/__init__.py
@@ -15,7 +15,6 @@ from fbgemm_gpu.sll.meta.meta_sll import (  # noqa F401
     meta_jagged_self_substraction_jagged_out,
 )
 
-# pyre-ignore[5]
 op_registrations = {
     "sll_jagged_self_substraction_jagged_out": {
         "Meta": meta_jagged_self_substraction_jagged_out,

--- a/fbgemm_gpu/fbgemm_gpu/sll/triton/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/triton/__init__.py
@@ -58,7 +58,6 @@ from fbgemm_gpu.sll.triton.triton_multi_head_jagged_flash_attention import (  # 
     MultiHeadJaggedFlashAttention,  # noqa F401
 )
 
-# pyre-ignore[5]
 op_registrations = {
     "sll_dense_jagged_cat_jagged_out": {
         "CUDA": dense_jagged_cat_jagged_out,

--- a/fbgemm_gpu/fbgemm_gpu/sll/triton/triton_jagged_dense_flash_attention.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/triton/triton_jagged_dense_flash_attention.py
@@ -86,10 +86,7 @@ def jagged_dense_flash_attention_fwd_kernel(
 
         # Load a block of K into [BLOCK_L, BLOCK_D]
         qj_ptrs = (
-            q_start_ptr
-            # pyre-fixme[16]: `int` has no attribute `__getitem__`.
-            + offs_l[:, None] * stride_ql
-            + offs_d[None, :] * stride_qd
+            q_start_ptr + offs_l[:, None] * stride_ql + offs_d[None, :] * stride_qd
         )
 
         qj = tl.load(

--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -53,12 +53,11 @@ from torch import SymInt, Tensor
 from torch.fx.experimental.symbolic_shapes import guard_or_true
 
 if hasattr(torch.library, "register_fake"):
-    # pyre-ignore[9]
     impl_abstract = torch.library.register_fake
 elif hasattr(torch.library, "impl_abstract"):
     impl_abstract = torch.library.impl_abstract
 else:
-    # pyre-ignore
+
     def impl_abstract(
         schema: str,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
@@ -91,11 +90,9 @@ def permute_2D_sparse_data_input1D_meta(
     else:
         ctx = torch.library.get_ctx()
         permuted_indices_size = ctx.new_dynamic_size()
-    # pyre-fixme
     permuted_indices = indices.new_empty(permuted_indices_size)
     permuted_weights = None
     if weights is not None:
-        # pyre-fixme
         permuted_weights = weights.new_empty(permuted_indices_size)
     return permuted_lengths, permuted_indices, permuted_weights
 
@@ -177,7 +174,6 @@ def permute_2D_sparse_preallocated_out_meta(
     else:
         ctx = torch.library.get_ctx()
         permuted_indices_size = ctx.new_dynamic_size()
-    # pyre-fixme
     permuted_indices = (
         permuted_indices_out
         if permuted_indices_out is not None
@@ -185,7 +181,6 @@ def permute_2D_sparse_preallocated_out_meta(
     )
     permuted_weights = None
     if weights is not None:
-        # pyre-fixme
         permuted_weights = (
             permuted_weights_out
             if permuted_weights_out is not None
@@ -327,7 +322,6 @@ def permute_1D_sparse_data_meta(
     else:
         ctx = torch.library.get_ctx()
         permuted_indices_size = ctx.new_dynamic_size()
-    # pyre-fixme
     permuted_indices = indices.new_empty(permuted_indices_size)
     permuted_weights = None
     if weights is not None:
@@ -751,12 +745,10 @@ def permute_sparse_features_abstract(
     B = lengths.size(1)
     permuted_lengths = lengths.new_empty(num_output_features, B)
     output_size = torch.library.get_ctx().new_dynamic_size()
-    # pyre-fixme[6]: In call `torch._C.TensorBase.new_empty`, for 1st positional argument,
     # expected `Sequence[int | types.SymInt]` but got `int | torch.SymInt`
     permuted_indices = indices.new_empty(output_size)
     permuted_weights = None
     if weights is not None:
-        # pyre-fixme[6]: In call `torch._C.TensorBase.new_empty`, for 1st positional argument,
         # expected `Sequence[int | types.SymInt]` but got `int | torch.SymInt`
         permuted_weights = weights.new_empty(output_size)
     return (permuted_lengths, permuted_indices, permuted_weights)
@@ -939,12 +931,10 @@ def keyed_jagged_index_select_dim1_abstract(
     This meta function is used to calculate the shape of output tensors
     from the original function `fbgemm::keyed_jagged_index_select_dim1` without the actual data.
     """
-    # pyre-ignore
     num_batches = len(lengths) // batch_size
     # offsets = [0] + lengths.cumsum(0)
     torch._check(len(lengths) + 1 == len(offsets))
     # len(lengths) == batch_size * num_batches
-    # pyre-ignore
     torch._check(len(lengths) % batch_size == 0)
     if weights is not None:
         # weights must have the same shape as values
@@ -952,7 +942,6 @@ def keyed_jagged_index_select_dim1_abstract(
 
     if selected_lengths_sum is None:
         length_indices = torch.cat(
-            # pyre-ignore
             [indices + i * batch_size for i in range(num_batches)]
         )
         selected_lengths_sum = (
@@ -1151,7 +1140,6 @@ def keyed_jagged_index_select_dim1_forward_cuda_impl_abstract(
 ) -> list[torch.Tensor]:
     num_batches = lengths.size(0) // batch_size
     torch._check(lengths.size(0) + 1 == offsets.size(0))
-    # pyre-fixme[58]: `%` is not supported for operand types `int` and `SymInt`.
     torch._check(lengths.size(0) % batch_size == 0)
 
     if weights is not None:

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -228,7 +228,6 @@ class EmbOptimType(enum.Enum):
                     torch.empty(
                         # If the state size is 1, then fix tensor to 1D to be
                         # consistent with training.py code
-                        # pyre-ignore [6]
                         (r, d) if d > 1 else r,
                         dtype=self._extract_dtype(optimizer_state_dtypes, state_name),
                         device="cpu",

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
@@ -196,7 +196,6 @@ def inputs_to_device(
     return indices, offsets, per_sample_weights
 
 
-# pyre-fixme[13]: Attribute `cache_miss_counter` is never initialized.
 class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
     """
     Table-batched version of nn.EmbeddingBag(sparse=False)
@@ -345,15 +344,10 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
     embedding_specs: list[tuple[str, int, int, SparseType, EmbeddingLocation]]
     record_cache_metrics: RecordCacheMetrics
-    # pyre-fixme[13]: Attribute `cache_miss_counter` is never initialized.
     cache_miss_counter: torch.Tensor
-    # pyre-fixme[13]: Attribute `uvm_cache_stats` is never initialized.
     uvm_cache_stats: torch.Tensor
-    # pyre-fixme[13]: Attribute `local_uvm_cache_stats` is never initialized.
     local_uvm_cache_stats: torch.Tensor
-    # pyre-fixme[13]: Attribute `weights_offsets` is never initialized.
     weights_offsets: torch.Tensor
-    # pyre-fixme[13]: Attribute `weights_placements` is never initialized.
     weights_placements: torch.Tensor
 
     def __init__(  # noqa C901
@@ -843,7 +837,6 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
     def prefetch(self, indices: Tensor, offsets: Tensor) -> None:
         self.timestep_counter.increment()
         self.timestep_prefetch_size.increment()
-        # pyre-fixme[29]: `(self: TensorBase) -> int | Module | Tensor` is not
         #  a function.
         if not self.lxu_cache_weights.numel():
             return
@@ -1100,7 +1093,6 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 self.index_remappings_array,
                 self.index_remappings_array_offsets,
             )
-        # pyre-fixme[29]: `(self: TensorBase) -> int | Module | Tensor` is not
         #  a function.
         if self.lxu_cache_weights.numel() > 0:
             if self.timestep_prefetch_size.get() <= 0:
@@ -1293,7 +1285,6 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         # pyre-fixme[16]: `IntNBitTableBatchedEmbeddingBagsCodegen` has no attribute
         #  `lxu_cache_weights`.
         self.lxu_cache_weights = torch.empty_like(
-            # pyre-fixme[6]: For 1st argument expected `Tensor` but got
             #  `Module | Tensor`.
             self.lxu_cache_weights,
             device=self.current_device,
@@ -1587,7 +1578,6 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             self.reset_uvm_cache_stats()
 
     def reset_cache_states(self) -> None:
-        # pyre-fixme[29]: `(self: TensorBase) -> int | Module | Tensor` is not
         #  a function.
         if not self.lxu_cache_weights.numel():
             return
@@ -1623,7 +1613,6 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 for i, weight in enumerate(weights):
                     weights[i] = (
                         weight[0].to(device),
-                        # pyre-fixme[16]: Undefined attribute: `Optional` has no attribute `to`.
                         weight[1].to(device) if weight[1] is not None else None,
                     )
             (
@@ -1989,7 +1978,6 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
             if self.use_cpu:
                 self.index_remapping_hash_table_cpu = (
-                    # pyre-ignore[16]
                     torch.classes.fbgemm.PrunedMapCPU()
                 )
                 self.index_remapping_hash_table_cpu.insert(
@@ -2106,7 +2094,6 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             )
 
         lxu_cache_locations = None
-        # pyre-fixme[29]: `(self: TensorBase) -> int | Module | Tensor` is not
         #  a function.
         if self.lxu_cache_weights.numel() > 0:
             linear_cache_indices = (

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -254,7 +254,6 @@ def apply_split_helper(
         dev_buffer = torch.zeros(
             split.dev_size,
             device=current_device,
-            # pyre-fixme[6]
             dtype=dtype,
         )
         dev_buffer = (
@@ -293,7 +292,6 @@ def apply_split_helper(
             host_buffer = torch.zeros(
                 split.host_size,
                 device=current_device,
-                # pyre-fixme[6]: Expected `type[torch._dtype] | None` for
                 #  3rd param but got `type[type[torch._dtype]]`.
                 dtype=dtype,
             )
@@ -329,7 +327,6 @@ def apply_split_helper(
                 torch.zeros(
                     split.uvm_size,
                     device=current_device,
-                    # pyre-fixme[6]: Expected `type[torch._dtype] | None` for
                     #  3rd param but got `type[type[torch._dtype]]`.
                     dtype=dtype,
                 ),
@@ -341,7 +338,6 @@ def apply_split_helper(
                     split.uvm_size,
                     device=current_device,
                     out=torch.ops.fbgemm.new_unified_tensor(
-                        # pyre-fixme[6]: Expected `type[torch._dtype] | None`
                         #  for 3rd param but got `type[type[torch._dtype]]`.
                         torch.zeros(1, device=current_device, dtype=dtype),
                         [split.uvm_size],
@@ -368,8 +364,6 @@ def get_available_compute_device() -> ComputeDevice:
         return ComputeDevice.CPU
 
 
-# pyre-fixme[13]: Attribute `uvm_cache_stats` is never initialized.
-# pyre-fixme[13]: Attribute `local_uvm_cache_stats` is never initialized.
 class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
     """
     Table Batched Embedding (TBE) operator.  Looks up one or more embedding
@@ -631,12 +625,9 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
     timesteps_prefetched: list[int]
     prefetched_info_list: list[PrefetchedInfo]
     record_cache_metrics: RecordCacheMetrics
-    # pyre-fixme[13]: Attribute `uvm_cache_stats` is never initialized.
     uvm_cache_stats: torch.Tensor
-    # pyre-fixme[13]: Attribute `local_uvm_cache_stats` is never initialized.
     local_uvm_cache_stats: torch.Tensor
     uuid: str
-    # pyre-fixme[13]: Attribute `last_uvm_cache_print_state` is never initialized.
     last_uvm_cache_print_state: torch.Tensor
     _vbe_B_offsets: torch.Tensor | None
     _vbe_max_B: int
@@ -1599,7 +1590,6 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 torch.zeros(
                     1,
                     device=self.current_device,
-                    # pyre-ignore Incompatible parameter type [6]: In call `torch._C._VariableFunctions.empty`, for argument `dtype`, expected `dtype | None` but got `Module | dtype | Tensor`
                     dtype=self.lxu_cache_weights.dtype,
                 ),
                 self.lxu_cache_weights.shape,
@@ -4401,7 +4391,6 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 per_sample_weights (Tensor | None): Input per
                     sample weights
             """
-            # pyre-fixme[29]: `Union[(self: TensorBase, other: Union[bool, complex,
             #  float, int, Tensor]) -> Tensor, Module, Tensor]` is not a function.
             if self.debug_step % 100 == 0:
                 # Get number of features (T) and batch size (B)
@@ -4488,9 +4477,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                         avg_seglen_cta_per_row_mth,
                     )
                 )
-            # pyre-fixme[16]: `SplitTableBatchedEmbeddingBagsCodegen` has no
             #  attribute `debug_step`.
-            # pyre-fixme[29]: `Union[(self: TensorBase, other: Union[bool, complex,
             #  float, int, Tensor]) -> Tensor, Module, Tensor]` is not a function.
             self.debug_step += 1
 
@@ -4830,7 +4817,6 @@ class DenseTableBatchedEmbeddingBagsCodegen(nn.Module):
                 SparseType.BF16,
             ], "Fused pooled embedding quantization only supported for cuda."
 
-        # pyre-fixme[8]: Attribute has type `device`; used as `int | device`.
         self.current_device: torch.device = (
             torch.device("cpu")
             if self.use_cpu

--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/bench_runs.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/bench_runs.py
@@ -666,14 +666,12 @@ def benchmark_vbe(
     for i, (indices, offsets, weights) in enumerate(requests):
         # forward
         if use_cuda:
-            # pyre-ignore[61]
             fwd_start_events[i].record()
         else:
             start_time = time.time()
 
         out = func(indices, offsets, weights)
         if use_cuda:
-            # pyre-ignore[61]
             fwd_end_events[i].record()
         else:
             # pyre-ignore[61]
@@ -682,14 +680,12 @@ def benchmark_vbe(
         grad = torch.rand_like(out)
 
         if use_cuda:
-            # pyre-ignore[61]
             bwd_start_events[i].record()
         else:
             start_time = time.time()
         # backward
         out.backward(grad)
         if use_cuda:
-            # pyre-ignore[61]
             bwd_end_events[i].record()
         else:
             # pyre-ignore[61]
@@ -701,12 +697,10 @@ def benchmark_vbe(
     if use_cuda:
         fwd_times_sec = [
             start_event.elapsed_time(end_event) * 1.0e-3
-            # pyre-ignore[61]
             for start_event, end_event in zip(fwd_start_events, fwd_end_events)
         ]
         bwd_times_sec = [
             start_event.elapsed_time(end_event) * 1.0e-3
-            # pyre-ignore[61]
             for start_event, end_event in zip(bwd_start_events, bwd_end_events)
         ]
 

--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/eval_compression.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/eval_compression.py
@@ -116,7 +116,6 @@ def benchmark_eval_compression(
     compressed_bwd = statistics.median(bwd_times)
 
     return EvalCompressionBenchmarkOutput(
-        # pyrefly: ignore [bad-argument-type]
         avg,
         fwd,
         bwd,

--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/__init__.py
@@ -21,7 +21,7 @@ from .cache_config import (  # noqa: F401
 # the symbol resolves under torch.package, whose importer does not honor
 # importlib.import_module calls inside a module-level __getattr__.
 try:
-    # pyre-ignore[21]: `.split_embeddings_cache_ops` is only present in heavy target.
+    # pyrefly: ignore [missing-import]
     from .split_embeddings_cache_ops import get_unique_indices_v2  # noqa: F401
 except ImportError:
     pass

--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/kv_embedding_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/kv_embedding_ops_inference.py
@@ -78,30 +78,25 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
         embedding_cache_mode: bool = False,  # True for zero initialization, False for randomized initialization
     ) -> None:  # noqa C901  # tuple of (rows, dims,)
         super().__init__(
-            # pyre-fixme[6]: Type-identity mismatch on EmbeddingLocation between shell
             # and canonical package; resolves once D103477971 unifies the classes via re-export.
             embedding_specs=embedding_specs,
             feature_table_map=feature_table_map,
             index_remapping=index_remapping,
-            # pyre-fixme[6]: Type-identity mismatch on PoolingMode between shell and
             # canonical package; resolves once D103477971 unifies the classes via re-export.
             pooling_mode=pooling_mode,
             device=device,
-            # pyre-fixme[6]: Type-identity mismatch on BoundsCheckMode between shell
             # and canonical package; resolves once D103477971 unifies the classes via re-export.
             bounds_check_mode=bounds_check_mode,
             weight_lists=weight_lists,
             pruning_hash_load_factor=pruning_hash_load_factor,
             use_array_for_index_remapping=use_array_for_index_remapping,
             output_dtype=output_dtype,
-            # pyre-fixme[6]: Type-identity mismatch on CacheAlgorithm between shell
             # and canonical package; resolves once D103477971 unifies the classes via re-export.
             cache_algorithm=cache_algorithm,
             cache_load_factor=cache_load_factor,
             cache_sets=cache_sets,
             cache_reserved_memory=cache_reserved_memory,
             enforce_hbm=enforce_hbm,
-            # pyre-fixme[6]: Type-identity mismatch on RecordCacheMetrics between shell
             # and canonical package; resolves once D103477971 unifies the classes via re-export.
             record_cache_metrics=record_cache_metrics,
             gather_uvm_cache_stats=gather_uvm_cache_stats,
@@ -330,7 +325,6 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
         assert table_id < len(
             self.embedding_specs
         ), f"table index {table_id} is out of range {len(self.embedding_specs)}"
-        # pyre-ignore [29]
         table_offset = self.hash_size_cumsum[table_id]
         sharding_offset = self.table_sharding_offset[table_id]
 

--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/uvm.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/uvm.py
@@ -21,7 +21,6 @@ except Exception:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:cumem_utils")
 
 # Import all uvm enums from c++ library
-# pyre-fixme[6]: For 2nd argument expected `() -> list[tuple[str, list[tuple[str,
 #  int]]]]` but got `OpOverloadPacket`.
 create_enums(globals(), torch.ops.fbgemm.fbgemm_gpu_uvm_enum_query)
 

--- a/fbgemm_gpu/fbgemm_gpu/tbe/monitoring/bench_params_reporter.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/monitoring/bench_params_reporter.py
@@ -23,7 +23,6 @@ from fbgemm_gpu.tbe.bench.tbe_data_config import (
 )
 
 open_source: bool = False
-# pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
 open_source: bool = getattr(fbgemm_gpu, "open_source", False)
 
 if open_source:

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/__init__.py
@@ -25,28 +25,28 @@ from .ssd_config import (  # noqa: F401
 # submodule, so a real circular / "cannot import name" error isn't masked (D107684315).
 # Eager (not a lazy `__getattr__`) so the symbols resolve under torch.package.
 try:
-    # pyre-ignore[21]: `.common` is only present in the heavy target.
+    # pyrefly: ignore [missing-import]
     from .common import ASSOC  # noqa: F401
 except ModuleNotFoundError as e:
     if e.name != "fbgemm_gpu.tbe.ssd.common":
         raise
 
 try:
-    # pyre-ignore[21]: fbgemm_gpu C extensions are not analyzed by Pyre.
+    # pyrefly: ignore [missing-import]
     from .inference import SSDIntNBitTableBatchedEmbeddingBags  # noqa: F401
 except ModuleNotFoundError as e:
     if e.name != "fbgemm_gpu.tbe.ssd.inference":
         raise
 
 try:
-    # pyre-ignore[21]: fbgemm_gpu C extensions are not analyzed by Pyre.
+    # pyrefly: ignore [missing-import]
     from .inference_serving import TurboSSDInferenceModule  # noqa: F401
 except ModuleNotFoundError as e:
     if e.name != "fbgemm_gpu.tbe.ssd.inference_serving":
         raise
 
 try:
-    # pyre-ignore[21]: fbgemm_gpu C extensions are not analyzed by Pyre.
+    # pyrefly: ignore [missing-import]
     from .training import DramKvPerfStat, SSDTableBatchedEmbeddingBags  # noqa: F401
 except ModuleNotFoundError as e:
     if e.name != "fbgemm_gpu.tbe.ssd.training":

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
@@ -830,7 +830,6 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
             self.ssd_db.flush()
 
             # 2. Open a new RocksDB instance at the new snapshot path.
-            # pyre-ignore[16]
             self.ssd_db = torch.classes.fbgemm.EmbeddingRocksDBWrapper(
                 ssd_storage_directory,
                 ssd_shards,

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -380,18 +380,11 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         self.load_ckpt_without_opt: bool = False
         if self.kv_zch_params:
             self.kv_zch_params.validate()
-            self.load_ckpt_without_opt = (
-                # pyre-ignore [16]
-                self.kv_zch_params.load_ckpt_without_opt
-            )
+            self.load_ckpt_without_opt = self.kv_zch_params.load_ckpt_without_opt
             self.enable_optimizer_offloading = (
-                # pyre-ignore [16]
                 self.kv_zch_params.enable_optimizer_offloading
             )
-            self.backend_return_whole_row = (
-                # pyre-ignore [16]
-                self.kv_zch_params.backend_return_whole_row
-            )
+            self.backend_return_whole_row = self.kv_zch_params.backend_return_whole_row
 
             if self.enable_optimizer_offloading:
                 logging.info("Optimizer state offloading is enabled")
@@ -403,7 +396,6 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 logging.info(
                     "Backend will return whole row including metaheader, weight and optimizer for checkpoint"
                 )
-            # pyre-ignore [16]
             self._embedding_cache_mode = self.kv_zch_params.embedding_cache_mode
             if self._embedding_cache_mode:
                 logging.info("KVZCH is in embedding_cache_mode")
@@ -419,13 +411,11 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             # paths (early-return flush, async enrichment writeback) that would
             # otherwise cause fp16 weight overflow on unrelated tables.
             self._enrichment_enabled = (
-                # pyre-ignore [16]
                 self.kv_zch_params.enrichment_policy is not None
                 and self._embedding_cache_mode
             )
             if self.load_ckpt_without_opt:
                 if (
-                    # pyre-ignore [16]
                     self.kv_zch_params.optimizer_type_for_st
                     == OptimType.PARTIAL_ROWWISE_ADAM.value
                 ):
@@ -433,11 +423,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     logging.info(
                         f"Override optimizer type with {self.optimizer=} for st publish"
                     )
-                if (
-                    # pyre-ignore [16]
-                    self.kv_zch_params.optimizer_state_dtypes_for_st
-                    is not None
-                ):
+                if self.kv_zch_params.optimizer_state_dtypes_for_st is not None:
                     optimizer_state_dtypes = {}
                     for k, v in dict(
                         self.kv_zch_params.optimizer_state_dtypes_for_st
@@ -1670,7 +1656,6 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         """
         if self.bulk_init_chunk_size > 0:
             self.lazy_init_thread = threading.Thread(target=self._insert_all_kv)
-            # pyre-ignore
             self.lazy_init_thread.start()
             logging.info(
                 f"lazy ssd tbe initialization started since bulk_init_chunk_size is set to {self.bulk_init_chunk_size}"
@@ -3076,7 +3061,6 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             itertools.accumulate([r * d for r, d in self.embedding_specs])
         )
 
-        # pyre-ignore[53]
         def _slice(tensor: Tensor, t: int, rowwise: bool) -> Tensor:
             d: int = dims[t]
             e: int = rows[t]
@@ -3139,7 +3123,6 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             itertools.accumulate([r * d for r, d in self.embedding_specs])
         )
 
-        # pyre-ignore[53]
         def _slice(state_name: str, tensor: Tensor, t: int, rowwise: bool) -> Tensor:
             d: int = dims[t]
 
@@ -3232,7 +3215,6 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             should_flush=should_flush,
         )
 
-        # pyre-ignore[53]
         def _fetch_offloaded_optimizer_states(
             t: int,
         ) -> list[Tensor]:
@@ -3436,7 +3418,6 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 for _ in dims_
             ]
 
-        # pyre-ignore[53]
         def _fetch_offloaded_optimizer_states(
             t: int,
         ) -> list[Tensor]:
@@ -3450,12 +3431,10 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
 
             # When backend returns whole row, the optimizer will be returned as
             # PMT directly
-            # pyre-ignore[16]
             if sorted_ids[t].size(0) == 0 and self.local_weight_counts[t] > 0:
                 logging.info(
                     f"Before opt PMT loading, resetting id tensor with {self.local_weight_counts[t]}"
                 )
-                # pyre-ignore[16]
                 sorted_ids[t] = torch.zeros(
                     (self.local_weight_counts[t], 1),
                     device=torch.device("cpu"),
@@ -3617,7 +3596,6 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
 
         logging.info(
             f"KV ZCH tables split_optimizer_states query latency: {(time.time() - start_time) * 1000} ms, "
-            # pyre-ignore[16]
             f"num ids list: {None if not sorted_id_tensor else [ids.numel() for ids in sorted_id_tensor]}"
         )
 
@@ -4268,7 +4246,6 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 self.local_weight_counts[i] > 0
             ), f"local_weight_counts for table {i} is not set"
 
-        # pyre-ignore [16]
         self._cached_kvzch_data.cached_optimizer_states_per_table = (
             self.optimizer.empty_states(
                 self.local_weight_counts,
@@ -4282,15 +4259,12 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             bucket_id_start, bucket_id_end = self.kv_zch_params.bucket_offsets[i]
             rows = self.local_weight_counts[i]
             weight_state = torch.empty(rows, emb_dim, dtype=dtype, device="cpu")
-            # pyre-ignore [16]
             self._cached_kvzch_data.cached_weight_tensor_per_table.append(weight_state)
             logging.info(
                 f"for checkpoint loading, table {i}, weight_state shape is {weight_state.shape}"
             )
             id_tensor = torch.zeros((rows, 1), dtype=torch.int64, device="cpu")
-            # pyre-ignore [16]
             self._cached_kvzch_data.cached_id_tensor_per_table.append(id_tensor)
-            # pyre-ignore [16]
             self._cached_kvzch_data.cached_bucket_splits.append(
                 torch.empty(
                     (bucket_id_end - bucket_id_start, 1),

--- a/fbgemm_gpu/fbgemm_gpu/tbe/utils/common.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/utils/common.py
@@ -32,11 +32,8 @@ def get_device() -> torch.device:
 
 def to_device(t: Deviceable, use_cpu: bool) -> Deviceable:
     if use_cpu:
-        # pyre-fixme[7]: Expected `Deviceable` but got `Union[Tensor, torch.nn.EmbeddingBag]`.
         return t.cpu()
     elif torch.cuda.is_available():
-        # pyre-fixme[7]: Expected `Deviceable` but got `Union[Tensor, torch.nn.EmbeddingBag]`.
         return t.cuda()
     else:
-        # pyre-fixme[7]: Expected `Deviceable` but got `Union[Tensor, torch.nn.EmbeddingBag]`.
         return t.to(device="mtia")

--- a/fbgemm_gpu/fbgemm_gpu/tbe/utils/quantize.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/utils/quantize.py
@@ -111,8 +111,6 @@ def dequantize_embs(
         E, D_4 = th_weights.shape
         D = D_4 * 4
 
-        # pyre-fixme[53]: Captured variable `scale_shift` is not annotated.
-        # pyre-fixme[53]: Captured variable `weights` is not annotated.
         def comp(i: int) -> torch.Tensor:
             subs = th_weights.view(torch.uint8) >> (i * 2)
             sub_mask = subs & 0x3
@@ -153,7 +151,6 @@ def dequantize_embs(
     elif weight_ty == SparseType.FP32:
         assert scale_shift is None
         comps = th_weights.view(torch.float32)
-        # pyre-fixme[7]: Expected `Tensor` but got implicit return value of `None`.
         return to_device(torch.tensor(comps), use_cpu)
 
 
@@ -197,8 +194,6 @@ def fake_quantize_embs(
         E, D_4 = th_weights.shape
         D = D_4 * 4
 
-        # pyre-fixme[53]: Captured variable `scale_shift` is not annotated.
-        # pyre-fixme[53]: Captured variable `weights` is not annotated.
         def comp(i: int) -> torch.Tensor:
             subs = th_weights.view(torch.uint8) >> (i * 2)
             sub_mask = subs & 0x3

--- a/fbgemm_gpu/test/batched_unary_embeddings_test.py
+++ b/fbgemm_gpu/test/batched_unary_embeddings_test.py
@@ -33,7 +33,6 @@ except Exception:
 
 
 # Relative tolerances
-# pyre-fixme[5]: Global expression must be annotated.
 TOLERANCE_REL = {
     torch.float32: 1e-4,
     torch.float16: 1e-2,
@@ -41,7 +40,6 @@ TOLERANCE_REL = {
 }
 
 # Absolute tolerances
-# pyre-fixme[5]: Global expression must be annotated.
 TOLERANCE_ABS = {
     torch.float32: 1e-4,
     torch.float16: 1e-2,
@@ -98,7 +96,6 @@ class TableBatchedEmbeddingsTest(unittest.TestCase):
         offset = 0
         for _ in range(batch_size):
             n_indices = 1
-            # pyre-fixme[6]: For 1st argument expected `Iterable[typing.Any]` but
             #  got `float`.
             indices += np.round(
                 np.random.random(n_indices) * (num_embeddings - 1)

--- a/fbgemm_gpu/test/combine/common.py
+++ b/fbgemm_gpu/test/combine/common.py
@@ -11,7 +11,6 @@ import fbgemm_gpu
 import torch
 from fbgemm_gpu.utils.loader import load_torch_module
 
-# pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
 open_source: bool = getattr(fbgemm_gpu, "open_source", False)
 
 if not open_source:

--- a/fbgemm_gpu/test/combine/empty_weights_test.py
+++ b/fbgemm_gpu/test/combine/empty_weights_test.py
@@ -75,7 +75,6 @@ class EmptyWeightsTest(unittest.TestCase):
 
         return (arg0, arg1, arg2)
 
-    # pyre-fixme[56]: Pyre was not able to infer the type of argument
     @given(device=cpu_and_maybe_gpu())
     @settings(deadline=None)
     def test_tbe_input_combine_with_length_partially_empty_weights(
@@ -93,7 +92,6 @@ class EmptyWeightsTest(unittest.TestCase):
         # per sample weights
         self.assertTrue(ref_outputs[2].allclose(outputs[2]))
 
-    # pyre-fixme[56]: Pyre was not able to infer the type of argument
     @given(device=cpu_and_maybe_gpu())
     @settings(deadline=None)
     def test_tbe_input_combine_with_length_all_empty_weights(

--- a/fbgemm_gpu/test/combine/input_combine_test.py
+++ b/fbgemm_gpu/test/combine/input_combine_test.py
@@ -376,21 +376,18 @@ class InputCombineTest(unittest.TestCase):
     ) -> None:
         self._run_test_with_prepadded_indices_weights_without_last_offsets()
 
-    # pyre-fixme[56]: Pyre was not able to infer the type of argument
     #  `test_utils.cpu_and_maybe_gpu()` to decorator factory `hypothesis.given`.
     @given(device=cpu_and_maybe_gpu())
     @settings(deadline=None)
     def test_input_combine_int64_with_length(self, device: torch.device) -> None:
         self._run_test_with_length((torch.int64, torch.int64), device=device)
 
-    # pyre-fixme[56]: Pyre was not able to infer the type of argument
     #  `test_utils.cpu_and_maybe_gpu()` to decorator factory `hypothesis.given`.
     @given(device=cpu_and_maybe_gpu())
     @settings(deadline=None)
     def test_input_combine_int32_with_length(self, device: torch.device) -> None:
         self._run_test_with_length((torch.int32, torch.int32), device=device)
 
-    # pyre-fixme[56]: Pyre was not able to infer the type of argument
     #  `test_utils.cpu_and_maybe_gpu()` to decorator factory `hypothesis.given`.
     @given(device=cpu_and_maybe_gpu())
     @settings(deadline=None)
@@ -415,7 +412,6 @@ class InputCombineTest(unittest.TestCase):
     def test_padding_fused_input_combined_mix_with_length(self) -> None:
         self._run_padding_fused_test_with_length((torch.int64, torch.int32), 64)
 
-    # pyre-fixme[56]: Pyre was not able to infer the type of argument
     #  `torch.cuda.is_available()` to decorator factory `unittest.skipUnless`.
     @unittest.skipUnless(torch.cuda.is_available(), "GPU not available")
     def test_tbe_input_combine_with_length_correctness_large(self) -> None:

--- a/fbgemm_gpu/test/faster_hash_test.py
+++ b/fbgemm_gpu/test/faster_hash_test.py
@@ -9,7 +9,6 @@
 import unittest
 from enum import IntEnum
 
-# pyre-ignore[21]
 import fbgemm_gpu  # noqa: F401
 import torch
 from hypothesis import given, settings, strategies as st
@@ -1641,7 +1640,6 @@ class FasterHashTest(unittest.TestCase):
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     @settings(deadline=None)
-    # pyre-ignore [56]
     @given(
         eviction_policy=st.sampled_from(
             [

--- a/fbgemm_gpu/test/layout_transform_ops_test.py
+++ b/fbgemm_gpu/test/layout_transform_ops_test.py
@@ -33,7 +33,6 @@ MAX_EXAMPLES = 20
 class LayoutTransformOpsTest(unittest.TestCase):
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
-    # pyre-fixme[56]
     @given(
         B=st.integers(min_value=1, max_value=20),
         T=st.integers(min_value=1, max_value=20),
@@ -61,7 +60,6 @@ class LayoutTransformOpsTest(unittest.TestCase):
 
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
-    # pyre-fixme[56]
     @given(
         B=st.integers(min_value=1, max_value=20),
         W=st.integers(min_value=1, max_value=20),
@@ -105,7 +103,6 @@ class LayoutTransformOpsTest(unittest.TestCase):
 
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
-    # pyre-fixme[56]
     @given(
         B=st.integers(min_value=1, max_value=20),
         W=st.integers(min_value=1, max_value=20),
@@ -127,9 +124,7 @@ class LayoutTransformOpsTest(unittest.TestCase):
             )
             for i in range(W)
         ]
-        # pyre-fixme[16]: Module `cuda` has no attribute `LongTensor`.
         dim_sum_per_rank_tensor = torch.cuda.LongTensor(dim_sum_per_rank)
-        # pyre-fixme[16]: Module `cuda` has no attribute `LongTensor`.
         cumsum_dim_sum_per_rank_tensor = torch.cuda.LongTensor(
             np.cumsum([0] + dim_sum_per_rank)[:-1]
         )
@@ -167,9 +162,7 @@ class LayoutTransformOpsTest(unittest.TestCase):
             )
             for i in range(W)
         ]
-        # pyre-fixme[16]: Module `cuda` has no attribute `LongTensor`.
         dim_sum_per_rank_tensor = torch.cuda.LongTensor(dim_sum_per_rank)
-        # pyre-fixme[16]: Module `cuda` has no attribute `LongTensor`.
         cumsum_dim_sum_per_rank_tensor = torch.cuda.LongTensor(
             np.cumsum([0] + dim_sum_per_rank)[:-1]
         )

--- a/fbgemm_gpu/test/merge_pooled_embeddings_test.py
+++ b/fbgemm_gpu/test/merge_pooled_embeddings_test.py
@@ -16,7 +16,6 @@ import numpy as np
 import torch
 from hypothesis import given, settings, Verbosity
 
-# pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
 open_source: bool = getattr(fbgemm_gpu, "open_source", False)
 
 if open_source:
@@ -55,7 +54,6 @@ def make_pitched_tensor(
 # @unittest.skipIf(open_source, "Not supported in open source yet")
 @unittest.skipIf(*typed_gpu_unavailable)
 class MergePooledEmbeddingsTest(unittest.TestCase):
-    # pyre-fixme[56]: Pyre was not able to infer the type of argument
     #  `hypothesis.strategies.integers($parameter$min_value = 1, $parameter$max_value =
     #  10)` to decorator factory `hypothesis.given`.
     @given(
@@ -125,7 +123,6 @@ class MergePooledEmbeddingsTest(unittest.TestCase):
         torch.testing.assert_close(output_ref, output.cpu())
         torch.testing.assert_close(output_ref, output_cpu)
 
-    # pyre-fixme[56]: Pyre was not able to infer the type of argument
     @given(
         num_inputs=st.integers(min_value=1, max_value=10),
         num_gpus=st.integers(min_value=1, max_value=torch.cuda.device_count()),
@@ -173,7 +170,6 @@ class MergePooledEmbeddingsTest(unittest.TestCase):
         )
         torch.testing.assert_close(output, ref_output)
 
-    # pyre-fixme[56]: Pyre was not able to infer the type of argument
     @given(
         num_inputs=st.integers(min_value=1, max_value=8),
         num_gpus=st.integers(min_value=1, max_value=torch.cuda.device_count()),
@@ -225,7 +221,6 @@ class MergePooledEmbeddingsTest(unittest.TestCase):
         self.assertFalse(output_meta.is_cpu)
         self.assertTrue(output_meta.is_meta)
 
-    # pyre-fixme[56]: Pyre was not able to infer the type of argument
     #  `hypothesis.strategies.integers($parameter$min_value = 1, $parameter$max_value =
     #  10)` to decorator factory `hypothesis.given`.
     @given(

--- a/fbgemm_gpu/test/metric_ops_test.py
+++ b/fbgemm_gpu/test/metric_ops_test.py
@@ -37,7 +37,6 @@ class MetricOpsTest(unittest.TestCase):
         True,
         "Test is sometimes failed due to issues with Flaky. Skipping until the issues are resolved. ",
     )
-    # pyre-ignore [56]
     @given(
         n_tasks=st.integers(1, 5),
         batch_size=st.integers(1, 1024),

--- a/fbgemm_gpu/test/permute/common.py
+++ b/fbgemm_gpu/test/permute/common.py
@@ -15,7 +15,6 @@ from fbgemm_gpu.permute_pooled_embedding_modules import PermutePooledEmbeddings
 from hypothesis import HealthCheck
 from torch import Tensor
 
-# pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
 open_source: bool = getattr(fbgemm_gpu, "open_source", False)
 
 if open_source:

--- a/fbgemm_gpu/test/permute/permute_pooled_embedding_test.py
+++ b/fbgemm_gpu/test/permute/permute_pooled_embedding_test.py
@@ -83,7 +83,6 @@ class PooledEmbeddingModulesTest(unittest.TestCase):
         output.sum().backward()
 
         # check grads for fc1 when permuted, equals to fc2 weights times input_sum
-        # pyre-fixme[16]: Optional type has no attribute `view`.
         permute_res = net.permute_pooled_embeddings(net.fc1.weight.grad.view(1, 10))
         permute_ref = input_sum * net.fc2.weight
         torch.testing.assert_close(permute_res, permute_ref, rtol=1e-03, atol=1e-03)

--- a/fbgemm_gpu/test/quantize/common.py
+++ b/fbgemm_gpu/test/quantize/common.py
@@ -15,8 +15,6 @@ import numpy as np
 import numpy.typing as npt
 import torch
 
-# pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
-# pyre-fixme[35]: Target cannot be annotated.
 open_source: bool = getattr(fbgemm_gpu, "open_source", False)
 
 try:

--- a/fbgemm_gpu/test/release/stable_release_test.py
+++ b/fbgemm_gpu/test/release/stable_release_test.py
@@ -22,14 +22,12 @@ from torch._utils_internal import get_file_path_2
 
 from .utils import infer_schema
 
-# pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
 open_source: bool = getattr(fbgemm_gpu, "open_source", False)
 
 if open_source:
     from test_utils import TestSuite  # pyre-fixme[21]
 
 else:
-    # pyre-fixme[21]
     from fbgemm_gpu.test.test_utils import TestSuite
 
 
@@ -56,7 +54,6 @@ def _check_schema_compatibility(
     msg = ""
     if not fwd_compatible:
         msg += f"Schema of {schema} is not forward compatible with {ref_schema}\n"
-    # pyre-fixme[16]
     if not bwd_compatible:
         msg += f"Schema of {schema} is not backward compatible with {ref_schema}"
     assert fwd_compatible and bwd_compatible, msg
@@ -78,7 +75,6 @@ def check_schema_compatibility(
         None
     """
     op_schema = infer_schema(op, mutates_args={})
-    # pyre-fixme[16]
     op_name = op.__name__
     # Create schema string
     schema_str = f"{op_name}{op_schema}"
@@ -193,7 +189,7 @@ class StableRelease(TestSuite):  # pyre-ignore[11]
             pass
 
         # Expect to fail
-        with self.assertRaises(AssertionError):  # pyre-fixme[16]
+        with self.assertRaises(AssertionError):
             check_schema_compatibility(
                 dummy_func,
                 op_dict["dummy_func"],

--- a/fbgemm_gpu/test/runtime_monitor_test.py
+++ b/fbgemm_gpu/test/runtime_monitor_test.py
@@ -19,7 +19,6 @@ from fbgemm_gpu.tbe.monitoring import (
     TBEStatsReporterConfig,
 )
 
-# pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
 open_source: bool = getattr(fbgemm_gpu, "open_source", False)
 
 if open_source:

--- a/fbgemm_gpu/test/test_utils.py
+++ b/fbgemm_gpu/test/test_utils.py
@@ -75,7 +75,6 @@ running_on_github: tuple[bool, str] = (
 )
 
 running_in_oss: tuple[bool, str] = (
-    # pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
     getattr(fbgemm_gpu, "open_source", False),
     "Test is currently known to fail in OSS mode",
 )
@@ -202,7 +201,6 @@ class optests:
                 test_class,
                 ["fb", "fbgemm"],
                 failures_dict_path,
-                # pyre-ignore[6]
                 additional_decorators,
                 tests_to_run,
             )


### PR DESCRIPTION
Summary:
This diff was automatically generated by the Pyre per-target upgrade tool.

It removes `# pyre-fixme` or `pyrefly: ignore` comments that are no longer needed because the underlying type errors have been resolved.
Note that it will also aim to ensure type checking runs cleanly, and will add suppressions to existing type errors.

#pyreupgrade

Differential Revision: D116378180
