### PR TITLE
Apply the host warning set to nvcc

### DIFF
--- a/cmake/modules/GpuCppLibrary.cmake
+++ b/cmake/modules/GpuCppLibrary.cmake
@@ -219,6 +219,34 @@ function(gpu_cpp_library)
     endif()
 
     ############################################################################
+    # Compilation Flags
+    ############################################################################
+
+    # Computed BEFORE the library is created, because `hip_add_library()` takes
+    # HIPCC_OPTIONS as a creation-time argument (it is a legacy FindHIP concept,
+    # not a target property that can be set afterwards), so the HIPCC list has to
+    # exist by then. A follow-up applies these lists; this block only computes
+    # them, and nothing consumes the NVCC/HIPCC ones yet.
+    #
+    # Only the flag computation moved here. The MSVC `target_compile_definitions`
+    # that used to sit in the same block stays after library creation, because it
+    # needs ${lib_name} to exist.
+
+    fbgemm_get_warning_flags(
+        MSVC_FLAGS_VAR  _msvc_flags
+        CC_FLAGS_VAR    _cc_flags
+        NVCC_FLAGS_VAR  _nvcc_warning_flags
+        HIPCC_FLAGS_VAR _hipcc_warning_flags
+        EXTRA_MSVC_FLAGS ${args_MSVC_FLAGS}
+        EXTRA_CC_FLAGS   ${args_CC_FLAGS})
+
+    if(MSVC)
+        set(lib_cc_flags ${_msvc_flags})
+    else()
+        set(lib_cc_flags ${_cc_flags})
+    endif()
+
+    ############################################################################
     # Build the Library
     ############################################################################
 
@@ -280,36 +308,18 @@ function(gpu_cpp_library)
     endif()
 
     ############################################################################
-    # Compilation Flags and Definitions
+    # Compilation Definitions
     ############################################################################
 
-    if(MSVC)
+    # The flag computation that used to be here moved above the "Build the
+    # Library" section -- see the note there. This part cannot move, because it
+    # operates on the target.
+    if(MSVC AND args_TYPE STREQUAL STATIC)
         # MSVC needs to define these variables to avoid generating _dllimport
         # functions.
-        if(args_TYPE STREQUAL STATIC)
-            target_compile_definitions(${lib_name}
-                PUBLIC ASMJIT_STATIC
-                PUBLIC FBGEMM_STATIC)
-        endif()
-
-        fbgemm_get_warning_flags(
-            MSVC_FLAGS_VAR  _msvc_flags
-            CC_FLAGS_VAR    _cc_flags
-            NVCC_FLAGS_VAR  _nvcc_warning_flags
-            HIPCC_FLAGS_VAR _hipcc_warning_flags
-            EXTRA_MSVC_FLAGS ${args_MSVC_FLAGS}
-            EXTRA_CC_FLAGS   ${args_CC_FLAGS})
-        set(lib_cc_flags ${_msvc_flags})
-
-    else()
-        fbgemm_get_warning_flags(
-            MSVC_FLAGS_VAR  _msvc_flags
-            CC_FLAGS_VAR    _cc_flags
-            NVCC_FLAGS_VAR  _nvcc_warning_flags
-            HIPCC_FLAGS_VAR _hipcc_warning_flags
-            EXTRA_MSVC_FLAGS ${args_MSVC_FLAGS}
-            EXTRA_CC_FLAGS   ${args_CC_FLAGS})
-        set(lib_cc_flags ${_cc_flags})
+        target_compile_definitions(${lib_name}
+            PUBLIC ASMJIT_STATIC
+            PUBLIC FBGEMM_STATIC)
     endif()
 
 

--- a/cmake/modules/GpuCppLibrary.cmake
+++ b/cmake/modules/GpuCppLibrary.cmake
@@ -391,9 +391,35 @@ function(gpu_cpp_library)
     ############################################################################
 
     # Set the additional compilation flags
+    #
+    # ⚠ `args_CC_FLAGS` is applied to EVERY language, unwrapped. No current caller
+    # passes a `-W` flag through it (audited), and one that did would
+    # reach nvcc raw and fail the build. Keep it that way.
     target_compile_options(${lib_name} PRIVATE
         ${args_CC_FLAGS}
         $<$<COMPILE_LANGUAGE:CXX>:${lib_cc_flags}>)
+
+    # Forward the host warning set to nvcc's host compiler.
+    #
+    # `_nvcc_warning_flags` is the CXX warning set with every entry wrapped as
+    # `-Xcompiler=<flag>` (see fbgemm_get_warning_flags). nvcc rejects a bare
+    # `-W...`, so the wrapping is mandatory, not cosmetic -- and it must be the
+    # single-token `-Xcompiler=<flag>` form, because the two-token
+    # `-Xcompiler <flag>` form can be split when CMake expands a `;`-list.
+    #
+    # The list form inside the genex is deliberate and matches the CXX line above:
+    # a `;`-list inside `$<...>` was measured NOT to leak to other languages, so
+    # a per-flag `foreach` would be a no-op.
+    #
+    # Skipped under MSVC: `_nvcc_warning_flags` is derived from the gcc/clang list
+    # regardless of host compiler, so on Windows nvcc would forward `-Wextra`,
+    # `-Wno-strict-aliasing` and friends to cl.exe, which does not accept them.
+    # The host CXX path already handles this by selecting `_msvc_flags` into
+    # `lib_cc_flags`; there is no MSVC-shaped equivalent for the nvcc list today.
+    if(NOT MSVC)
+        target_compile_options(${lib_name} PRIVATE
+            $<$<COMPILE_LANGUAGE:CUDA>:${_nvcc_warning_flags}>)
+    endif()
 
     ############################################################################
     # Post-Build Steps

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/fp8fp8bf16_fast_gemv.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/fp8fp8bf16_fast_gemv.cu
@@ -214,7 +214,12 @@ at::Tensor fp8fp8bf16_fast_gemv(
     at::Tensor x_scale,
     at::Tensor w_scale,
     bool is_batched) {
-  unsigned int b, m, n, k;
+  // `b` is initialized here rather than left indeterminate: it is assigned only
+  // on the `is_batched` path and read only on the same condition, so the code
+  // is correct -- but gcc's `-Wmaybe-uninitialized` cannot correlate the two
+  // checks and reports a false positive. That became fatal once `-Wall -Werror`
+  // was forwarded to nvcc's host compiler, which is gcc in OSS CI.
+  unsigned int b = 0, m, n, k;
   if (is_batched) {
     TORCH_CHECK(XQ.dim() == 3 && WQ.dim() == 3);
     b = XQ.size(0);


### PR DESCRIPTION
Summary:
Applies `_nvcc_warning_flags` to CUDA sources in `gpu_cpp_library()`. **This is the
first change that actually turns a warning surface on:** `.cu` compilation
previously received only `TORCH_CUDA_OPTIONS` -- no `-W` flags at all.

The effective change is four lines:

```cmake
if(NOT MSVC)
    target_compile_options(${lib_name} PRIVATE
        $<$<COMPILE_LANGUAGE:CUDA>:${_nvcc_warning_flags}>)
endif()
```

This covers the `.cu` **host pass** only. nvcc cannot warn device code -- that is
architectural, and why HIP is the device-code gate.

**Uses the list form rather than a per-flag `foreach`.** A `;`-list inside a
generator expression was measured not to leak to other languages, so `foreach` would
be a no-op refactor and would make this line inconsistent with the CXX line directly
above it.

**Guarded against MSVC.** `_nvcc_warning_flags` is derived from the gcc/clang list
unconditionally, so on a Windows CUDA build nvcc would forward `-Wextra`,
`-Wno-strict-aliasing` and friends to `cl.exe`, which does not accept them. The host
CXX path already handles this by selecting `_msvc_flags` into `lib_cc_flags`; there
is no MSVC-shaped equivalent for the nvcc list today, so the CUDA application is
skipped there rather than fabricating one.

**Includes one source fix.** Turning this surface on produced exactly one hard
error across 316 targets:

    fp8fp8bf16_fast_gemv.cu:232: error: 'b' may be used uninitialized
                                        [-Werror=maybe-uninitialized]

`-Wmaybe-uninitialized` is a gcc-only warning with no clang equivalent, and CI's
nvcc host compiler is gcc. The diagnostic is a false positive -- `b` is assigned
only on the `is_batched` path and read only under the same condition, so the code is
correct; gcc cannot correlate the two checks. The fix is an initializer rather than
a suppression: `unsigned int b = 0, m, n, k;` costs nothing and documents why. The
only other diagnostic in the log is 378 x `-Wunused-parameter`, which is pre-existing
`-Wextra` output demoted by `-Wno-error=unused-parameter` and unrelated.

Differential Revision: D115805271


