### PR TITLE
TBE inference benchmark improvements and scripts

### DIFF
--- a/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
@@ -1606,7 +1606,7 @@ def device_with_spec(  # noqa C901
     "--print-kernel-summary",
     is_flag=True,
     default=False,
-    help="Whether the table is weighted or not",
+    help="Whether to print a summary of kernel execution times",
 )
 @click.option("--ssd", is_flag=True, default=False)
 @click.option(

--- a/fbgemm_gpu/bench/tbe/tbe_inference_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_inference_benchmark.py
@@ -49,7 +49,9 @@ logger: logging.Logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-def kineto_trace_profiler(p: profile, trace_info: tuple[str, str, str, str]) -> float:
+def kineto_trace_profiler(
+    p: profile, trace_info: tuple[str, str, str, str], print_summary: bool = False
+) -> float:
     phase, trace_url, tbe_type, kern_name = trace_info
     p.export_chrome_trace(
         trace_url.format(tbe_type=tbe_type, phase=phase, ospid=os.getpid())
@@ -59,8 +61,10 @@ def kineto_trace_profiler(p: profile, trace_info: tuple[str, str, str, str]) -> 
         # Sum the total time of forward kernel runs
         if kern_name in event.key:
             kernel_time += event.device_time
-    assert kernel_time > 0
+    assert kernel_time > 0, f"No kernel time found in {kern_name}."
     print(f"Total CUDA time: {kernel_time:.2f} ")
+    if print_summary:
+        print(p.key_averages().table(sort_by="cuda_time_total", row_limit=10))
     return kernel_time
 
 
@@ -285,8 +289,6 @@ def nbit_cpu(  # noqa C901
 @click.option("--check-median", is_flag=True, default=True)
 @click.option("--iters", default=100)
 @click.option("--runs-of-iters", default=5)
-@click.option("--warmup-runs", default=2)
-@click.option("--warmup-ms", type=int, default=None)
 @click.option("--output-dtype", type=SparseType, default=SparseType.FP16)
 @click.option("--report-aibench", is_flag=True)
 @click.option("--run-reference", is_flag=True, default=False)
@@ -295,6 +297,12 @@ def nbit_cpu(  # noqa C901
 @click.option("--fp8-exponent-bits", type=int, default=None)
 @click.option("--fp8-exponent-bias", type=int, default=None)
 @click.option("--export-trace", is_flag=True, default=False)
+@click.option(
+    "--print-kernel-summary",
+    is_flag=True,
+    default=False,
+    help="Whether to print a summary of kernel execution times",
+)
 @click.option(
     "--trace-url",
     type=str,
@@ -339,6 +347,7 @@ def nbit_device(  # noqa C901
     fp8_exponent_bits: int | None,
     fp8_exponent_bias: int | None,
     export_trace: bool,
+    print_kernel_summary: bool,
     trace_url: str,
     warmup_runs: int,
     warmup_ms: int | None,
@@ -346,6 +355,13 @@ def nbit_device(  # noqa C901
     np.random.seed(42)
     torch.manual_seed(42)
     reporter = BenchmarkReporter(report_aibench)
+
+    if warmup_runs >= runs_of_iters:
+        logging.warning(
+            f"warmup_runs ({warmup_runs}) >= runs_of_iters ({runs_of_iters}), "
+            f"adjusting runs_of_iters to {warmup_runs + 1}"
+        )
+        runs_of_iters = warmup_runs + 1
 
     B = batch_size
     D = embedding_dim
@@ -513,7 +529,7 @@ def nbit_device(  # noqa C901
     # Get trace for one run of iter
     tbe_type: str = "split"
     # input of the kineto_trace_profiler
-    trace_info = ("fwd", trace_url, tbe_type, "embedding_codegen_forward")
+    trace_info = ("fwd", trace_url, tbe_type, "codegen_forward")
     time_dict = {"kernel_time": None}  # dict to hold the kernel time
 
     # warm-up right before profiling
@@ -533,7 +549,9 @@ def nbit_device(  # noqa C901
 
     with context_factory(
         # pyre-ignore[6]
-        lambda p: time_dict.update(kernel_time=kineto_trace_profiler(p, trace_info))
+        lambda p: time_dict.update(
+            kernel_time=kineto_trace_profiler(p, trace_info, print_kernel_summary)
+        )
     ):
         # forward
         time_per_iter = benchmark_requests(
@@ -661,6 +679,12 @@ def nbit_device(  # noqa C901
 @click.option("--use-cpu", is_flag=True, default=False)
 @click.option("--export-trace", is_flag=True, default=False)
 @click.option(
+    "--print-kernel-summary",
+    is_flag=True,
+    default=False,
+    help="Whether to print a summary of kernel execution times",
+)
+@click.option(
     "--trace-url",
     type=str,
     default="{tbe_type}_tbe_spec_{phase}_trace_{ospid}.json",
@@ -707,6 +731,7 @@ def nbit_device_with_spec(  # noqa C901
     fp8_exponent_bias: int | None,
     use_cpu: bool,
     export_trace: bool,
+    print_kernel_summary: bool,
     trace_url: str,
     warmup_runs: int,
     warmup_ms: int | None,
@@ -715,6 +740,14 @@ def nbit_device_with_spec(  # noqa C901
     np.random.seed(42)
     torch.manual_seed(42)
     reporter = BenchmarkReporter(report_aibench)
+
+    if warmup_runs >= runs_of_iters:
+        logging.warning(
+            f"warmup_runs ({warmup_runs}) >= runs_of_iters ({runs_of_iters}), "
+            f"adjusting runs_of_iters to {warmup_runs + 1}"
+        )
+        runs_of_iters = warmup_runs + 1
+
     B = batch_size
     Ds = [int(D) for D in embedding_dim_list.split(",")]
     Ls = [int(L) for L in bag_size_list.split(",")]
@@ -949,7 +982,7 @@ def nbit_device_with_spec(  # noqa C901
         # profile with kineto
         tbe_type: str = "split"
         time_dict = {"kernel_time": None}  # Shared variable to hold the kernel time
-        trace_info = ("fwd", trace_url, tbe_type, "embedding_codegen_forward")
+        trace_info = ("fwd", trace_url, tbe_type, "codegen_forward")
 
         # warm-up right before profiling
         # warmup_ms prioritized over warmup_runs
@@ -968,7 +1001,9 @@ def nbit_device_with_spec(  # noqa C901
 
         with context_factory(
             # pyre-ignore[6]
-            lambda p: time_dict.update(kernel_time=kineto_trace_profiler(p, trace_info))
+            lambda p: time_dict.update(
+                kernel_time=kineto_trace_profiler(p, trace_info, print_kernel_summary)
+            )
         ):
             # forward
             time_per_iter = benchmark_requests(


### PR DESCRIPTION
Summary:
# TLDR

Adds the TBE **inference** benchmark tooling: a runner, a shape sweep, a trace-driven replay, and an analyzer, plus the benchmark-side options they need. The sweep covers 48 distinct inference shapes (96 runs, each shape at two Zipf alphas).

# Changes

- `tbe_inference_benchmark.py`
  - `--print-kernel-summary` on `nbit_device` and `nbit_device_with_spec`, matching the training benchmark. `kineto_trace_profiler` takes a `print_summary` flag and prints the top-10 kernel table
  - kernel-name filter changed from `embedding_codegen_forward` to `codegen_forward`. The nobag kernels are named `..._split_embedding_nobag_codegen_forward_...`, so the old substring missed them entirely and the `kernel_time > 0` assert fired. Both spellings match the pruned-lookup kernels, so nothing new is double-counted
  - that assert now names the kernel it looked for instead of failing bare
  - `warmup_runs >= runs_of_iters` is raised to `warmup_runs + 1` with a warning, instead of leaving zero timed runs
  - dropped the duplicate `--warmup-runs` / `--warmup-ms` declarations on `nbit_device`; the documented ones further down are the live pair
- `split_table_batched_embeddings_benchmark.py` - `--print-kernel-summary` help said "Whether the table is weighted or not"
- `run_tbe_inference_benchmark.sh` - single-shape runner: arch/precision/shape flags, ncu, trace export, per-run log. Unknown flags are rejected rather than silently ending argv parsing (`* ) break` used to discard everything after the first unrecognised token, `-c/--arch` included), and every value-taking flag is checked before `shift 2`, which otherwise spins the loop forever on a missing value
- `run_tbe_inference_sweep.sh` - two shape families, selected with `--grid all|large-table|many-tables`:

|  family |  shape |  grid |  shapes |  runs |
| -- |
|  large-table |  T=2, D=256, E=1e8, int8; long bags |  B(3) x L(4) |  12 |  24 |
|  many-tables |  B=2048; int4 and int8, small/medium tables |  (dtype,D)(6) x L(3) x E(2) |  36 |  72 |

  - each shape runs at alpha 1 (uniform) and 1.15 (skewed), which is what doubles runs over shapes
  - unknown flags are still forwarded to the runner, as documented; the runner now rejects the ones it does not know, so a typo surfaces instead of silently truncating the argument list
- `run_tbe_inference_from_trace.sh` - replays shapes captured from a trace rather than a grid
- `analyze_bench_inference.py` + `BUCK` target - parses the inference traces/logs into a comparison table, same shape as the training analyzers
- `external/run_tbe_inference_amd.sh` - standalone OSS/AMD runner; `run_gis_bench_amd.sh` moved alongside it under `external/`

# Usage

```
bash ${HOME}/fbsource/fbcode/ai_codesign/nonprod/supadchaya/scripts/fbgemm/run_tbe_inference_sweep.sh -c mi350
bash ${HOME}/fbsource/fbcode/ai_codesign/nonprod/supadchaya/scripts/fbgemm/run_tbe_inference_sweep.sh --grid large-table -c mi350
python3 ${HOME}/fbsource/fbcode/ai_codesign/nonprod/supadchaya/scripts/fbgemm/analyze_bench_inference.py --dir ./baseline --dir ./new --names baseline,new
```

Differential Revision: D101591048
