### PR TITLE
Add init and control-flow warnings, split across buckets (#6174)

### DIFF
--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -65,7 +65,11 @@ function(fbgemm_get_warning_flags)
     # by default; gcc via -Wall). Its value is on DEVICE code, which reaches it
     # via `_hipcc` -- but only once that list is applied. Until then this is
     # host-only and should produce nothing.
-    -Wunused-value)
+    -Wunused-value
+    # Init and control flow. `-Winfinite-recursion` and `-Wself-assign` are
+    # g++-rejected and live in `_cc_clang_only`.
+    -Wimplicit-fallthrough
+    -Wuninitialized)
 
   # Clang-only warning flags. These are appended to `_cc` ONLY when the host
   # compiler is clang (see the guarded append below), because the OSS CI matrix
@@ -80,7 +84,14 @@ function(fbgemm_get_warning_flags)
   # error on gcc. Verified by compiling a probe with each.
   set(_cc_clang_only
     # clang has no gcc equivalent for this one.
-    -Wmove)
+    -Wmove
+    # g++ rejects both of these outright.
+    #
+    # `-Winfinite-recursion` is `-Wall`-implied in clang (measured: 0 diagnostics
+    # at baseline, 1 with `-Wall`), so the OSS clang leg already has it and is
+    # green. No suppression is needed.
+    -Winfinite-recursion
+    -Wself-assign)
 
   # Suppressions. These are appended LAST so they win over everything above.
   #


### PR DESCRIPTION
Summary:

Adds `-Wuninitialized`, `-Wimplicit-fallthrough`, `-Winfinite-recursion` and
`-Wself-assign`.

**These do not all go in one bucket.** Measured with a compiler probe:

| flag | g++ 11.5 | clang 22 | bucket |
| --- | --- | --- | --- |
| `-Wuninitialized` | OK | OK | `_cc_common` |
| `-Wimplicit-fallthrough` | OK | OK | `_cc_common` |
| `-Winfinite-recursion` | **hard error** | OK | `_cc_clang_only` |
| `-Wself-assign` | **hard error** | OK | `_cc_clang_only` |

"init and control flow" is a semantic grouping, not a compiler claim -- putting all
four in `_cc_common` would have broken the gcc leg.

**`-Winfinite-recursion` needed more checking than the others.** There is no
`-Wno-infinite-recursion` anywhere in the OSS CMake, and no per-file properties on
`PackMatrix.cc`. Rather than assume that was an oversight, I measured:
`-Winfinite-recursion` is `-Wall`-implied in clang (0 diagnostics at baseline, 1 with
`-Wall`, 1 explicit), and g++ does not have the warning even under `-Wall`. So the
clang leg has had it active all along and is green, which is exactly why no
suppression exists. Adding it explicitly is a no-op.

Differential Revision: D115842468


