### PR TITLE
Ignore rocm.docs.amd.com in Sphinx linkcheck

### DIFF
--- a/fbgemm_gpu/docs/src/conf.py
+++ b/fbgemm_gpu/docs/src/conf.py
@@ -137,7 +137,12 @@ exclude_patterns = [
 ]
 
 # Ignore false-negative broken links
-linkcheck_ignore = [r"https://gcc.gnu.org/bugzilla/show_bug.cgi\?id=105593"]
+linkcheck_ignore = [
+    r"https://gcc\.gnu\.org/bugzilla/show_bug\.cgi\?id=105593",
+    # rocm.docs.amd.com rate-limits the shared-IP GitHub runners (429 Too Many
+    # Requests), intermittently failing the docs job on unrelated PRs.
+    r"https://rocm\.docs\.amd\.com/.*",
+]
 
 # -- Breathe configuration ---------------------------------------------------
 


### PR DESCRIPTION
Summary:
The docs CI job runs Sphinx linkcheck over the documentation and fails the
build on any broken link. `rocm.docs.amd.com` rate-limits requests from the
shared-IP CI runners, so its two links (BuildInstructions, Releases)
intermittently come back `429 Too Many Requests` and fail the docs job on PRs
that touch no documentation at all. The checker's own retry already backs off
(`-rate limited- ... sleeping...`) and still gets throttled.

Add the domain to `linkcheck_ignore`, alongside the existing gcc bugzilla
entry that exists for the same reason. While reformatting the list, also
escape the unescaped `.`s in that pre-existing gcc pattern -- these entries
are regexes, so a bare `.` silently matches any character. The links remain in the docs; they are
just no longer a CI signal, since their availability tracks AMD's rate
limiter rather than the health of these pages.

___

Differential Revision: D116532863


