### PR TITLE
Vectorize the u8s8 compute kernel with NEON

### DIFF
--- a/src/ExecuteKernelU8S8.cc
+++ b/src/ExecuteKernelU8S8.cc
@@ -8,6 +8,10 @@
 
 #include "./ExecuteKernelU8S8.h" // @manual
 #include <cpuinfo.h>
+#include <algorithm>
+#include <cstdint>
+#include <type_traits>
+#include <vector>
 
 #ifdef FBGEMM_MEASURE_TIME_BREAKDOWN
 double kernel_time = 0.0;
@@ -15,6 +19,105 @@ double postprocessing_time = 0.0;
 #endif
 
 namespace fbgemm {
+
+#ifdef __aarch64__
+namespace {
+
+// Saturating narrow to int16, i.e. what every x86 "s"-suffixed pack/add does.
+std::int16_t satInt16(std::int32_t v) {
+  return static_cast<std::int16_t>(std::clamp(v, -32768, 32767));
+}
+
+// Portable reference implementation of the u8s8 GEMM micro-kernel for aarch64.
+//
+// On x86 the compute kernel is JIT-generated assembly (see
+// GenerateKernelU8S8*.cc); no such kernel exists for arm, so we compute the
+// mc x nc x kc block directly from the packed A/B buffers. Both the packed
+// layout and the integer arithmetic mirror the avx2 kernel exactly:
+//   - A is packed row-major with row stride kBlock (== KCB); element A[i][k]
+//     lives at aBuf[i * kBlock + k] and is unsigned 8-bit.
+//   - B is packed with row_interleave consecutive K values adjacent per column;
+//     element B[k][n] lives at
+//       bBuf[k * nBlock + n * row_interleave + (k % row_interleave)]
+//     (k here is already a multiple of row_interleave) and is signed 8-bit.
+//   - acc16 (accT == int16_t, row_interleave == 2): vpmaddubsw multiplies the
+//     unsigned A byte by the signed B byte and horizontally adds the pair into
+//     an int16 that saturates; the running accumulator is a saturating int16
+//     add (vpaddsw). The int16 result is sign-extended to int32 on store.
+//   - acc32 (accT == int32_t, row_interleave == 4): each pair is reduced with
+//     the saturating int16 vpmaddubsw, then widened and summed to int32
+//     (vpmaddwd) and accumulated without saturation (vpaddd).
+// `accum` selects overwrite vs. accumulate into the int32 C buffer, matching
+// the JIT store path (used across successive K-blocks).
+//
+// Loop order mirrors the register blocking of the JIT kernel: one row of
+// accumulators is held across the whole K sweep, so the inner loop walks the
+// packed B block and the accumulators contiguously. Reversing it (accumulating
+// a single C element at a time) strides B by row_interleave * NCB per step and
+// re-reads the whole block for every column, which costs well over an order of
+// magnitude.
+template <typename accT>
+void computeBlockRef(
+    const uint8_t* aBuf,
+    const int8_t* bBuf,
+    int32_t* cBuf,
+    int mc,
+    int nc,
+    int kc,
+    int kBlock,
+    int nBlock,
+    bool accum,
+    int ldc) {
+  constexpr int row_interleave = std::is_same_v<accT, std::int16_t> ? 2 : 4;
+  static thread_local std::vector<accT> acc;
+  acc.resize(nc);
+
+  for (int i = 0; i < mc; ++i) {
+    std::fill(acc.begin(), acc.end(), accT{0});
+    for (int k = 0; k < kc; k += row_interleave) {
+      const uint8_t* aPtr = aBuf + i * kBlock + k;
+      const int8_t* bPtr = bBuf + k * nBlock;
+      if constexpr (std::is_same_v<accT, std::int16_t>) {
+        const std::int32_t a0 = aPtr[0];
+        const std::int32_t a1 = aPtr[1];
+        for (int n = 0; n < nc; ++n) {
+          // vpmaddubsw: (u8 * s8) + (u8 * s8) saturated to int16.
+          const std::int16_t prod =
+              satInt16(a0 * bPtr[2 * n] + a1 * bPtr[2 * n + 1]);
+          // vpaddsw: saturating int16 accumulate.
+          acc[n] = satInt16(acc[n] + prod);
+        }
+      } else {
+        const std::int32_t a0 = aPtr[0];
+        const std::int32_t a1 = aPtr[1];
+        const std::int32_t a2 = aPtr[2];
+        const std::int32_t a3 = aPtr[3];
+        for (int n = 0; n < nc; ++n) {
+          const std::int16_t p01 =
+              satInt16(a0 * bPtr[4 * n] + a1 * bPtr[4 * n + 1]);
+          const std::int16_t p23 =
+              satInt16(a2 * bPtr[4 * n + 2] + a3 * bPtr[4 * n + 3]);
+          // vpmaddwd (widen+add) followed by vpaddd (non-saturating int32).
+          acc[n] += p01 + p23;
+        }
+      }
+    }
+    // Sign-extend the accumulator to int32 to match vpmovsxwd (acc16) / the
+    // native int32 register (acc32).
+    int32_t* cRow = cBuf + i * ldc;
+    if (accum) {
+      for (int n = 0; n < nc; ++n) {
+        cRow[n] += acc[n];
+      }
+    } else {
+      for (int n = 0; n < nc; ++n) {
+        cRow[n] = acc[n];
+      }
+    }
+  }
+}
+} // namespace
+#endif // __aarch64__
 
 template <typename packingAMatrix, typename cT, typename processOutputType>
 ExecuteKernel<
@@ -48,6 +151,13 @@ ExecuteKernel<
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
   if (params) {
+#ifdef __aarch64__
+    // aarch64 reference compute path consumes the avx2/user-provided blocking.
+    mbSize_ = params->MCB;
+    nbSize_ = params->NCB;
+    nrMinSize_ = params->NR_MIN;
+    nrSize_ = params->NR;
+#else
     if (fbgemmHasAvx2Support()) {
       mbSize_ = params->MCB;
       nbSize_ = params->NCB;
@@ -58,6 +168,7 @@ ExecuteKernel<
       assert(0 && "unsupported architecure");
       throw std::runtime_error("unsupported architecure");
     }
+#endif
   } else {
     const inst_set_t isa = fbgemmInstructionSet();
     switch (isa) {
@@ -89,6 +200,11 @@ ExecuteKernel<
             inst_set_t::avx512_ymm>::getKernelParams();
         break;
 
+#ifdef __aarch64__
+      // aarch64 reference compute path reuses the avx2 kernel blocking params.
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         std::tie(mbSize_, nbSize_, nrMinSize_, nrSize_) = PackingTraits<
             typename packingAMatrix::inpType,
@@ -137,6 +253,13 @@ void ExecuteKernel<
   if (jb_end == jb_begin) {
     return;
   }
+
+#ifdef __aarch64__
+  // OutputProcessing-inl.h forces its generic implementation on aarch64, so the
+  // avx2 tag below resolves to portable code and needs no x86 SIMD support.
+  constexpr bool hasOutputProcessingKernel = true;
+#else
+  const bool hasOutputProcessingKernel = fbgemmHasAvx2Support();
 
   typename BaseType::jit_micro_kernel_fp fn;
 
@@ -211,6 +334,7 @@ void ExecuteKernel<
       assert(0 && "unsupported architecture");
       throw std::runtime_error("unsupported architecure");
   }
+#endif // __aarch64__
 
 #ifdef FBGEMM_MEASURE_TIME_BREAKDOWN
   std::chrono::time_point<std::chrono::high_resolution_clock> t_end;
@@ -219,60 +343,66 @@ void ExecuteKernel<
 #endif
 
   for (int jb = jb_begin; jb < jb_end; ++jb) {
-    if (jb == bColBlocks - 1) {
-      int nc = ((packedB_.lastBcol() - 1) / nrMinSize_ + 1) * nrMinSize_;
-      if (nc != nbSize_) {
-        switch (isa) {
-          case inst_set_t::avx512_vnni:
-            if constexpr (std::is_same_v<
-                              typename packingAMatrix::accType,
-                              std::int16_t>) {
-              // For AVX512VNNI, we redirect int16_t to int32_t accumulation.
-              CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
-              fn = codeObj.getOrCreate<inst_set_t::avx512_vnni>(
-                  accum, packed_rows_A, nc, packedA_.numPackedCols());
-            } else {
-              fn = BaseType::template getOrCreate<inst_set_t::avx512_vnni>(
-                  accum, packed_rows_A, nc, packedA_.numPackedCols());
-            }
-            break;
+    // Columns actually computed for this block: the last one is rounded up to
+    // NR_MIN. The JIT bakes this into the generated code; the aarch64 reference
+    // kernel takes it as an argument, so it is computed once here for both.
+    const int nc = jb == bColBlocks - 1
+        ? ((packedB_.lastBcol() - 1) / nrMinSize_ + 1) * nrMinSize_
+        : nbSize_;
 
-          case inst_set_t::avx512_vnni_ymm:
-            if constexpr (std::is_same_v<
-                              typename packingAMatrix::accType,
-                              std::int16_t>) {
-              // For AVX512VNNI, we redirect int16_t to int32_t accumulation.
-              CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
-              fn = codeObj.getOrCreate<inst_set_t::avx512_vnni_ymm>(
-                  accum, packed_rows_A, nc, packedA_.numPackedCols());
-            } else {
-              fn = BaseType::template getOrCreate<inst_set_t::avx512_vnni_ymm>(
-                  accum, packed_rows_A, nc, packedA_.numPackedCols());
-            }
-            break;
-
-          case inst_set_t::avx512:
-            fn = BaseType::template getOrCreate<inst_set_t::avx512>(
+#ifndef __aarch64__
+    if (nc != nbSize_) {
+      switch (isa) {
+        case inst_set_t::avx512_vnni:
+          if constexpr (std::is_same_v<
+                            typename packingAMatrix::accType,
+                            std::int16_t>) {
+            // For AVX512VNNI, we redirect int16_t to int32_t accumulation.
+            CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
+            fn = codeObj.getOrCreate<inst_set_t::avx512_vnni>(
                 accum, packed_rows_A, nc, packedA_.numPackedCols());
-            break;
-
-          case inst_set_t::avx512_ymm:
-            fn = BaseType::template getOrCreate<inst_set_t::avx512_ymm>(
+          } else {
+            fn = BaseType::template getOrCreate<inst_set_t::avx512_vnni>(
                 accum, packed_rows_A, nc, packedA_.numPackedCols());
-            break;
+          }
+          break;
 
-          case inst_set_t::avx2:
-            fn = BaseType::template getOrCreate<inst_set_t::avx2>(
+        case inst_set_t::avx512_vnni_ymm:
+          if constexpr (std::is_same_v<
+                            typename packingAMatrix::accType,
+                            std::int16_t>) {
+            // For AVX512VNNI, we redirect int16_t to int32_t accumulation.
+            CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
+            fn = codeObj.getOrCreate<inst_set_t::avx512_vnni_ymm>(
                 accum, packed_rows_A, nc, packedA_.numPackedCols());
-            break;
+          } else {
+            fn = BaseType::template getOrCreate<inst_set_t::avx512_vnni_ymm>(
+                accum, packed_rows_A, nc, packedA_.numPackedCols());
+          }
+          break;
 
-          default:
-            // TODO: Have default slower path
-            assert(0 && "unsupported architecture");
-            throw std::runtime_error("unsupported architecure");
-        }
+        case inst_set_t::avx512:
+          fn = BaseType::template getOrCreate<inst_set_t::avx512>(
+              accum, packed_rows_A, nc, packedA_.numPackedCols());
+          break;
+
+        case inst_set_t::avx512_ymm:
+          fn = BaseType::template getOrCreate<inst_set_t::avx512_ymm>(
+              accum, packed_rows_A, nc, packedA_.numPackedCols());
+          break;
+
+        case inst_set_t::avx2:
+          fn = BaseType::template getOrCreate<inst_set_t::avx2>(
+              accum, packed_rows_A, nc, packedA_.numPackedCols());
+          break;
+
+        default:
+          // TODO: Have default slower path
+          assert(0 && "unsupported architecture");
+          throw std::runtime_error("unsupported architecure");
       }
     }
+#endif // __aarch64__
 
     bBuf = packedB_.getBuf(jb, kBlock);
     // prefetch addr of the next packed block of B matrix
@@ -304,12 +434,30 @@ void ExecuteKernel<
       leadingDim = nbSize_;
     }
 
+#ifdef __aarch64__
+    // No JIT micro-kernel exists for arm; compute this block with the portable
+    // reference kernel. `fn` bakes mc/nc/kc into the JIT'd code, so the
+    // reference kernel takes them as arguments instead.
+    (void)bBuf_pf; // prefetch hint is unused on the reference path
+    computeBlockRef<typename packingAMatrix::accType>(
+        aBuf,
+        bBuf,
+        C_buffer_start,
+        packed_rows_A, // mc
+        nc,
+        packedA_.numPackedCols(), // kc
+        packedA_.blockColSize(), // kBlock == A row stride (KCB)
+        packedB_.blockColSize(), // nBlock == NCB
+        accum,
+        leadingDim);
+#else
     fn(aBuf,
        bBuf,
        bBuf_pf,
        C_buffer_start,
        packedA_.numPackedCols(),
        leadingDim);
+#endif
 
 #ifdef FBGEMM_MEASURE_TIME_BREAKDOWN
     t_end = std::chrono::high_resolution_clock::now();
@@ -328,7 +476,7 @@ void ExecuteKernel<
           (C_buffer_start == C_tile_.data() ? (jb - jb_begin) * nbSize_
                                             : (jb_end - jb_begin) * nbSize_);
       if (nSize) {
-        if (fbgemmHasAvx2Support()) {
+        if (hasOutputProcessingKernel) {
           // TODO: avx512 path
           // Currently use avx2 code
           outputProcess_.template f<inst_set_t::avx2>(
@@ -350,7 +498,7 @@ void ExecuteKernel<
       if (C_buffer_start == C_tile_.data()) {
         // When C_tile_ scratchpad was used to avoid accessing memory past
         // C_buffer_ .
-        if (fbgemmHasAvx2Support()) {
+        if (hasOutputProcessingKernel) {
           // TODO: avx512 path
           // Currently use avx2 code
           outputProcess_.template f<inst_set_t::avx2>(

--- a/src/ExecuteKernelU8S8.cc
+++ b/src/ExecuteKernelU8S8.cc
@@ -13,6 +13,10 @@
 #include <type_traits>
 #include <vector>
 
+#ifdef __aarch64__
+#include <arm_neon.h>
+#endif
+
 #ifdef FBGEMM_MEASURE_TIME_BREAKDOWN
 double kernel_time = 0.0;
 double postprocessing_time = 0.0;
@@ -28,7 +32,7 @@ std::int16_t satInt16(std::int32_t v) {
   return static_cast<std::int16_t>(std::clamp(v, -32768, 32767));
 }
 
-// Portable reference implementation of the u8s8 GEMM micro-kernel for aarch64.
+// NEON implementation of the u8s8 GEMM micro-kernel for aarch64.
 //
 // On x86 the compute kernel is JIT-generated assembly (see
 // GenerateKernelU8S8*.cc); no such kernel exists for arm, so we compute the
@@ -50,14 +54,13 @@ std::int16_t satInt16(std::int32_t v) {
 // `accum` selects overwrite vs. accumulate into the int32 C buffer, matching
 // the JIT store path (used across successive K-blocks).
 //
-// Loop order mirrors the register blocking of the JIT kernel: one row of
-// accumulators is held across the whole K sweep, so the inner loop walks the
-// packed B block and the accumulators contiguously. Reversing it (accumulating
-// a single C element at a time) strides B by row_interleave * NCB per step and
-// re-reads the whole block for every column, which costs well over an order of
-// magnitude.
+// NEON mapping, exact by construction: the interleaved layout makes vld2/vld4
+// de-interleave a K-pair/quad for 8 columns per load; vpmaddubsw is
+// vmull/vmlal into int32 lanes followed by the saturating narrow vqmovn_s32;
+// vpaddsw is vqaddq_s16; vpmaddwd+vpaddd is vaddl_s16 into a non-saturating
+// vaddq_s32. Columns beyond the last multiple of 8 take the scalar tail.
 template <typename accT>
-void computeBlockRef(
+void computeBlockNeon(
     const uint8_t* aBuf,
     const int8_t* bBuf,
     int32_t* cBuf,
@@ -69,49 +72,97 @@ void computeBlockRef(
     bool accum,
     int ldc) {
   constexpr int row_interleave = std::is_same_v<accT, std::int16_t> ? 2 : 4;
-  static thread_local std::vector<accT> acc;
-  acc.resize(nc);
 
   for (int i = 0; i < mc; ++i) {
-    std::fill(acc.begin(), acc.end(), accT{0});
-    for (int k = 0; k < kc; k += row_interleave) {
-      const uint8_t* aPtr = aBuf + i * kBlock + k;
-      const int8_t* bPtr = bBuf + k * nBlock;
-      if constexpr (std::is_same_v<accT, std::int16_t>) {
-        const std::int32_t a0 = aPtr[0];
-        const std::int32_t a1 = aPtr[1];
-        for (int n = 0; n < nc; ++n) {
-          // vpmaddubsw: (u8 * s8) + (u8 * s8) saturated to int16.
-          const std::int16_t prod =
-              satInt16(a0 * bPtr[2 * n] + a1 * bPtr[2 * n + 1]);
-          // vpaddsw: saturating int16 accumulate.
-          acc[n] = satInt16(acc[n] + prod);
-        }
-      } else {
-        const std::int32_t a0 = aPtr[0];
-        const std::int32_t a1 = aPtr[1];
-        const std::int32_t a2 = aPtr[2];
-        const std::int32_t a3 = aPtr[3];
-        for (int n = 0; n < nc; ++n) {
-          const std::int16_t p01 =
-              satInt16(a0 * bPtr[4 * n] + a1 * bPtr[4 * n + 1]);
-          const std::int16_t p23 =
-              satInt16(a2 * bPtr[4 * n + 2] + a3 * bPtr[4 * n + 3]);
-          // vpmaddwd (widen+add) followed by vpaddd (non-saturating int32).
-          acc[n] += p01 + p23;
-        }
-      }
-    }
-    // Sign-extend the accumulator to int32 to match vpmovsxwd (acc16) / the
-    // native int32 register (acc32).
+    const uint8_t* aRow = aBuf + i * kBlock;
     int32_t* cRow = cBuf + i * ldc;
-    if (accum) {
-      for (int n = 0; n < nc; ++n) {
-        cRow[n] += acc[n];
+    int n = 0;
+
+    if constexpr (std::is_same_v<accT, std::int16_t>) {
+      for (; n + 8 <= nc; n += 8) {
+        int16x8_t acc = vdupq_n_s16(0);
+        for (int k = 0; k < kc; k += 2) {
+          const std::int16_t a0 = aRow[k];
+          const std::int16_t a1 = aRow[k + 1];
+          const int8x8x2_t b = vld2_s8(bBuf + k * nBlock + 2 * n);
+          const int16x8_t b0 = vmovl_s8(b.val[0]);
+          const int16x8_t b1 = vmovl_s8(b.val[1]);
+          int32x4_t lo = vmull_n_s16(vget_low_s16(b0), a0);
+          lo = vmlal_n_s16(lo, vget_low_s16(b1), a1);
+          int32x4_t hi = vmull_n_s16(vget_high_s16(b0), a0);
+          hi = vmlal_n_s16(hi, vget_high_s16(b1), a1);
+          const int16x8_t prod = vcombine_s16(vqmovn_s32(lo), vqmovn_s32(hi));
+          acc = vqaddq_s16(acc, prod);
+        }
+        int32x4_t outLo = vmovl_s16(vget_low_s16(acc));
+        int32x4_t outHi = vmovl_s16(vget_high_s16(acc));
+        if (accum) {
+          outLo = vaddq_s32(outLo, vld1q_s32(cRow + n));
+          outHi = vaddq_s32(outHi, vld1q_s32(cRow + n + 4));
+        }
+        vst1q_s32(cRow + n, outLo);
+        vst1q_s32(cRow + n + 4, outHi);
+      }
+      for (; n < nc; ++n) {
+        std::int16_t acc = 0;
+        for (int k = 0; k < kc; k += 2) {
+          const int8_t* bPtr = bBuf + k * nBlock + 2 * n;
+          const std::int16_t prod =
+              satInt16(aRow[k] * bPtr[0] + aRow[k + 1] * bPtr[1]);
+          acc = satInt16(acc + prod);
+        }
+        cRow[n] = accum ? cRow[n] + acc : acc;
       }
     } else {
-      for (int n = 0; n < nc; ++n) {
-        cRow[n] = acc[n];
+      static_assert(row_interleave == 4);
+      for (; n + 8 <= nc; n += 8) {
+        int32x4_t accLo = vdupq_n_s32(0);
+        int32x4_t accHi = vdupq_n_s32(0);
+        for (int k = 0; k < kc; k += 4) {
+          const std::int16_t a0 = aRow[k];
+          const std::int16_t a1 = aRow[k + 1];
+          const std::int16_t a2 = aRow[k + 2];
+          const std::int16_t a3 = aRow[k + 3];
+          const int8x8x4_t b = vld4_s8(bBuf + k * nBlock + 4 * n);
+          const int16x8_t b0 = vmovl_s8(b.val[0]);
+          const int16x8_t b1 = vmovl_s8(b.val[1]);
+          const int16x8_t b2 = vmovl_s8(b.val[2]);
+          const int16x8_t b3 = vmovl_s8(b.val[3]);
+          int32x4_t lo01 = vmull_n_s16(vget_low_s16(b0), a0);
+          lo01 = vmlal_n_s16(lo01, vget_low_s16(b1), a1);
+          int32x4_t hi01 = vmull_n_s16(vget_high_s16(b0), a0);
+          hi01 = vmlal_n_s16(hi01, vget_high_s16(b1), a1);
+          const int16x8_t p01 =
+              vcombine_s16(vqmovn_s32(lo01), vqmovn_s32(hi01));
+          int32x4_t lo23 = vmull_n_s16(vget_low_s16(b2), a2);
+          lo23 = vmlal_n_s16(lo23, vget_low_s16(b3), a3);
+          int32x4_t hi23 = vmull_n_s16(vget_high_s16(b2), a2);
+          hi23 = vmlal_n_s16(hi23, vget_high_s16(b3), a3);
+          const int16x8_t p23 =
+              vcombine_s16(vqmovn_s32(lo23), vqmovn_s32(hi23));
+          accLo =
+              vaddq_s32(accLo, vaddl_s16(vget_low_s16(p01), vget_low_s16(p23)));
+          accHi = vaddq_s32(
+              accHi, vaddl_s16(vget_high_s16(p01), vget_high_s16(p23)));
+        }
+        if (accum) {
+          accLo = vaddq_s32(accLo, vld1q_s32(cRow + n));
+          accHi = vaddq_s32(accHi, vld1q_s32(cRow + n + 4));
+        }
+        vst1q_s32(cRow + n, accLo);
+        vst1q_s32(cRow + n + 4, accHi);
+      }
+      for (; n < nc; ++n) {
+        std::int32_t acc = 0;
+        for (int k = 0; k < kc; k += 4) {
+          const int8_t* bPtr = bBuf + k * nBlock + 4 * n;
+          const std::int16_t p01 =
+              satInt16(aRow[k] * bPtr[0] + aRow[k + 1] * bPtr[1]);
+          const std::int16_t p23 =
+              satInt16(aRow[k + 2] * bPtr[2] + aRow[k + 3] * bPtr[3]);
+          acc += p01 + p23;
+        }
+        cRow[n] = accum ? cRow[n] + acc : acc;
       }
     }
   }
@@ -435,11 +486,11 @@ void ExecuteKernel<
     }
 
 #ifdef __aarch64__
-    // No JIT micro-kernel exists for arm; compute this block with the portable
-    // reference kernel. `fn` bakes mc/nc/kc into the JIT'd code, so the
-    // reference kernel takes them as arguments instead.
-    (void)bBuf_pf; // prefetch hint is unused on the reference path
-    computeBlockRef<typename packingAMatrix::accType>(
+    // No JIT micro-kernel exists for arm; compute this block with the NEON
+    // kernel. `fn` bakes mc/nc/kc into the JIT'd code, so the NEON kernel
+    // takes them as arguments instead.
+    (void)bBuf_pf; // prefetch hint is unused on the NEON path
+    computeBlockNeon<typename packingAMatrix::accType>(
         aBuf,
         bBuf,
         C_buffer_start,

--- a/src/Fbgemm.cc
+++ b/src/Fbgemm.cc
@@ -51,11 +51,13 @@ void fbgemmPacked(
   if (!cpuinfo_initialize()) {
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
+#ifndef __aarch64__
   if ((!fbgemmHasAvx512VnniSupport() && !fbgemmHasAvx512Support() &&
        !fbgemmHasAvx2Support())) {
     assert(0 && "unknown architecure");
     throw std::runtime_error("unknown architecure");
   }
+#endif
 
   int64_t MCB = 0;
   int KCB = 0;
@@ -96,6 +98,13 @@ void fbgemmPacked(
             inst_set_t::avx512_ymm>::getCacheBlockParams();
         break;
 
+#ifdef __aarch64__
+      // aarch64 has no int8-specific cache-blocking params; reuse avx2 (the
+      // reference compute path consumes the same layout). Mirrors the
+      // sve/anyarch -> avx2 fall-through in FbgemmFP16.cc / FbgemmFP32.cc.
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         std::tie(MCB, KCB, MR) = PackingTraits<
             typename packingAMatrix::inpType,

--- a/src/FbgemmI8Spmdm.cc
+++ b/src/FbgemmI8Spmdm.cc
@@ -73,7 +73,15 @@ void CompressedSparseColumn::SpMDM(
   // This results in strided access, which we want to avoid.
   // Instead, we pre-transpose A and C, and compute C = (C^T + B^T * A^T)^T
 
-  if (IsHyperSparse()) {
+#ifdef __aarch64__
+  // aarch64 has no AVX2 transpose/compute kernels for the denser SpMDM path;
+  // the scalar loop below is a correct general fallback (it is what x86 uses
+  // for hyper-sparse inputs), so always take it here.
+  constexpr bool kForceScalarSpMDM = true;
+#else
+  constexpr bool kForceScalarSpMDM = false;
+#endif
+  if (kForceScalarSpMDM || IsHyperSparse()) {
     // The cost of transpose is O(K*N) and we do O(NNZ*N) multiplications.
     // If NNZ/K is small, it's not worth doing transpose so we just use this
     // scalar loop.
@@ -144,10 +152,9 @@ void CompressedSparseColumn::SpMDM(
     return;
   }
 
-#ifdef __aarch64__
-  throw std::runtime_error(
-      "No fallback for fbgemm::SpMDM when AVX2 is not available");
-#else
+// Everything below is unreachable on aarch64: kForceScalarSpMDM makes the
+// scalar path above handle every request.
+#ifndef __aarch64__
 
 #ifdef FBGEMM_MEASURE_TIME_BREAKDOWN
   t_end = std::chrono::high_resolution_clock::now();
@@ -275,7 +282,7 @@ void CompressedSparseColumn::SpMDM(
   t_start = std::chrono::high_resolution_clock::now();
 #endif
 
-#endif // __aarch64__
+#endif // !__aarch64__
 }
 
 void CompressedSparseColumn::SparseConv(

--- a/src/PackAMatrix.cc
+++ b/src/PackAMatrix.cc
@@ -38,10 +38,12 @@ PackAMatrix<T, accT>::PackAMatrix(
   if (!cpuinfo_initialize()) {
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
+#ifndef __aarch64__
   if ((!fbgemmHasAvx512VnniSupport() && !fbgemmHasAvx512Support() &&
        !fbgemmHasAvx2Support())) {
     assert(0 && "unknown architecure");
   }
+#endif
 
   if (params) {
     BaseType::brow_ = params->MCB;
@@ -73,6 +75,12 @@ PackAMatrix<T, accT>::PackAMatrix(
                 getMatrixPackAParams();
         break;
 
+#ifdef __aarch64__
+      // aarch64 has no int8-specific packing layout; reuse avx2 blocking
+      // params (the reference compute path consumes the same layout).
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx2>::getMatrixPackAParams();

--- a/src/PackAWithIm2Col.cc
+++ b/src/PackAWithIm2Col.cc
@@ -51,10 +51,12 @@ PackAWithIm2Col<T, accT, SPATIAL_DIM>::PackAWithIm2Col(
   if (!cpuinfo_initialize()) {
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
+#ifndef __aarch64__
   if ((!fbgemmHasAvx512VnniSupport() && !fbgemmHasAvx512Support() &&
        !fbgemmHasAvx2Support())) {
     assert(0 && "unknown architecure");
   }
+#endif
 
   if (params) {
     BaseType::brow_ = params->MCB;
@@ -86,6 +88,12 @@ PackAWithIm2Col<T, accT, SPATIAL_DIM>::PackAWithIm2Col(
                 getMatrixPackAParams();
         break;
 
+#ifdef __aarch64__
+      // aarch64 has no int8-specific packing layout; reuse avx2 blocking
+      // params (the reference compute path consumes the same layout).
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx2>::getMatrixPackAParams();
@@ -737,9 +745,19 @@ int PackAWithIm2Col<T, accT, SPATIAL_DIM>::rowOffsetBufferSize(
       } else if (fbgemmHasAvx2Support()) {
         return PackingTraits<T, accT, inst_set_t::avx2>::MCB;
       } else {
+#ifdef __aarch64__
+        // The packing ctor above routes sve/anyarch to the avx2 blocking
+        // params, so the row-offset buffer must be sized to match. Returning
+        // -1 here is not merely wrong, it is silent: with NDEBUG set (opt
+        // builds) the assert vanishes and callers do
+        // `vector<int32_t> buf(rowOffsetBufferSize())`, so -1 becomes a huge
+        // size_t and throws std::length_error.
+        return PackingTraits<T, accT, inst_set_t::avx2>::MCB;
+#else
         // TODO: Have default slower path
         assert(0 && "unsupported architecture");
         return -1;
+#endif
       }
     }
   } else {

--- a/src/PackAWithQuantRowOffset.cc
+++ b/src/PackAWithQuantRowOffset.cc
@@ -58,10 +58,12 @@ PackAWithQuantRowOffset<T, accT>::PackAWithQuantRowOffset(
   if (std::isinf(1.0f / scale_)) {
     throw std::runtime_error("scale's reciprocal cannot be infinity");
   }
+#ifndef __aarch64__
   if ((!fbgemmHasAvx512VnniSupport() && !fbgemmHasAvx512Support() &&
        !fbgemmHasAvx2Support())) {
     assert(0 && "unknown architecure");
   }
+#endif
 
   if (params) {
     BaseType::brow_ = params->MCB;
@@ -93,6 +95,12 @@ PackAWithQuantRowOffset<T, accT>::PackAWithQuantRowOffset(
                 getMatrixPackAParams();
         break;
 
+#ifdef __aarch64__
+      // aarch64 has no int8-specific packing layout; reuse avx2 blocking
+      // params (the reference compute path consumes the same layout).
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx2>::getMatrixPackAParams();
@@ -257,8 +265,13 @@ int PackAWithQuantRowOffset<T, accT>::rowOffsetBufferSize(
       } else if (fbgemmHasAvx2Support()) {
         return PackingTraits<T, accT, inst_set_t::avx2>::MCB;
       } else {
+#ifdef __aarch64__
+        // aarch64 reuses the avx2 blocking params for the reference path.
+        return PackingTraits<T, accT, inst_set_t::avx2>::MCB;
+#else
         assert(0 && "unsupported architecture");
         return -1;
+#endif
       }
     }
   } else {

--- a/src/PackAWithRowOffset.cc
+++ b/src/PackAWithRowOffset.cc
@@ -43,10 +43,12 @@ PackAWithRowOffset<T, accT>::PackAWithRowOffset(
   if (!cpuinfo_initialize()) {
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
+#ifndef __aarch64__
   if ((!fbgemmHasAvx512VnniSupport() && !fbgemmHasAvx512Support() &&
        !fbgemmHasAvx2Support())) {
     assert(0 && "unknown architecure");
   }
+#endif
 
   if (params) {
     BaseType::brow_ = params->MCB;
@@ -78,6 +80,12 @@ PackAWithRowOffset<T, accT>::PackAWithRowOffset(
                 getMatrixPackAParams();
         break;
 
+#ifdef __aarch64__
+      // aarch64 has no int8-specific packing layout; reuse avx2 blocking
+      // params (the reference compute path consumes the same layout).
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx2>::getMatrixPackAParams();
@@ -224,9 +232,14 @@ int PackAWithRowOffset<T, accT>::rowOffsetBufferSize(
       } else if (fbgemmHasAvx2Support()) {
         return PackingTraits<T, accT, inst_set_t::avx2>::MCB;
       } else {
+#ifdef __aarch64__
+        // aarch64 reuses the avx2 blocking params for the reference path.
+        return PackingTraits<T, accT, inst_set_t::avx2>::MCB;
+#else
         // TODO: Have default slower path
         assert(0 && "unsupported architecture");
         return -1;
+#endif
       }
     }
   } else {

--- a/src/PackBMatrix.cc
+++ b/src/PackBMatrix.cc
@@ -221,6 +221,15 @@ PackBMatrix<T, accT>::PackBMatrix(
                 getMatrixPackBParams();
         break;
 
+#ifdef __aarch64__
+      // No aarch64-specific int8 packing layout exists yet; the NEON/SVE
+      // reference compute path (see ExecuteKernelU8S8) consumes the same
+      // interleaved layout the avx2 packing produces, so reuse its blocking
+      // params. Mirrors the sve/anyarch -> avx2 fall-through in FbgemmFP16.cc
+      // and FbgemmFP32.cc.
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_) =
             PackingTraits<T, accT, inst_set_t::avx2>::getMatrixPackBParams();

--- a/src/PackMatrix.cc
+++ b/src/PackMatrix.cc
@@ -37,10 +37,12 @@ int PackMatrix<PT, inpType, accType>::packedBufferSize(
   if (!cpuinfo_initialize()) {
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
+#ifndef __aarch64__
   if ((!fbgemmHasAvx512VnniSupport() && !fbgemmHasAvx512Support() &&
        !fbgemmHasAvx2Support())) {
     assert(0 && "unknown architecure");
   }
+#endif
 
   int MCB = 0, KCB = 0, NCB = 0;
   if (params) {
@@ -74,6 +76,12 @@ int PackMatrix<PT, inpType, accType>::packedBufferSize(
         KCB = PackingTraits<inpType, accType, inst_set_t::avx512_ymm>::KCB;
         break;
 
+#ifdef __aarch64__
+      // aarch64 has no int8-specific packing layout; reuse avx2 blocking
+      // params (the reference compute path consumes the same layout).
+      case inst_set_t::sve:
+      case inst_set_t::anyarch:
+#endif
       case inst_set_t::avx2:
         MCB = PackingTraits<inpType, accType, inst_set_t::avx2>::MCB;
         NCB = PackingTraits<inpType, accType, inst_set_t::avx2>::NCB;


### PR DESCRIPTION
Summary:
Replaces the scalar aarch64 `computeBlockRef` from the u8s8 port with a NEON
implementation, `computeBlockNeon`, preserving the x86 integer semantics
exactly. The interleaved packed-B layout turns out to be ideal for NEON: vld2
(acc16) / vld4 (acc32) de-interleave a K-pair/quad for 8 columns in one load,
and each x86 instruction has a direct lane-wise mapping:

- `vpmaddubsw` (saturating u8*s8 pair reduction) = `vmull_n_s16`/`vmlal_n_s16`
  into int32 lanes, then the saturating narrow `vqmovn_s32`
- `vpaddsw` (acc16's saturating int16 accumulate) = `vqaddq_s16`
- `vpmaddwd` + `vpaddd` (acc32's widen-and-add) = `vaddl_s16` + `vaddq_s32`

Columns past the last multiple of 8 take a scalar tail with the same
arithmetic. No dispatch changes: aarch64 implies NEON, so the kernel replaces
the scalar one outright. x86 is untouched (the whole block is `#ifdef
__aarch64__`).

Incidental, not a perf claim: the scalar kernel's `thread_local std::vector`
accumulator disappears because accumulators now live in registers. That vector
never allocated per call in steady state (`resize` to a bounded `nc` allocates
only while capacity grows -- once per thread), so its removal is a
simplification, not a measurable win; the identical asan suite times below
corroborate that allocation was never a hot-path cost here.

Considered and rejected: reusing QNNPACK's aarch64 q8gemm microkernels.
Three independent blockers: (1) the acc16 contract (`matmul_u8i8acc16_ref`)
requires saturating int16 pair-reduction and accumulation, which QNNPACK's
int32-accumulating kernels cannot express; (2) QNNPACK kernels consume their
own packed-W layout (nr-tiles with fused bias/column sums) and fuse
requantization, incompatible with the packed-B layout and separate
output-processing pipeline everything else here consumes; (3) the dependency
points the wrong way -- QNNPACK lives in pytorch, pytorch depends on this
library, and this tree is the source of a standalone public repo, so vendoring
would mean importing foreign assembly wholesale.

Differential Revision: D116819344


