### PR TITLE
Observe shutdown on teardown instead of running loops to completion (#6189)

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
@@ -11,6 +11,7 @@
 #ifdef FBGEMM_FBCODE
 #include <folly/coro/Task.h>
 #include <folly/futures/Future.h>
+#include <atomic>
 #endif
 
 #include <utility>
@@ -158,6 +159,9 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
   size_t res_num_hbm_copy_threads_;
 #endif
 #ifdef FBGEMM_FBCODE
+  // Set by the destructor before any join, so shutdown-observing loops bail out
+  // instead of running to their timeouts.
+  std::atomic<bool> stop_{false};
   // Named executor that ships enqueued StreamQueueItems to the PS. Push model:
   // producers submit one ship task per item and workers wake on submit (no
   // polling). Sized to res_num_consumers_.

--- a/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
@@ -343,6 +343,9 @@ RawEmbeddingStreamer::RawEmbeddingStreamer(
 
 RawEmbeddingStreamer::~RawEmbeddingStreamer() {
 #ifdef FBGEMM_FBCODE
+  // Signal shutdown before any join so spin loops bail out instead of waiting
+  // out their timeouts.
+  stop_.store(true, std::memory_order_relaxed);
   if (enable_raw_embedding_streaming_) {
     // Drain in producer order: dispatch schedules onto uvm_hit_copy_executor_,
     // and copy groups submit ship tasks onto consumer_executor_, so join
@@ -365,10 +368,12 @@ RawEmbeddingStreamer::~RawEmbeddingStreamer() {
       hbm_copy_executor_->join();
     }
     // Producers (dispatch + copy) are all joined above, so no further ship
-    // tasks will be submitted. join() drains the in-flight ones before the
-    // executor's threads stop, then destroys members in a safe order.
+    // tasks will be submitted. stop(), not join(): each queued item is a
+    // blocking co_setEmbeddings carrying no RpcOptions timeout, so draining the
+    // backlog would stall teardown behind a wedged PS. The threads are still
+    // joined, so in-flight ships finish; only the queued backlog is discarded.
     if (consumer_executor_ != nullptr) {
-      consumer_executor_->join();
+      consumer_executor_->stop();
     }
   }
 #endif
@@ -628,6 +633,11 @@ bool RawEmbeddingStreamer::poll_copy_done_flag(
     folly::stop_watch<std::chrono::microseconds> poll_watch;
     while (*ptr == 0) {
       std::this_thread::yield();
+      // At shutdown the producing GPU work is abandoned, so the flag may never
+      // be set.
+      if (stop_.load(std::memory_order_relaxed)) {
+        return false;
+      }
       if (poll_watch.elapsed().count() > kCopyDonePollTimeoutUs) {
         LOG(ERROR) << "[TBE_ID" << unique_id_
                    << "] copy_done_flag poll timed out after "


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3078

Before this stack, base set `stop_ = true` before joining its raw threads at shutdown; the executor rewrite dropped `stop_`, so both teardown loops keep running work instead of bailing out. This diff restores parity.

```
 ~RawEmbeddingStreamer() {
+  stop_ = true;                 // base did this; the rewrite dropped it
   ...
-  consumer_executor_->join();   // drains the backlog -- N blocking
+  consumer_executor_->stop();   // co_setEmbeddings, uncapped, no timeout
 }

 while (*ptr == 0) {             // poll_copy_done_flag
   std::this_thread::yield();
+  if (stop_) return false;      // else spins the full 10s at shutdown
```

`stop()` and `join()` both enqueue poison at `LO_PRI` and join the threads; they differ only in `shouldStopThread()`, where `join()` forbids early exit so a worker must drain down to its poison task. `stop()` lets workers exit at any dequeue point -- best-effort per folly's contract ("no guarantee that unexecuted tasks won't be executed"), and in-flight ships finish either way. Producer joins stay `join()`: draining dispatch and copy is what keeps anything from scheduling onto the consumer after it stops.

Reviewed By: bottler

Differential Revision: D116397924


