### PR TITLE
Drop rocm 7.14 from the GenAI x86 wheels matrix until supported

### DIFF
--- a/.github/workflows/build_wheels_genai_linux_x86.yml
+++ b/.github/workflows/build_wheels_genai_linux_x86.yml
@@ -56,11 +56,14 @@ jobs:
       #   fails with "Unknown distribution". 13.4 is still on toolkit 13.4.0rc1
       #   (not GA). Drop until each is supported.
       # rocm/3.13t: causes segfaults at runtime
+      # rocm/7.14: not supported in the Nova scripts yet (nova_dir.bash knows
+      #   rocm 7.0/6.4/6.3/6.2); the build produces no wheel and the job fails
+      #   on the empty dist/. Drop until supported.
       run: |
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter gpu_arch_version:11.8 --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2,13.4' )"
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter gpu_arch_version:11.8 --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2,13.4' --filter 'gpu_arch_type:rocm;gpu_arch_version:7.14' )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
Summary:
The GenAI wheels build matrix is generated by pytorch/test-infra@main, which
recently began emitting a `rocm7.14` variant. FBGEMM's Nova build scripts do
not know that version: `.github/scripts/nova_dir.bash` handles rocm 7.0, 6.4,
6.3 and 6.2, and unknown versions take a fallback path that completes without
placing a wheel in `dist/`, so the job fails on
`pip install ... dist/` ("Neither 'setup.py' nor 'pyproject.toml' found") --
deterministically, on every pull request, with the `upload` job cascading.

Filter the variant out of the matrix until real rocm 7.14 support is added,
exactly as this filter step already drops CUDA 13.2/13.4 ("not supported by
FBGEMM yet ... Drop until each is supported"). Scoped to the GenAI workflow:
the non-GenAI wheels workflow's rocm 7.14 job passes.

The alternative -- and the eventual right fix -- is adding a rocm7.14 case to
`nova_dir.bash`, which is a decision about which gfx targets 7.14 wheels
should build for; leaving that judgement to the fbgemm maintainers rather than
guessing here.

Differential Revision: D116566622


