### PR TITLE
Rename hit-lane copy/dispatch executors + knob to uvm_hit_* for symmetry

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
@@ -62,7 +62,7 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
       // experimentation; too many consumer threads per TBE may be wasteful --
       // tune via experiments.
       int64_t res_num_consumers = 8,
-      int64_t res_num_copy_threads = 4,
+      int64_t res_num_uvm_hit_copy_threads = 4,
       int64_t res_num_hbm_copy_threads = 4);
 
   ~RawEmbeddingStreamer() override;
@@ -74,7 +74,7 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
   /// them into the background queue, which is drained by a pool of consumer
   /// threads that stream out to the thrift server (co-located on same host
   /// now). The copy is split into <= res_chunk_size-row chunks that run
-  /// concurrently across the res_num_copy_threads-worker copy pool.
+  /// concurrently across the res_num_uvm_hit_copy_threads-worker copy pool.
   ///
   /// This is used in cuda stream callback, which doesn't require to be
   /// serialized with other callbacks, thus a separate thread is used to
@@ -92,10 +92,10 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
   /// non-blocking path joins/assigns the separate HBM dispatch future
   /// (hbm_dispatch_future_) on hbm_dispatch_executor_ instead of the main
   /// cache-hit one, and the copies fan out on the dedicated hbm_copy_executor_
-  /// instead of the shared copy_executor_, so HBM/UVM-miss drain does not
-  /// interfere with cache-hit streaming at the dispatch or copy level. Only the
-  /// ship path (consumer_executor_) stays shared. Defaults false (main path) --
-  /// inert until an out-of-scope caller opts in.
+  /// instead of the shared uvm_hit_copy_executor_, so HBM/UVM-miss drain does
+  /// not interfere with cache-hit streaming at the dispatch or copy level. Only
+  /// the ship path (consumer_executor_) stays shared. Defaults false (main
+  /// path) -- inert until an out-of-scope caller opts in.
   ///
   /// @return None
   void stream(
@@ -154,7 +154,7 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
 #ifdef FBGEMM_FBCODE
   size_t res_chunk_size_;
   size_t res_num_consumers_;
-  size_t res_num_copy_threads_;
+  size_t res_num_uvm_hit_copy_threads_;
   size_t res_num_hbm_copy_threads_;
 #endif
 #ifdef FBGEMM_FBCODE
@@ -163,18 +163,18 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
   // polling). Sized to res_num_consumers_.
   std::unique_ptr<folly::CPUThreadPoolExecutor> consumer_executor_;
   // Persistent pool that runs the per-chunk tensor copies (CPU-bound
-  // std::copy), sized res_num_copy_threads_ so chunks run concurrently. Used by
-  // the blocking and non-blocking main (cache-hit) stream() paths; this assumes
-  // a given table streams in a single mode at a time (blocking OR
+  // std::copy), sized res_num_uvm_hit_copy_threads_ so chunks run concurrently.
+  // Used by the blocking and non-blocking main (cache-hit) stream() paths; this
+  // assumes a given table streams in a single mode at a time (blocking OR
   // non-blocking), never concurrently.
-  std::unique_ptr<folly::CPUThreadPoolExecutor> copy_executor_;
+  std::unique_ptr<folly::CPUThreadPoolExecutor> uvm_hit_copy_executor_;
   // Dedicated HBM copy pool sized res_num_hbm_copy_threads_, so HBM copies
   // don't contend with hit copies for the shared pool and delay the other
   // lane's read-before-overwrite barrier.
   std::unique_ptr<folly::CPUThreadPoolExecutor> hbm_copy_executor_;
   // Persistent size-1 executor that runs the per-iteration dispatch (poll_flag
   // + chunked_copy_and_enqueue). Named so its thread is identifiable in traces.
-  std::unique_ptr<folly::CPUThreadPoolExecutor> dispatch_executor_;
+  std::unique_ptr<folly::CPUThreadPoolExecutor> uvm_hit_dispatch_executor_;
   // Size-1 executor dedicated to the HBM path's dispatch coroutine, so a
   // hit-path poll_copy_done_flag spin can't hold the only dispatch worker and
   // stall HBM drain.
@@ -198,10 +198,10 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
   void submit_stream_item(StreamQueueItem item);
   // Copies `count` rows of the source tensors into CPU chunks and enqueues each
   // via submit_stream_item, fanning the per-chunk copies out across the
-  // selected copy pool (hbm_copy_executor_ when use_hbm, else copy_executor_)
-  // and awaiting them all (the read-before-overwrite barrier). A coroutine so
-  // the non-blocking dispatch can co_await it; tensor args are by value so
-  // nothing dangles once a chunk is scheduled.
+  // selected copy pool (hbm_copy_executor_ when use_hbm, else
+  // uvm_hit_copy_executor_) and awaiting them all (the read-before-overwrite
+  // barrier). A coroutine so the non-blocking dispatch can co_await it; tensor
+  // args are by value so nothing dangles once a chunk is scheduled.
   folly::coro::Task<void> chunked_copy_and_enqueue(
       at::Tensor indices,
       at::Tensor weights,
@@ -210,10 +210,10 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
       at::Tensor count,
       bool use_hbm);
   // Copies one chunk [start, end) and enqueues it via submit_stream_item. Runs
-  // to completion on a single copy_executor_ worker; the per-chunk try/catch
-  // keeps an exception from escaping into collectAllRange (which awaits every
-  // sibling to completion and then rethrows one exception onto the blocking
-  // caller / dispatch future). By value for the same reason as
+  // to completion on a single uvm_hit_copy_executor_ worker; the per-chunk
+  // try/catch keeps an exception from escaping into collectAllRange (which
+  // awaits every sibling to completion and then rethrows one exception onto the
+  // blocking caller / dispatch future). By value for the same reason as
   // chunked_copy_and_enqueue.
   folly::coro::Task<void> copy_chunk_task(
       at::Tensor indices,
@@ -230,9 +230,9 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
 
   // Coroutine form of the non-blocking dispatch (poll_copy_done_flag +
   // chunked_copy_and_enqueue). Args are taken by value so nothing dangles once
-  // it is scheduled on dispatch_executor_ -- a capturing lambda coroutine would
-  // risk a use-after-free (clang-tidy cppcoreguidelines-avoid-capturing-lambda-
-  // coroutines).
+  // it is scheduled on uvm_hit_dispatch_executor_ -- a capturing lambda
+  // coroutine would risk a use-after-free
+  // (clang-tidy cppcoreguidelines-avoid-capturing-lambda-coroutines).
   folly::coro::Task<void> dispatch_copy_task(
       at::Tensor indices,
       at::Tensor weights,
@@ -254,8 +254,8 @@ fbgemm_gpu::StreamQueueItem tensor_copy_chunk(
 
 // Tiles [0, num_rows) into flat [start, end) chunks of size <= chunk_size,
 // contiguous and non-overlapping (their union is the whole range). One task per
-// chunk is submitted to copy_executor_, which load-balances them across its
-// workers. Pure/build-agnostic so it is unit-testable without a GPU or
+// chunk is submitted to uvm_hit_copy_executor_, which load-balances them across
+// its workers. Pure/build-agnostic so it is unit-testable without a GPU or
 // FBGEMM_FBCODE.
 std::vector<std::pair<int64_t, int64_t>> computeChunks(
     int64_t num_rows,

--- a/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
@@ -234,7 +234,7 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
     const std::vector<int64_t>& table_sizes,
     int64_t res_chunk_size [[maybe_unused]],
     int64_t res_num_consumers [[maybe_unused]],
-    int64_t res_num_copy_threads [[maybe_unused]],
+    int64_t res_num_uvm_hit_copy_threads [[maybe_unused]],
     int64_t res_num_hbm_copy_threads [[maybe_unused]])
     : unique_id_(std::move(unique_id)),
       enable_raw_embedding_streaming_(enable_raw_embedding_streaming),
@@ -249,7 +249,7 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
       ,
       res_chunk_size_(res_chunk_size),
       res_num_consumers_(res_num_consumers),
-      res_num_copy_threads_(res_num_copy_threads),
+      res_num_uvm_hit_copy_threads_(res_num_uvm_hit_copy_threads),
       res_num_hbm_copy_threads_(res_num_hbm_copy_threads)
 #endif
 {
@@ -259,18 +259,18 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
     // compile-time constants), and 0 -- or a negative that wrapped to a huge
     // size_t -- would silently break streaming: res_num_consumers=0 spawns no
     // drain threads (queue grows unbounded), res_chunk_size=0 makes
-    // computeChunks return empty (enqueues nothing), res_num_copy_threads=0
-    // sizes copy_executor_ to zero workers (copy tasks never run). Reject
-    // rather than silently no-op.
+    // computeChunks return empty (enqueues nothing),
+    // res_num_uvm_hit_copy_threads=0 sizes uvm_hit_copy_executor_ to zero
+    // workers (copy tasks never run). Reject rather than silently no-op.
     TORCH_CHECK(
         res_chunk_size > 0 && res_num_consumers > 0 &&
-            res_num_copy_threads > 0 && res_num_hbm_copy_threads > 0,
+            res_num_uvm_hit_copy_threads > 0 && res_num_hbm_copy_threads > 0,
         "RES config knobs must be > 0: res_chunk_size=",
         res_chunk_size,
         ", res_num_consumers=",
         res_num_consumers,
-        ", res_num_copy_threads=",
-        res_num_copy_threads,
+        ", res_num_uvm_hit_copy_threads=",
+        res_num_uvm_hit_copy_threads,
         ", res_num_hbm_copy_threads=",
         res_num_hbm_copy_threads);
     XLOG(INFO) << "[TBE_ID" << unique_id_
@@ -288,7 +288,7 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
     // prefix is kept short because Linux caps thread names at 15 chars
     // (pthread_setname_np) and NamedThreadFactory still appends a suffix, so a
     // longer prefix would truncate unique_id_ away.
-    dispatch_executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
+    uvm_hit_dispatch_executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
         1,
         std::make_unique<folly::NamedThreadFactory>(
             fmt::format("RESDisp{}", unique_id_)));
@@ -297,7 +297,7 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
                << "] Starting RES ship executor with " << res_num_consumers_
                << " threads"
                << ", chunk_size=" << res_chunk_size_
-               << ", copy_threads=" << res_num_copy_threads_;
+               << ", copy_threads=" << res_num_uvm_hit_copy_threads_;
     // Push model: ship tasks are submitted onto this executor (one per enqueued
     // StreamQueueItem) and its workers wake on submit -- no polled queue, no
     // raw std::thread that could std::terminate on an escaped exception.
@@ -316,11 +316,11 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
             fmt::format("RESShip.{}", unique_id_)));
 
     // Persistent pool that runs the per-chunk tensor copies (CPU-bound
-    // std::copy) off the trainer thread. Sized res_num_copy_threads_ so N
-    // chunks run concurrently -- the same N-way parallelism the old
+    // std::copy) off the trainer thread. Sized res_num_uvm_hit_copy_threads_ so
+    // N chunks run concurrently -- the same N-way parallelism the old
     // one-std::thread-per-group model gave.
-    copy_executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
-        res_num_copy_threads_,
+    uvm_hit_copy_executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
+        res_num_uvm_hit_copy_threads_,
         std::make_unique<folly::NamedThreadFactory>(
             fmt::format("RESCopy.{}", unique_id_)));
 
@@ -344,22 +344,22 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
 RawEmbeddingStreamer::~RawEmbeddingStreamer() {
 #ifdef FBGEMM_FBCODE
   if (enable_raw_embedding_streaming_) {
-    // Drain in producer order: dispatch schedules onto copy_executor_, and copy
-    // groups submit ship tasks onto consumer_executor_, so join dispatch ->
-    // copy -> consumer. A wrong order risks joining an executor while a
-    // producer still schedules onto it.
+    // Drain in producer order: dispatch schedules onto uvm_hit_copy_executor_,
+    // and copy groups submit ship tasks onto consumer_executor_, so join
+    // dispatch -> copy -> consumer. A wrong order risks joining an executor
+    // while a producer still schedules onto it.
     join_dispatch_and_workers();
     // The HBM path has its own dispatch + copy executors; drain its dispatch
     // future too before joining those executors.
     join_hbm_dispatch_and_workers();
-    if (dispatch_executor_ != nullptr) {
-      dispatch_executor_->join();
+    if (uvm_hit_dispatch_executor_ != nullptr) {
+      uvm_hit_dispatch_executor_->join();
     }
     if (hbm_dispatch_executor_ != nullptr) {
       hbm_dispatch_executor_->join();
     }
-    if (copy_executor_ != nullptr) {
-      copy_executor_->join();
+    if (uvm_hit_copy_executor_ != nullptr) {
+      uvm_hit_copy_executor_->join();
     }
     if (hbm_copy_executor_ != nullptr) {
       hbm_copy_executor_->join();
@@ -415,7 +415,7 @@ void RawEmbeddingStreamer::stream(
   // transition) and rely on the arrival-wins / versioned store (T281413204) for
   // cross-lane freshness.
   auto* dispatch_exec =
-      use_hbm ? hbm_dispatch_executor_.get() : dispatch_executor_.get();
+      use_hbm ? hbm_dispatch_executor_.get() : uvm_hit_dispatch_executor_.get();
 
   if (blocking_tensor_copy) {
     if (!poll_flag()) {
@@ -595,9 +595,10 @@ folly::coro::Task<void> RawEmbeddingStreamer::chunked_copy_and_enqueue(
   }
 
   // Pick the copy pool for this stream's path: the dedicated hbm_copy_executor_
-  // for HBM drain, else the main copy_executor_. Only the ship path
+  // for HBM drain, else the main uvm_hit_copy_executor_. Only the ship path
   // (consumer_executor_) is shared between the two.
-  auto* copy_exec = use_hbm ? hbm_copy_executor_.get() : copy_executor_.get();
+  auto* copy_exec =
+      use_hbm ? hbm_copy_executor_.get() : uvm_hit_copy_executor_.get();
 
   // One copy task per chunk. Chunk boundaries live entirely in computeChunks,
   // so the enqueued row set is identical regardless of how the tasks run.

--- a/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
@@ -105,7 +105,7 @@ auto raw_embedding_streamer =
                 torch::arg("table_sizes") = torch::List<int64_t>(),
                 torch::arg("res_chunk_size") = 500000,
                 torch::arg("res_num_consumers") = 8,
-                torch::arg("res_num_copy_threads") = 4,
+                torch::arg("res_num_uvm_hit_copy_threads") = 4,
                 torch::arg("res_num_hbm_copy_threads") = 4,
             })
         .def(

--- a/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
@@ -57,7 +57,7 @@ getRawEmbeddingStreamer(
       table_sizes,
       500000, // res_chunk_size
       8, // res_num_consumers
-      4); // res_num_copy_threads
+      4); // res_num_uvm_hit_copy_threads
 }
 
 TEST(RawEmbeddingStreamerTest, TestConstructorAndDestructor) {
@@ -339,9 +339,9 @@ TEST(RawEmbeddingStreamerTest, ComputeChunksZeroChunkSizeIsEmpty) {
 #ifdef FBGEMM_FBCODE
 TEST(RawEmbeddingStreamerTest, CtorRejectsZeroKnob) {
   // A 0-valued RES knob would silently disable streaming (0 consumers never
-  // drain the queue; res_chunk_size/res_num_copy_threads=0 make chunk ranges
-  // empty), so the ctor must reject it loudly. The TORCH_CHECK fires before any
-  // thrift client is created, so no mock server is needed.
+  // drain the queue; res_chunk_size/res_num_uvm_hit_copy_threads=0 make chunk
+  // ranges empty), so the ctor must reject it loudly. The TORCH_CHECK fires
+  // before any thrift client is created, so no mock server is needed.
   EXPECT_ANY_THROW(
       fbgemm_gpu::RawEmbeddingStreamer(
           "test_zero_knob",
@@ -353,20 +353,20 @@ TEST(RawEmbeddingStreamerTest, CtorRejectsZeroKnob) {
           /*table_sizes=*/{},
           /*res_chunk_size=*/0,
           /*res_num_consumers=*/8,
-          /*res_num_copy_threads=*/4));
+          /*res_num_uvm_hit_copy_threads=*/4));
 }
 
 TEST(RawEmbeddingStreamerTest, TestMultiChunkFanOutShipsEveryChunk) {
   // The stream()/tensor_stream tests all run at the default res_chunk_size (one
-  // chunk), so the chunked_copy_and_enqueue -> computeChunks -> copy_executor_
-  // fan-out -> collectAllRange -> per-chunk submit_stream_item composition is
-  // otherwise never exercised with >1 chunk. Here res_chunk_size=4 over 10 rows
-  // tiles into ceil(10/4)=3 chunks; with a single shard each chunk ships
-  // exactly one co_setEmbeddings, so RPC count == chunk count proves every
-  // chunk is copied and shipped -- a dropped/duplicated chunk future or an
-  // off-by-one in the fan-out would change the count. computeChunks' partition
-  // correctness (no gap/dup/overflow) is covered by the ComputeChunks* unit
-  // tests above.
+  // chunk), so the chunked_copy_and_enqueue -> computeChunks ->
+  // uvm_hit_copy_executor_ fan-out -> collectAllRange -> per-chunk
+  // submit_stream_item composition is otherwise never exercised with >1 chunk.
+  // Here res_chunk_size=4 over 10 rows tiles into ceil(10/4)=3 chunks; with a
+  // single shard each chunk ships exactly one co_setEmbeddings, so RPC count ==
+  // chunk count proves every chunk is copied and shipped -- a
+  // dropped/duplicated chunk future or an off-by-one in the fan-out would
+  // change the count. computeChunks' partition correctness (no
+  // gap/dup/overflow) is covered by the ComputeChunks* unit tests above.
   std::vector<std::string> table_names = {"tb1"};
   std::vector<int64_t> table_offsets = {0};
   std::vector<int64_t> table_sizes = {0, 300};
@@ -411,7 +411,7 @@ TEST(RawEmbeddingStreamerTest, TestMultiChunkFanOutShipsEveryChunk) {
       table_sizes,
       /*res_chunk_size=*/4,
       /*res_num_consumers=*/2,
-      /*res_num_copy_threads=*/3,
+      /*res_num_uvm_hit_copy_threads=*/3,
       /*res_num_hbm_copy_threads=*/4);
 
   constexpr int64_t kNumRows = 10;
@@ -1067,8 +1067,8 @@ TEST(RawEmbeddingStreamerTest, TestStreamHbmLaneE2E) {
 
 TEST(RawEmbeddingStreamerTest, TestStreamHbmLaneNonBlockingCopy) {
   // A non-blocking HBM stream dispatches its copy onto the shared
-  // copy_executor_, so join_hbm_dispatch_and_workers() must drain the HBM
-  // path's dispatch future before the queue is read -- asserting before the
+  // uvm_hit_copy_executor_, so join_hbm_dispatch_and_workers() must drain the
+  // HBM path's dispatch future before the queue is read -- asserting before the
   // join would race the background copy. One item lands in the shared queue.
   std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
   std::vector<int64_t> table_offsets = {0, 100, 300};
@@ -1119,9 +1119,9 @@ TEST(RawEmbeddingStreamerTest, TestStreamMainAndHbmLanesIndependent) {
   // A blocking main-lane stream (use_hbm=false) and a blocking
   // HBM-path stream (use_hbm=true) each enqueue one item into the
   // shared consumer queue: two items total. Both lanes feed the same shared
-  // ship path (consumer_executor_) and copy pool (copy_executor_); the blocking
-  // path is lane-agnostic, so this exercises the shared plumbing, not the
-  // per-lane dispatch futures (those are covered by
+  // ship path (consumer_executor_) and copy pool (uvm_hit_copy_executor_); the
+  // blocking path is lane-agnostic, so this exercises the shared plumbing, not
+  // the per-lane dispatch futures (those are covered by
   // TestStreamHbmLaneNonBlockingCopy and TestStreamHbmLaneDestructorJoins).
   std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
   std::vector<int64_t> table_offsets = {0, 100, 300};
@@ -1184,8 +1184,8 @@ TEST(RawEmbeddingStreamerTest, TestStreamMainAndHbmLanesIndependent) {
 TEST(RawEmbeddingStreamerTest, TestStreamHbmLaneDestructorJoins) {
   // A non-blocking stream on BOTH lanes leaves a pending dispatch future on
   // each lane. The destructor must join both futures -- and the shared
-  // dispatch_executor_ / copy_executor_ / consumer_executor_ -- without hanging
-  // or leaking. Reaching the end is the assertion.
+  // uvm_hit_dispatch_executor_ / uvm_hit_copy_executor_ / consumer_executor_ --
+  // without hanging or leaking. Reaching the end is the assertion.
   std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
   std::vector<int64_t> table_offsets = {0, 100, 300};
   std::vector<int64_t> table_sizes = {0, 50, 200, 300};

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -98,11 +98,12 @@ EmbeddingKVDB::EmbeddingKVDB(
               // SSD/kv_db TBEs are intentionally left on the default RES ship/
               // copy knobs: the config layer that makes these tunable is not
               // threaded through the kv_db ctor. Plumb res_chunk_size/
-              // res_num_consumers/res_num_copy_threads/res_num_hbm_copy_threads
-              // here if SSD-backed tables ever need to tune them.
+              // res_num_consumers/res_num_uvm_hit_copy_threads/
+              // res_num_hbm_copy_threads here if SSD-backed tables ever need to
+              // tune them.
               /*res_chunk_size=*/500000,
               /*res_num_consumers=*/8,
-              /*res_num_copy_threads=*/4,
+              /*res_num_uvm_hit_copy_threads=*/4,
               /*res_num_hbm_copy_threads=*/4)) {
   CHECK(num_shards > 0);
   if (cache_size_gb > 0) {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3062

Renames the UVM cache-hit lane's copy/dispatch executors and their thread-count knob to `uvm_hit_*`, for symmetry with the `hbm_*` lane added in D113752426. C++ only -- 5 files, no Python.

The torchbind arg rename `res_num_copy_threads` -> `res_num_uvm_hit_copy_threads` is technically BC-breaking (`Argument::isBackwardCompatibleWith` compares names before anything else), but no caller is affected: every construction site in fbsource is positional with 7 of 11 args, so params 8-11 always take their `torch::arg` defaults, and nothing anywhere names the knob. Arity is unchanged, and a name change is only observable to keyword callers.

Worth noting the asymmetry with the BC freeze a few lines below in the same registration block, which keeps `join_stream_tensor_copy_thread` exposed under its old name for the frozen fbgemm clones in published models. That freeze applies because *method* names bind by name unconditionally; *arg* names bind only for keyword invocation, and there are none.

Doing this now rather than later is deliberate. The descendant diffs turn this knob into a `fused_params` string key in deployed model configs, and an unconsumed `fused_params` key is silently dropped on the SSD path -- so a rename after that point would quietly revert a tuned knob to its default instead of failing loudly.

Reviewed By: chouxi

Differential Revision: D113848362


