### PR TITLE
VLE support on benchmark

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/utils/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/utils/__init__.py
@@ -10,4 +10,8 @@
 from .common import get_device, round_up, to_device  # noqa: F401
 from .offsets import b_indices, get_table_batched_offsets_from_dense  # noqa: F401
 from .quantize import dequantize_embs, fake_quantize_embs, quantize_embs  # noqa: F401
-from .requests import generate_requests, TBERequest  # noqa: F401
+from .requests import (  # noqa: F401
+    generate_requests,
+    generate_requests_for_grouped_tables,
+    TBERequest,
+)

--- a/fbgemm_gpu/fbgemm_gpu/tbe/utils/requests.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/utils/requests.py
@@ -647,6 +647,114 @@ def maybe_to_dtype(tensor: torch.Tensor, dtype: torch.dtype | None) -> torch.Ten
     return tensor if dtype is None else tensor.to(dtype)
 
 
+def generate_requests_for_grouped_tables(  # noqa C901
+    iters: int,
+    B: int,
+    T: int,
+    L: int,
+    E: int,
+    *,
+    Ls: list[int],
+    feature_table_map: list[int],
+    Es: list[int],
+    alpha: float = 1.0,
+    weighted: bool = False,
+) -> list[TBERequest]:
+    """Generate fixed-batch requests with multiple features per physical table."""
+    if T <= 0:
+        raise ValueError(f"T must be positive, got {T}")
+    if B <= 0:
+        raise ValueError(f"B must be positive, got {B}")
+    if iters <= 0:
+        raise ValueError(f"iters must be positive, got {iters}")
+    if len(Es) != T:
+        raise ValueError(f"len(Es)={len(Es)} must equal T={T}")
+    if len(Ls) != len(feature_table_map):
+        raise ValueError(
+            f"len(Ls)={len(Ls)} must equal "
+            f"len(feature_table_map)={len(feature_table_map)}"
+        )
+    if not feature_table_map:
+        raise ValueError("feature_table_map must not be empty")
+    if any(table < 0 or table >= T for table in feature_table_map):
+        raise ValueError(
+            f"feature_table_map entries must be in [0, {T}), "
+            f"got {feature_table_map}"
+        )
+    missing_tables = sorted(set(range(T)) - set(feature_table_map))
+    if missing_tables:
+        raise ValueError(
+            f"Each physical table must have at least one feature; "
+            f"missing tables: {missing_tables}"
+        )
+    if any(length < 0 for length in Ls):
+        raise ValueError(f"Ls must be non-negative, got {Ls}")
+    if any(num_embeddings <= 0 for num_embeddings in Es):
+        raise ValueError(f"Es must be positive, got {Es}")
+    if L != max(Ls):
+        raise ValueError(f"L={L} must equal max(Ls)={max(Ls)}")
+    if E != max(Es):
+        raise ValueError(f"E={E} must equal max(Es)={max(Es)}")
+
+    device = get_device()
+    feature_Es = [Es[table] for table in feature_table_map]
+    Bs = [B] * len(feature_table_map)
+    lengths = np.repeat(np.array(Ls, dtype=np.int32), B)
+    lengths = np.tile(lengths, iters)
+    L_offsets = torch.from_numpy(np.insert(lengths.cumsum(), 0, 0)).to(torch.long)
+
+    if alpha <= 1.0:
+        all_indices = generate_indices_uniform(
+            iters,
+            Bs,
+            L,
+            E,
+            True,
+            L_offsets,
+            device=device,
+            Es=feature_Es,
+        )
+    else:
+        all_indices = generate_indices_zipf(
+            iters,
+            Bs,
+            L,
+            E,
+            alpha,
+            3,
+            True,
+            L_offsets,
+            False,
+            device=device,
+            Es=feature_Es,
+        )
+
+    total_B = sum(Bs)
+    all_indices = all_indices.flatten()
+    requests = []
+    for it in range(iters):
+        start_offset = L_offsets[it * total_B]
+        request_offsets = torch.concat(
+            [
+                torch.zeros(1, dtype=L_offsets.dtype, device=L_offsets.device),
+                L_offsets[it * total_B + 1 : (it + 1) * total_B + 1] - start_offset,
+            ]
+        )
+        per_sample_weights = (
+            torch.randn(int(request_offsets[-1].item()), device=device)
+            if weighted
+            else None
+        )
+        requests.append(
+            TBERequest(
+                all_indices[start_offset : L_offsets[(it + 1) * total_B]],
+                request_offsets.to(device),
+                per_sample_weights,
+            )
+        )
+    return requests
+
+
 def generate_requests(  # noqa C901
     iters: int,
     B: int,

--- a/fbgemm_gpu/fbgemm_gpu/tbe/utils/requests.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/utils/requests.py
@@ -649,7 +649,7 @@ def maybe_to_dtype(tensor: torch.Tensor, dtype: torch.dtype | None) -> torch.Ten
 
 def generate_requests_for_grouped_tables(  # noqa C901
     iters: int,
-    B: int,
+    B: int | list[int],
     T: int,
     L: int,
     E: int,
@@ -660,11 +660,9 @@ def generate_requests_for_grouped_tables(  # noqa C901
     alpha: float = 1.0,
     weighted: bool = False,
 ) -> list[TBERequest]:
-    """Generate fixed-batch requests with multiple features per physical table."""
+    """Generate requests with multiple features per physical table."""
     if T <= 0:
         raise ValueError(f"T must be positive, got {T}")
-    if B <= 0:
-        raise ValueError(f"B must be positive, got {B}")
     if iters <= 0:
         raise ValueError(f"iters must be positive, got {iters}")
     if len(Es) != T:
@@ -687,6 +685,21 @@ def generate_requests_for_grouped_tables(  # noqa C901
             f"Each physical table must have at least one feature; "
             f"missing tables: {missing_tables}"
         )
+    if isinstance(B, int):
+        if B <= 0:
+            raise ValueError(f"B must be positive, got {B}")
+        Bs = [B] * len(feature_table_map)
+        Bs_feature_rank = None
+    else:
+        if len(B) != len(feature_table_map):
+            raise ValueError(
+                f"len(Bs)={len(B)} must equal "
+                f"len(feature_table_map)={len(feature_table_map)}"
+            )
+        if any(batch_size <= 0 for batch_size in B):
+            raise ValueError(f"Bs must be positive, got {B}")
+        Bs = B
+        Bs_feature_rank = [[batch_size] for batch_size in Bs]
     if any(length < 0 for length in Ls):
         raise ValueError(f"Ls must be non-negative, got {Ls}")
     if any(num_embeddings <= 0 for num_embeddings in Es):
@@ -698,8 +711,7 @@ def generate_requests_for_grouped_tables(  # noqa C901
 
     device = get_device()
     feature_Es = [Es[table] for table in feature_table_map]
-    Bs = [B] * len(feature_table_map)
-    lengths = np.repeat(np.array(Ls, dtype=np.int32), B)
+    lengths = np.repeat(np.array(Ls, dtype=np.int32), Bs)
     lengths = np.tile(lengths, iters)
     L_offsets = torch.from_numpy(np.insert(lengths.cumsum(), 0, 0)).to(torch.long)
 
@@ -750,6 +762,7 @@ def generate_requests_for_grouped_tables(  # noqa C901
                 all_indices[start_offset : L_offsets[(it + 1) * total_B]],
                 request_offsets.to(device),
                 per_sample_weights,
+                Bs_feature_rank,
             )
         )
     return requests

--- a/fbgemm_gpu/test/tbe/utils/requests_test.py
+++ b/fbgemm_gpu/test/tbe/utils/requests_test.py
@@ -16,18 +16,27 @@ from fbgemm_gpu.tbe.utils import generate_requests_for_grouped_tables
 
 
 class GroupedTableRequestsTest(unittest.TestCase):
-    def _validate_requests(self, alpha: float, weighted: bool) -> None:
-        B = 3
+    def _validate_requests(
+        self,
+        alpha: float,
+        weighted: bool,
+        batch_sizes: int | list[int],
+    ) -> None:
         Ls = [2, 0, 3]
         feature_table_map = [0, 1, 0]
         Es = [11, 13]
+        Bs = (
+            [batch_sizes] * len(feature_table_map)
+            if isinstance(batch_sizes, int)
+            else batch_sizes
+        )
         with patch(
             "fbgemm_gpu.tbe.utils.requests.torch.cuda.is_available",
             return_value=False,
         ):
             requests = generate_requests_for_grouped_tables(
                 2,
-                B,
+                batch_sizes,
                 2,
                 max(Ls),
                 max(Es),
@@ -40,10 +49,13 @@ class GroupedTableRequestsTest(unittest.TestCase):
 
         self.assertEqual(len(requests), 2)
         expected_lengths = torch.tensor(
-            [length for length in Ls for _ in range(B)], dtype=torch.long
+            [length for length, batch_size in zip(Ls, Bs) for _ in range(batch_size)],
+            dtype=torch.long,
         )
         for request in requests:
-            indices, offsets, per_sample_weights = request.unpack_3()
+            indices, offsets, per_sample_weights, Bs_per_feature_per_rank = (
+                request.unpack_4()
+            )
             offsets_cpu = offsets.cpu()
             torch.testing.assert_close(
                 offsets_cpu[1:] - offsets_cpu[:-1], expected_lengths
@@ -51,8 +63,9 @@ class GroupedTableRequestsTest(unittest.TestCase):
             self.assertEqual(indices.numel(), int(expected_lengths.sum().item()))
 
             for feature, table in enumerate(feature_table_map):
-                start = int(offsets_cpu[feature * B].item())
-                end = int(offsets_cpu[(feature + 1) * B].item())
+                feature_row_start = sum(Bs[:feature])
+                start = int(offsets_cpu[feature_row_start].item())
+                end = int(offsets_cpu[feature_row_start + Bs[feature]].item())
                 feature_indices = indices[start:end]
                 self.assertTrue(torch.all(feature_indices >= 0).item())
                 self.assertTrue(torch.all(feature_indices < Es[table]).item())
@@ -63,18 +76,54 @@ class GroupedTableRequestsTest(unittest.TestCase):
                 self.assertEqual(per_sample_weights.numel(), indices.numel())
             else:
                 self.assertIsNone(per_sample_weights)
+            self.assertEqual(
+                Bs_per_feature_per_rank,
+                (
+                    None
+                    if isinstance(batch_sizes, int)
+                    else [[batch_size] for batch_size in Bs]
+                ),
+            )
 
     def test_uniform_weighted_requests(self) -> None:
-        self._validate_requests(alpha=1.0, weighted=True)
+        self._validate_requests(alpha=1.0, weighted=True, batch_sizes=[3, 2, 4])
 
     def test_zipf_unweighted_requests(self) -> None:
-        self._validate_requests(alpha=1.2, weighted=False)
+        self._validate_requests(alpha=1.2, weighted=False, batch_sizes=[2, 4, 1])
+
+    def test_fixed_batch_size_omits_vbe_metadata(self) -> None:
+        self._validate_requests(alpha=1.0, weighted=False, batch_sizes=3)
+
+    def test_rejects_invalid_batch_sizes(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"len\(Bs\)"):
+            generate_requests_for_grouped_tables(
+                1,
+                [2],
+                2,
+                2,
+                11,
+                Ls=[2, 1],
+                feature_table_map=[0, 1],
+                Es=[7, 11],
+            )
+
+        with self.assertRaisesRegex(ValueError, "must be positive"):
+            generate_requests_for_grouped_tables(
+                1,
+                [2, 0],
+                2,
+                2,
+                11,
+                Ls=[2, 1],
+                feature_table_map=[0, 1],
+                Es=[7, 11],
+            )
 
     def test_rejects_invalid_mapping(self) -> None:
         with self.assertRaisesRegex(ValueError, "must equal"):
             generate_requests_for_grouped_tables(
                 1,
-                2,
+                [2],
                 2,
                 2,
                 11,
@@ -86,7 +135,7 @@ class GroupedTableRequestsTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "must be in"):
             generate_requests_for_grouped_tables(
                 1,
-                2,
+                [2, 2],
                 2,
                 2,
                 11,
@@ -98,7 +147,7 @@ class GroupedTableRequestsTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "missing tables"):
             generate_requests_for_grouped_tables(
                 1,
-                2,
+                [2, 2],
                 2,
                 2,
                 11,
@@ -106,7 +155,3 @@ class GroupedTableRequestsTest(unittest.TestCase):
                 feature_table_map=[0, 0],
                 Es=[7, 11],
             )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/fbgemm_gpu/test/tbe/utils/requests_test.py
+++ b/fbgemm_gpu/test/tbe/utils/requests_test.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from unittest.mock import patch
+
+import torch
+from fbgemm_gpu import sparse_ops  # noqa: F401
+from fbgemm_gpu.tbe.utils import generate_requests_for_grouped_tables
+
+
+class GroupedTableRequestsTest(unittest.TestCase):
+    def _validate_requests(self, alpha: float, weighted: bool) -> None:
+        B = 3
+        Ls = [2, 0, 3]
+        feature_table_map = [0, 1, 0]
+        Es = [11, 13]
+        with patch(
+            "fbgemm_gpu.tbe.utils.requests.torch.cuda.is_available",
+            return_value=False,
+        ):
+            requests = generate_requests_for_grouped_tables(
+                2,
+                B,
+                2,
+                max(Ls),
+                max(Es),
+                Ls=Ls,
+                feature_table_map=feature_table_map,
+                Es=Es,
+                alpha=alpha,
+                weighted=weighted,
+            )
+
+        self.assertEqual(len(requests), 2)
+        expected_lengths = torch.tensor(
+            [length for length in Ls for _ in range(B)], dtype=torch.long
+        )
+        for request in requests:
+            indices, offsets, per_sample_weights = request.unpack_3()
+            offsets_cpu = offsets.cpu()
+            torch.testing.assert_close(
+                offsets_cpu[1:] - offsets_cpu[:-1], expected_lengths
+            )
+            self.assertEqual(indices.numel(), int(expected_lengths.sum().item()))
+
+            for feature, table in enumerate(feature_table_map):
+                start = int(offsets_cpu[feature * B].item())
+                end = int(offsets_cpu[(feature + 1) * B].item())
+                feature_indices = indices[start:end]
+                self.assertTrue(torch.all(feature_indices >= 0).item())
+                self.assertTrue(torch.all(feature_indices < Es[table]).item())
+
+            if weighted:
+                self.assertIsNotNone(per_sample_weights)
+                assert per_sample_weights is not None
+                self.assertEqual(per_sample_weights.numel(), indices.numel())
+            else:
+                self.assertIsNone(per_sample_weights)
+
+    def test_uniform_weighted_requests(self) -> None:
+        self._validate_requests(alpha=1.0, weighted=True)
+
+    def test_zipf_unweighted_requests(self) -> None:
+        self._validate_requests(alpha=1.2, weighted=False)
+
+    def test_rejects_invalid_mapping(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must equal"):
+            generate_requests_for_grouped_tables(
+                1,
+                2,
+                2,
+                2,
+                11,
+                Ls=[2, 1],
+                feature_table_map=[0],
+                Es=[7, 11],
+            )
+
+        with self.assertRaisesRegex(ValueError, "must be in"):
+            generate_requests_for_grouped_tables(
+                1,
+                2,
+                2,
+                2,
+                11,
+                Ls=[2, 1],
+                feature_table_map=[0, 2],
+                Es=[7, 11],
+            )
+
+        with self.assertRaisesRegex(ValueError, "missing tables"):
+            generate_requests_for_grouped_tables(
+                1,
+                2,
+                2,
+                2,
+                11,
+                Ls=[2, 1],
+                feature_table_map=[0, 0],
+                Es=[7, 11],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3070

## Request generation

- Extend `generate_requests_for_grouped_tables` to accept either a scalar batch
  size or a list of per-feature batch sizes.
- Preserve the existing fixed-batch behavior for scalar input, including leaving
  `Bs_per_feature_per_rank` unset.
- For list input, validate that every batch size is positive and that the list
  length matches the logical feature count.
- Generate feature-major lengths and offsets using each feature's batch size.
- Populate `Bs_per_feature_per_rank` as `[[B0], [B1], ...]`, modeling the common
  one-rank VLE/VBE workload.
- Continue generating each feature's indices within the embedding count of its
  mapped physical table, with uniform or Zipf distributions and optional
  per-sample weights.

## Triton TBE benchmark

- Allow `--batch-size` to be either one value or a comma-separated list when
  `--vbe` is selected. A scalar value is replicated across all logical features.
- Use the grouped-table request generator for both fixed-batch and VLE/VBE
  requests.
- Model the common VLE/VBE path as one feature per table and one rank. The
  benchmark infers the identity feature-to-table mapping, so VLE/VBE commands do
  not need `--feature-table-map` or `--vbe-num-ranks`.
- Remove randomized `--sigma-B` and multi-rank `--vbe-num-ranks` request
  generation from this benchmark path.
- Reject multiple `--batch-size` values unless `--vbe` is enabled.
- Calculate accessed weight bytes as the sum of each feature's
  `batch_size * embedding_dim * bag_size` contribution.
- Report per-feature batch sizes while preserving the existing scalar `B` field
  for non-VBE benchmark statistics.

Reviewed By: JChunX

Differential Revision: D115936874


