### PR TITLE
Add three clang-leaning warnings, one of them portable (#6175)

### DIFF
--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -69,7 +69,10 @@ function(fbgemm_get_warning_flags)
     # Init and control flow. `-Winfinite-recursion` and `-Wself-assign` are
     # g++-rejected and live in `_cc_clang_only`.
     -Wimplicit-fallthrough
-    -Wuninitialized)
+    -Wuninitialized
+    # g++ accepts `-Wvexing-parse`, so it goes in the portable bucket for
+    # gcc-leg coverage.
+    -Wvexing-parse)
 
   # Clang-only warning flags. These are appended to `_cc` ONLY when the host
   # compiler is clang (see the guarded append below), because the OSS CI matrix
@@ -91,7 +94,10 @@ function(fbgemm_get_warning_flags)
     # at baseline, 1 with `-Wall`), so the OSS clang leg already has it and is
     # green. No suppression is needed.
     -Winfinite-recursion
-    -Wself-assign)
+    -Wself-assign
+    # g++ rejects these two; only `-Wvexing-parse` is portable.
+    -Wnull-conversion
+    -Wstring-concatenation)
 
   # Suppressions. These are appended LAST so they win over everything above.
   #


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3065


Adds `-Wnull-conversion`, `-Wvexing-parse` and `-Wstring-concatenation`.

Two of the three are clang-only; the third is portable. Measured:

| flag | g++ 11.5 | clang 22 | bucket |
| --- | --- | --- | --- |
| `-Wnull-conversion` | hard error | OK | `_cc_clang_only` |
| `-Wstring-concatenation` | hard error | OK | `_cc_clang_only` |
| `-Wvexing-parse` | **OK** | OK | `_cc_common` |

`-Wvexing-parse` goes in the portable bucket. Putting it in `_cc_clang_only` would
work but would silently cover only half the CI matrix -- the same coverage loss
avoided earlier with `-Wunused-local-typedefs`. When a flag is portable, the portable
bucket is strictly better.

This is the third group whose expected bucketing did not survive measurement, which
is the argument for keeping the compiler-probe step per group rather than trusting
the grouping.

Differential Revision: D115842465


