### PR TITLE
UE support on benchmark (#6179)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/utils/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/utils/__init__.py
@@ -10,4 +10,8 @@
 from .common import get_device, round_up, to_device  # noqa: F401
 from .offsets import b_indices, get_table_batched_offsets_from_dense  # noqa: F401
 from .quantize import dequantize_embs, fake_quantize_embs, quantize_embs  # noqa: F401
-from .requests import generate_requests, TBERequest  # noqa: F401
+from .requests import (  # noqa: F401
+    generate_requests,
+    generate_requests_for_grouped_tables,
+    TBERequest,
+)

--- a/fbgemm_gpu/fbgemm_gpu/tbe/utils/requests.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/utils/requests.py
@@ -647,6 +647,114 @@ def maybe_to_dtype(tensor: torch.Tensor, dtype: torch.dtype | None) -> torch.Ten
     return tensor if dtype is None else tensor.to(dtype)
 
 
+def generate_requests_for_grouped_tables(  # noqa C901
+    iters: int,
+    B: int,
+    T: int,
+    L: int,
+    E: int,
+    *,
+    Ls: list[int],
+    feature_table_map: list[int],
+    Es: list[int],
+    alpha: float = 1.0,
+    weighted: bool = False,
+) -> list[TBERequest]:
+    """Generate fixed-batch requests with multiple features per physical table."""
+    if T <= 0:
+        raise ValueError(f"T must be positive, got {T}")
+    if B <= 0:
+        raise ValueError(f"B must be positive, got {B}")
+    if iters <= 0:
+        raise ValueError(f"iters must be positive, got {iters}")
+    if len(Es) != T:
+        raise ValueError(f"len(Es)={len(Es)} must equal T={T}")
+    if len(Ls) != len(feature_table_map):
+        raise ValueError(
+            f"len(Ls)={len(Ls)} must equal "
+            f"len(feature_table_map)={len(feature_table_map)}"
+        )
+    if not feature_table_map:
+        raise ValueError("feature_table_map must not be empty")
+    if any(table < 0 or table >= T for table in feature_table_map):
+        raise ValueError(
+            f"feature_table_map entries must be in [0, {T}), "
+            f"got {feature_table_map}"
+        )
+    missing_tables = sorted(set(range(T)) - set(feature_table_map))
+    if missing_tables:
+        raise ValueError(
+            f"Each physical table must have at least one feature; "
+            f"missing tables: {missing_tables}"
+        )
+    if any(length < 0 for length in Ls):
+        raise ValueError(f"Ls must be non-negative, got {Ls}")
+    if any(num_embeddings <= 0 for num_embeddings in Es):
+        raise ValueError(f"Es must be positive, got {Es}")
+    if L != max(Ls):
+        raise ValueError(f"L={L} must equal max(Ls)={max(Ls)}")
+    if E != max(Es):
+        raise ValueError(f"E={E} must equal max(Es)={max(Es)}")
+
+    device = get_device()
+    feature_Es = [Es[table] for table in feature_table_map]
+    Bs = [B] * len(feature_table_map)
+    lengths = np.repeat(np.array(Ls, dtype=np.int32), B)
+    lengths = np.tile(lengths, iters)
+    L_offsets = torch.from_numpy(np.insert(lengths.cumsum(), 0, 0)).to(torch.long)
+
+    if alpha <= 1.0:
+        all_indices = generate_indices_uniform(
+            iters,
+            Bs,
+            L,
+            E,
+            True,
+            L_offsets,
+            device=device,
+            Es=feature_Es,
+        )
+    else:
+        all_indices = generate_indices_zipf(
+            iters,
+            Bs,
+            L,
+            E,
+            alpha,
+            3,
+            True,
+            L_offsets,
+            False,
+            device=device,
+            Es=feature_Es,
+        )
+
+    total_B = sum(Bs)
+    all_indices = all_indices.flatten()
+    requests = []
+    for it in range(iters):
+        start_offset = L_offsets[it * total_B]
+        request_offsets = torch.concat(
+            [
+                torch.zeros(1, dtype=L_offsets.dtype, device=L_offsets.device),
+                L_offsets[it * total_B + 1 : (it + 1) * total_B + 1] - start_offset,
+            ]
+        )
+        per_sample_weights = (
+            torch.randn(int(request_offsets[-1].item()), device=device)
+            if weighted
+            else None
+        )
+        requests.append(
+            TBERequest(
+                all_indices[start_offset : L_offsets[(it + 1) * total_B]],
+                request_offsets.to(device),
+                per_sample_weights,
+            )
+        )
+    return requests
+
+
 def generate_requests(  # noqa C901
     iters: int,
     B: int,

--- a/fbgemm_gpu/test/tbe/utils/requests_test.py
+++ b/fbgemm_gpu/test/tbe/utils/requests_test.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from unittest.mock import patch
+
+import torch
+from fbgemm_gpu import sparse_ops  # noqa: F401
+from fbgemm_gpu.tbe.utils import generate_requests_for_grouped_tables
+
+
+class GroupedTableRequestsTest(unittest.TestCase):
+    def _validate_requests(self, alpha: float, weighted: bool) -> None:
+        B = 3
+        Ls = [2, 0, 3]
+        feature_table_map = [0, 1, 0]
+        Es = [11, 13]
+        with patch(
+            "fbgemm_gpu.tbe.utils.requests.torch.cuda.is_available",
+            return_value=False,
+        ):
+            requests = generate_requests_for_grouped_tables(
+                2,
+                B,
+                2,
+                max(Ls),
+                max(Es),
+                Ls=Ls,
+                feature_table_map=feature_table_map,
+                Es=Es,
+                alpha=alpha,
+                weighted=weighted,
+            )
+
+        self.assertEqual(len(requests), 2)
+        expected_lengths = torch.tensor(
+            [length for length in Ls for _ in range(B)], dtype=torch.long
+        )
+        for request in requests:
+            indices, offsets, per_sample_weights = request.unpack_3()
+            offsets_cpu = offsets.cpu()
+            torch.testing.assert_close(
+                offsets_cpu[1:] - offsets_cpu[:-1], expected_lengths
+            )
+            self.assertEqual(indices.numel(), int(expected_lengths.sum().item()))
+
+            for feature, table in enumerate(feature_table_map):
+                start = int(offsets_cpu[feature * B].item())
+                end = int(offsets_cpu[(feature + 1) * B].item())
+                feature_indices = indices[start:end]
+                self.assertTrue(torch.all(feature_indices >= 0).item())
+                self.assertTrue(torch.all(feature_indices < Es[table]).item())
+
+            if weighted:
+                self.assertIsNotNone(per_sample_weights)
+                assert per_sample_weights is not None
+                self.assertEqual(per_sample_weights.numel(), indices.numel())
+            else:
+                self.assertIsNone(per_sample_weights)
+
+    def test_uniform_weighted_requests(self) -> None:
+        self._validate_requests(alpha=1.0, weighted=True)
+
+    def test_zipf_unweighted_requests(self) -> None:
+        self._validate_requests(alpha=1.2, weighted=False)
+
+    def test_rejects_invalid_mapping(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must equal"):
+            generate_requests_for_grouped_tables(
+                1,
+                2,
+                2,
+                2,
+                11,
+                Ls=[2, 1],
+                feature_table_map=[0],
+                Es=[7, 11],
+            )
+
+        with self.assertRaisesRegex(ValueError, "must be in"):
+            generate_requests_for_grouped_tables(
+                1,
+                2,
+                2,
+                2,
+                11,
+                Ls=[2, 1],
+                feature_table_map=[0, 2],
+                Es=[7, 11],
+            )
+
+        with self.assertRaisesRegex(ValueError, "missing tables"):
+            generate_requests_for_grouped_tables(
+                1,
+                2,
+                2,
+                2,
+                11,
+                Ls=[2, 1],
+                feature_table_map=[0, 0],
+                Es=[7, 11],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3049

### Request generation

- Add `generate_requests_for_grouped_tables` to `fbgemm_gpu.tbe.utils` and export it from the package.
- Model `T` and `Es` as physical-table metadata while `Ls` and `feature_table_map` describe logical lookup features.
- Allow `len(Ls) > T` so multiple fixed-`B` lookups can share a physical table.
- Generate each feature's indices within `Es[feature_table_map[feature]]` and construct offsets for its configured bag size.
- Support uniform and Zipf indices plus optional per-sample weights.
- Keep file-backed requests, VBE, reuse, pruning, and dtype conversion out of the new focused helper.
- Validate mapping lengths, table-index bounds, physical-table coverage, pooling factors, and table sizes.

### Triton TBE benchmark

- Add `--feature-table-map`, where entry `i` maps logical feature `i` to a zero-based physical table index.
- Default to the existing one-feature-per-table mapping when the option is omitted.
- Use `generate_requests_for_grouped_tables` for every non-VBE request.
- Pass the feature mapping to both `SplitTableBatchedEmbeddingBagsCodegen` and `TritonTableBatchedEmbeddingBags`.
- Calculate feature dimensions, accessed bytes, bag-size hints, and backward gradient shape from the logical feature mapping.
- Keep VBE on `generate_requests` and require its mapping to remain one-to-one.
- Reject nonzero `--reuse` for grouped-table request generation rather than silently ignoring it.

Reviewed By: JChunX

Differential Revision: D115828870


