### PR TITLE
Make x86-only conv kernels fail loudly on arm instead of faulting or returning zeros (#6177)

### DIFF
--- a/src/CodeCache.h
+++ b/src/CodeCache.h
@@ -7,8 +7,10 @@
  */
 
 #pragma once
+#include <exception>
 #include <future>
 #include <map>
+#include <optional>
 #include <shared_mutex>
 
 #ifdef FBCODE_CAFFE2
@@ -64,10 +66,29 @@ class CodeCache {
         values_[key] = returnPromise.get_future().share();
 
         uniqueLock.unlock();
-        // The value (code) generation is not happening under a lock
-        VALUE val = generatorFunction();
-        returnPromise.set_value(val);
-        return val;
+        // Generation runs outside the lock. Only the generator call may sit in
+        // the try: a throw from set_value() would hit set_exception() on an
+        // already-satisfied promise.
+        std::optional<VALUE> val;
+        try {
+          val = generatorFunction();
+        } catch (...) {
+          // The future is already published, so hand waiters the generator's
+          // exception (a destroyed unfulfilled promise means broken_promise),
+          // then erase so a later call retries. set_exception() first: a
+          // waiter parked in get() still holds mutex_.
+          returnPromise.set_exception(std::current_exception());
+          try {
+            std::unique_lock<std::shared_timed_mutex> eraseLock(mutex_);
+            values_.erase(key);
+            // Cleanup must not displace the generator's exception.
+            // NOLINTNEXTLINE(bugprone-empty-catch)
+          } catch (...) {
+          }
+          throw;
+        }
+        returnPromise.set_value(*val);
+        return *val;
       } else {
         return it->second.get();
       }

--- a/src/GenerateI8Depthwise.cc
+++ b/src/GenerateI8Depthwise.cc
@@ -8,15 +8,21 @@
 
 #include "./GenerateI8Depthwise.h" // @manual
 
+#include <cpuinfo.h>
+
 #include <cassert>
-#include <iostream>
 #include <numeric>
+#include <stdexcept>
 
 #include "./CodeCache.h" // @manual
 #include "./CodeGenHelpers.h" // @manual
 #include "fbgemm/Utils.h"
 
 namespace fbgemm {
+
+// The entire generator is asmjit x86 codegen; off x86, getOrCreate at the
+// bottom of the file throws instead.
+#if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
 
 namespace {
 asmjit::JitRuntime& runtime() {
@@ -562,8 +568,12 @@ GenI8Depthwise::jit_kernel_signature GenI8Depthwise::getOrCreate(
       err = runtime().add(&fn, &code);
     }
     if (err) {
-      std::cout << "Error: in fn add" << '\n';
-      return nullptr;
+      // Callers dereference the returned pointer unconditionally; nullptr
+      // here would turn a codegen failure into a SIGSEGV at address 0.
+      throw std::runtime_error(
+          "[FBGEMM_CONV_ERROR] failed to register JIT-generated i8 depthwise "
+          "kernel with the asmjit runtime (asmjit error " +
+          std::to_string(err) + ")");
     }
 
 #ifdef FBGEMM_LOG_CODE
@@ -574,5 +584,28 @@ GenI8Depthwise::jit_kernel_signature GenI8Depthwise::getOrCreate(
     return fn;
   });
 }
+
+#else // non-x86
+
+GenI8Depthwise::jit_kernel_signature GenI8Depthwise::getOrCreate(
+    int /*D*/,
+    std::array<int, 3> /*F*/,
+    int /*oc_per_g*/,
+    bool /*compute_a_sum*/,
+    int /*remainder*/,
+    int /*prev_skip*/,
+    int /*next_skip*/,
+    int /*top_skip*/,
+    int /*bottom_skip*/,
+    int /*left_skip*/,
+    int /*right_skip*/) {
+  // Callers invoke the returned pointer directly; a diagnosable error beats
+  // a null function pointer that faults at address 0.
+  throw std::runtime_error(
+      "[FBGEMM_CONV_ERROR] i8 depthwise convolution is not implemented for "
+      "this architecture (the compute kernel is JIT-generated x86 assembly)");
+}
+
+#endif // x86
 
 } // namespace fbgemm

--- a/src/GroupwiseConv.cc
+++ b/src/GroupwiseConv.cc
@@ -164,8 +164,12 @@ static jit_conv_kernel_fp getOrCreateConvKernel(
     } else
 #endif
     {
-      // TODO: Have default slower path
+      // Callers dereference the returned pointer; returning nullptr here
+      // would fault at address 0, and the assert is a no-op under NDEBUG.
       assert(0 && "unsupported architecture");
+      throw runtime_error(
+          "[FBGEMM_CONV_ERROR] groupwise convolution kernel generation is not "
+          "implemented for this architecture (JIT-generated x86 assembly)");
     }
   } else {
     throw runtime_error("Failed to initialize cpuinfo!");
@@ -962,7 +966,12 @@ static void dispatchOutputProcessing(
     } else
 #endif
     {
+      // The assert alone is a no-op under NDEBUG, which silently produced
+      // all-zero results in opt builds; the throw makes it diagnosable.
       assert(0 && "unsupported architecture");
+      throw runtime_error(
+          "[FBGEMM_CONV_ERROR] groupwise per-group requantization is not "
+          "implemented for this architecture");
     }
   } else {
     throw runtime_error("Failed to initialize cpuinfo!");
@@ -998,6 +1007,19 @@ void fbgemmGroupwiseConv(
   if (!cpuinfo_initialize()) {
     throw runtime_error("Failed to initialize cpuinfo!");
   }
+
+  // The compute kernel is JIT-generated x86 assembly; off x86 this function
+  // used to return normally with the output buffer never written -- silently
+  // all-zero results, far worse than refusing to run. An early throw, not an
+  // #if around the body: the body's own per-block x86 guards would nest
+  // redundantly inside an identical outer #if (clang-tidy, 10 hits).
+#if !(                                          \
+    defined(__x86_64__) || defined(__i386__) || \
+    (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))))
+  throw runtime_error(
+      "[FBGEMM_CONV_ERROR] groupwise convolution is not implemented for this "
+      "architecture (the compute kernel is JIT-generated x86 assembly)");
+#endif // !x86
 
   int MB = conv_param.MB;
   int OT = SPATIAL_DIM <= 2 ? 1 : conv_param.OUT_DIM[SPATIAL_DIM - 3];

--- a/test/CodeCacheTest.cc
+++ b/test/CodeCacheTest.cc
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <future>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "src/CodeCache.h" // @manual
+
+using namespace fbgemm;
+
+namespace {
+
+struct GenFailure : std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+} // namespace
+
+// Kernel generators report failure by throwing -- GenerateI8Depthwise.cc does
+// so when asmjit cannot register the generated code. The caller has to receive
+// that exception, not a std::future_error from the cache's own bookkeeping.
+TEST(CodeCacheTest, GeneratorExceptionPropagates) {
+  CodeCache<int, int> cache;
+
+  EXPECT_THROW(
+      cache.getOrCreate(0, []() -> int { throw GenFailure("kernel gen"); }),
+      GenFailure);
+}
+
+// A failed generation must not be cached. The cache publishes the future
+// before running the generator, so an escaping exception used to leave a
+// broken promise behind under that key.
+TEST(CodeCacheTest, FailureIsNotCachedAndRetries) {
+  CodeCache<int, int> cache;
+  int calls = 0;
+
+  EXPECT_THROW(
+      cache.getOrCreate(
+          0,
+          [&]() -> int {
+            ++calls;
+            throw GenFailure("kernel gen");
+          }),
+      GenFailure);
+  EXPECT_EQ(calls, 1);
+
+  // Same key: the generator must run again rather than replay the failure.
+  EXPECT_EQ(
+      cache.getOrCreate(
+          0,
+          [&]() -> int {
+            ++calls;
+            return 42;
+          }),
+      42);
+  EXPECT_EQ(calls, 2);
+}
+
+// Every repeat of a persistent failure keeps reporting the generator's own
+// diagnostic, instead of degrading to broken_promise after the first attempt.
+TEST(CodeCacheTest, RepeatedFailuresKeepTheDiagnostic) {
+  CodeCache<int, int> cache;
+
+  for (int attempt = 0; attempt < 3; ++attempt) {
+    try {
+      cache.getOrCreate(
+          0, []() -> int { throw GenFailure("asmjit registration failed"); });
+      FAIL() << "expected GenFailure on attempt " << attempt;
+    } catch (const GenFailure& e) {
+      EXPECT_STREQ(e.what(), "asmjit registration failed");
+    }
+  }
+}
+
+// The single-threaded cases above all pass on values_.erase() alone -- delete
+// the set_exception() call and they stay green. What set_exception() is for is
+// a *waiter*: the cache publishes the future before running the generator, so
+// another thread can already be parked in get() when the generator throws.
+// Without it that thread wakes on future_error(broken_promise) instead of the
+// generator's own diagnostic, which is the bug this all exists to fix.
+TEST(CodeCacheTest, WaiterNeverSeesBrokenPromise) {
+  CodeCache<int, int> cache;
+  std::promise<void> generatorEntered;
+  std::promise<void> releaseGenerator;
+  auto entered = generatorEntered.get_future();
+  auto release = releaseGenerator.get_future();
+
+  auto first = std::async(std::launch::async, [&]() -> int {
+    return cache.getOrCreate(0, [&]() -> int {
+      generatorEntered.set_value();
+      release.wait();
+      throw GenFailure("asmjit registration failed");
+    });
+  });
+
+  // Only start the second caller once the generator is actually running, so it
+  // finds the already-published future and parks on it.
+  entered.wait();
+  auto second = std::async(std::launch::async, [&]() -> int {
+    return cache.getOrCreate(0, []() -> int { return 0; });
+  });
+  releaseGenerator.set_value();
+
+  EXPECT_THROW(first.get(), GenFailure);
+
+  // std::future_error must never surface. Which of the two legal outcomes we
+  // get is a real race -- the waiter either parked before the failure and sees
+  // the generator's exception, or arrived after the erase and re-ran
+  // generation -- so accept both. A broken promise is neither, and escapes.
+  try {
+    EXPECT_EQ(second.get(), 0);
+  } catch (const GenFailure&) {
+    SUCCEED() << "waiter observed the generator's own exception";
+  }
+}
+
+// The success path still memoizes: one generator call per key.
+TEST(CodeCacheTest, SuccessIsCached) {
+  CodeCache<int, int> cache;
+  int calls = 0;
+  auto gen = [&]() -> int {
+    ++calls;
+    return 7;
+  };
+
+  EXPECT_EQ(cache.getOrCreate(1, gen), 7);
+  EXPECT_EQ(cache.getOrCreate(1, gen), 7);
+  EXPECT_EQ(calls, 1);
+}

--- a/test/GConvTest.cc
+++ b/test/GConvTest.cc
@@ -487,6 +487,10 @@ static void runRequantizeTest(matrix_op_t /* unused */,
 }
 
 TEST_P(fbgemmGConvAcc32WithQuantGranularityTest, requantizeTest) {
+  if (!hasGroupwiseKernels()) {
+    // fbgemmGroupwiseConv would throw here, aborting the whole binary.
+    GTEST_SKIP() << "groupwise convolution needs the x86 AVX2 JIT kernels";
+  }
   auto [atrans, btrans, q_granularity, a_symmetric, b_symmetric] = GetParam();
 
   runRequantizeTest<2>(atrans, btrans, q_granularity, a_symmetric, b_symmetric);

--- a/test/I8DepthwiseTest.cc
+++ b/test/I8DepthwiseTest.cc
@@ -137,6 +137,10 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(1, 2, 3, 4, 5, 9, 10, 11, 27)));
 
 TEST_P(FBGemmDepthWiseTest, Test2D) {
+  if (!hasDepthwiseKernels()) {
+    // depthwise_{2,3}d_same_pad would throw here, aborting the whole binary.
+    GTEST_SKIP() << "i8 depthwise convolution needs the x86 AVX2 JIT kernels";
+  }
   auto [a_symmetric, b_symmetric, oc_per_g] = GetParam();
 
   for (auto shape : shapes) {
@@ -272,6 +276,10 @@ TEST_P(FBGemmDepthWiseTest, Test2D) {
 } // Test3x3
 
 TEST_P(FBGemmDepthWiseTest, Test3D) {
+  if (!hasDepthwiseKernels()) {
+    // depthwise_{2,3}d_same_pad would throw here, aborting the whole binary.
+    GTEST_SKIP() << "i8 depthwise convolution needs the x86 AVX2 JIT kernels";
+  }
   auto [a_symmetric, b_symmetric, oc_per_g] = GetParam();
 
   // 3D tests take a long time so for a symmetric quantization, we only
@@ -413,6 +421,10 @@ TEST_P(FBGemmDepthWiseTest, Test3D) {
 TEST_P(
     FBGemmDepthWisePerChannelQuantizationTest,
     Test2DPerChannelQuantization) {
+  if (!hasDepthwiseKernels()) {
+    // depthwise_{2,3}d_same_pad would throw here, aborting the whole binary.
+    GTEST_SKIP() << "i8 depthwise convolution needs the x86 AVX2 JIT kernels";
+  }
   int oc_per_g = GetParam();
 
   for (auto shape : shapes) {
@@ -554,6 +566,10 @@ TEST_P(
 TEST_P(
     FBGemmDepthWisePerChannelQuantizationTest,
     Test3DPerChannelQuantization) {
+  if (!hasDepthwiseKernels()) {
+    // depthwise_{2,3}d_same_pad would throw here, aborting the whole binary.
+    GTEST_SKIP() << "i8 depthwise convolution needs the x86 AVX2 JIT kernels";
+  }
   int oc_per_g = GetParam();
 
   for (auto shape : shapes_3d) {

--- a/test/TestUtils.h
+++ b/test/TestUtils.h
@@ -7,11 +7,31 @@
  */
 
 #pragma once
+#include <cpuinfo.h>
 #include <gtest/gtest.h>
 #include <cmath>
 #include <vector>
 
+#include "fbgemm/Utils.h"
+
 namespace fbgemm {
+
+// Groupwise and i8 depthwise conv kernels are JIT-generated x86 asm (AVX2+)
+// with no other implementation; their entry points throw elsewhere, so tests
+// that reach them must skip or the uncaught throw aborts the whole binary.
+// Runtime checks, not #ifdefs: a non-AVX2 x86 host throws too.
+inline bool hasGroupwiseKernels() {
+#if defined(__x86_64__) || defined(__i386__) || \
+    (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86)))
+  return cpuinfo_initialize() && fbgemmHasAvx2Support();
+#else
+  return false;
+#endif
+}
+
+inline bool hasDepthwiseKernels() {
+  return hasGroupwiseKernels(); // same JIT support today; separate for intent
+}
 
 /*
  * @brief Check and validate the buffers for reference and FBGEMM result.

--- a/test/UniConvTest.cc
+++ b/test/UniConvTest.cc
@@ -965,6 +965,10 @@ static void runRequantizeTest(
 }
 
 TEST_P(UniConvQGranTest, requantizeTest) {
+  if (!hasGroupwiseKernels()) {
+    // fbgemmGroupwiseConv would throw here, aborting the whole binary.
+    GTEST_SKIP() << "groupwise convolution needs the x86 AVX2 JIT kernels";
+  }
   auto [q_granularity, a_symmetric, b_symmetric, test_bias, test_float_bias] =
       GetParam();
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3069


Three fbgemm convolution paths have no aarch64 implementation. None of them
said so: one segfaulted, one silently produced all-zero results, and the tests
covering them reported the damage as ordinary numeric failures. This makes each
one fail with a diagnosable error and skips the affected tests.

The common root cause is `assert(0 && "unsupported architecture")` used as an
error path. Under NDEBUG -- i.e. in every optimized build -- the assert
compiles away and control simply falls through.

**1. Groupwise convolution: silently wrong results.** This is the serious one.
`fbgemmGroupwiseConv` has its kernel generation under `#if defined(__x86_64__)`,
but `dispatchOutputProcessing` runs unconditionally afterwards. On arm the
kernel never runs, the output buffer is never written, and the function returns
normally -- handing back an all-zero tensor as if it had succeeded. The
per-group requantize dispatch (GroupwiseConv.cc:957) has the same shape: guarded
by `#if !defined(__aarch64__)`, falling through to a bare `assert(0)`. A
quantized GEMM that quietly returns zeros is a much worse failure than one that
refuses to run, so `fbgemmGroupwiseConv` now throws at entry on non-x86, as do
the kernel-generation and requantize helpers.

**2. i8 depthwise convolution: SIGSEGV at address 0.** `GenerateI8Depthwise.cc`
is pure asmjit x86 codegen with no architecture guard. On arm
`runtime().add(&fn, &code)` fails, the lambda prints to stdout and returns
`nullptr`, and all six call sites invoke that pointer directly --
FbgemmI8Depthwise2D-inl.h:75 among them. The generator is now guarded, with a
non-x86 `getOrCreate` that throws. The x86 asmjit-error path was returning
nullptr into the same dereference, so it throws now too rather than depending on
a codegen failure never happening.

**2a. Making the throw survive the code cache.** Review asked for evidence that
the asmjit error path really throws rather than returning nullptr. Producing it
turned up a defect in the change: the throw happens inside the generator lambda
handed to `CodeCache::getOrCreate`, which publishes the shared_future under the
key *before* running the generator and only calls `set_value` afterwards. An
escaping exception therefore destroyed an unfulfilled promise, so the first
caller saw the real diagnostic and every later caller of the same kernel
signature got `std::future_error: Broken promise` instead -- with the failure
cached forever and never retried. That defeats the entire purpose of this diff.
`CodeCache.h` now catches, forwards the exception to anyone already waiting via
`set_exception`, erases the entry so a later call retries, and rethrows. New
CodeCacheTest covers it; without the fix its `FailureIsNotCachedAndRetries` case
fails with exactly that `Broken promise`. GroupwiseConv's throws are outside any
cache lambda and were never affected.

GenerateI8Depthwise.cc's guard uses cpuinfo's `CPUINFO_ARCH_X86 ||
CPUINFO_ARCH_X86_64` (always defined 0/1 once `<cpuinfo.h>` is included, and
covering MSVC's `_M_IX86`/`_M_X64` internally). fbgemmGroupwiseConv's guard
keeps the compiler-macro spelling to match the five pre-existing per-block
guards in the same file; either form covers Windows, where `__x86_64__` /
`__i386__` are not defined.

**3. Tests.** GConvTest (requantizeTest), UniConvTest
(UniConvQGranTest.requantizeTest) and I8DepthwiseTest (Test2D, Test3D and the
two per-channel-quantization variants) exercise those kernels directly, so they
now `GTEST_SKIP()`. Skipping only the affected tests matters: an uncaught throw
aborts the whole binary, and in I8DepthwiseTest that was taking 65 unrelated
pack/unpack and requantization cases down with it.

The skip conditions are `hasGroupwiseKernels()` / `hasDepthwiseKernels()` in
test/TestUtils.h -- runtime checks named for the capability each test needs,
not for the current non-implementation. Runtime rather than `#ifdef
__aarch64__` because the kernels throw on every non-x86 target and on non-AVX2
x86 hosts too; keying the skips to aarch64 alone would leave those aborting on
an uncaught exception, precisely the failure this diff exists to remove.

This reports the truth; it does not port anything. Making these paths actually
run on arm needs real kernels. Note GroupwiseConv.cc:610-804 contains a
`conv_ref`-based naive fallback that is entirely commented out -- reviving it
would be one route, but that is a design call for the fbgemm maintainers,
not a build fix.

**Review findings, folded in.** bensonma415 reviewed the above and found six
issues, four of them defects rather than style. Folded here rather than stacked,
since most correct a fault in this diff:
- `fbgemmGroupwiseConv`'s arch guard is an early throw under the negated
  predicate again, not an `#if` around the whole body. The body already carries
  five per-block guards with the byte-identical predicate, so nesting them in an
  outer copy tripped `readability-redundant-preprocessor` ten times.
- `CodeCache.h`: the `try` now covers only the generator call. With `set_value()`
  and the return copy inside it, a throw from either would have called
  `set_exception()` on an already-satisfied promise, raising `future_error` --
  displacing the real diagnostic and skipping the erase. The erase is also
  best-effort now, and the ordering is documented: `set_exception()` must precede
  it, because a waiter parked in `get()` still holds the shared lock.
- The test skips use a runtime capability check, not the compile-time
  architecture constant: the generators only emit AVX2 and newer, so a non-AVX2
  x86 host takes the same throwing branch as a non-x86 one. (Since split into
  `hasGroupwiseKernels()` / `hasDepthwiseKernels()` per later review.)
- The conv-facing throws carry the `[FBGEMM_CONV_ERROR]` prefix. This is
  load-bearing: `UniConvTest.cc:589` asserts messages start with it.
- `assert(0 && "unsupported architecture")` is restored alongside the two
  `GroupwiseConv.cc` throws, matching how `ExecuteKernelU8S8.cc`, `PackAMatrix.cc`
  and `Fbgemm.cc` pair them, and repairing a comment that referred to an assert
  that no longer existed.
- `CodeCacheTest` gains `WaiterNeverSeesBrokenPromise`. The original four cases
  were single-threaded and passed on the `erase()` alone -- deleting
  `set_exception()` left them green, so they never pinned half the fix.

Also drops a now-dead `#include <iostream>`, registers `CodeCacheTest` in
`SUPPORT_STATIC_LISTING`, and silences the one new `bugprone-empty-catch` on the
best-effort erase with a justified NOLINT.

Reviewed By: q10, MatzeB

Differential Revision: D116410048


