### PR TITLE
Honor disable_random_init in DRAM inference embedding

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
@@ -165,6 +165,9 @@ c10::List<at::Tensor> DramKVEmbeddingInferenceWrapper::serialize() const {
   results.push_back(
       torch::tensor(
           {uniform_init_lower_, uniform_init_upper_}, torch::kDouble));
+  results.push_back(
+      torch::tensor(
+          {static_cast<int64_t>(disable_random_init_)}, torch::kInt64));
   return results;
 }
 
@@ -183,6 +186,12 @@ void DramKVEmbeddingInferenceWrapper::deserialize(
   const auto* floatPtr = states[1].const_data_ptr<double>();
   uniform_init_lower_ = floatPtr[0];
   uniform_init_upper_ = floatPtr[1];
+
+  // Payloads published before disable_random_init_ was serialized carry only
+  // the two entries above; leave the constructor default in place for those.
+  if (states.size() >= 3 && states[2].numel() >= 1) {
+    disable_random_init_ = states[2].const_data_ptr<int64_t>()[0] != 0;
+  }
 }
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_inference_embedding.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_inference_embedding.h
@@ -136,7 +136,7 @@ class DramKVInferenceEmbedding
         uniform_init_lower,
         uniform_init_upper,
         row_storage_bitwidth,
-        false /* disable_random_init */);
+        disable_random_init);
     if (table_dims.has_value()) {
       TORCH_CHECK_TENSOR_PROPERTIES(table_dims, at::ScalarType::Long);
       TORCH_NUM_CHECK_AND_ASSIGN_TENSOR_DATA(


### PR DESCRIPTION
Summary:
For an embedding cache, a cache miss should return a zero row at inference,
matching training. Two things prevented that.

1. DramKVInferenceEmbedding's constructor passed a hardcoded false into
   initialize_initializers, which assigns disable_random_init_ from its
   parameter -- overwriting the value the member initializer had just set. The
   flag was discarded regardless of what the caller passed, so the zero-fill in
   fill_from_row_storage was unreachable and every miss was served from
   wlmap->begin()->second, i.e. another key's row.

2. The wrapper's serialize()/deserialize() carried num_shards_ and the two
   uniform-init bounds but not disable_random_init_. __setstate__ rebuilds the
   wrapper from the default constructor and init() runs after it, so the flag
   was reset to false on model load even with (1) fixed. init() consumes all
   four constructor parameters; three were round-tripped and this one was not.

deserialize() guards on states.size() >= 3, so payloads published before this
change keep the constructor default. The pre-existing size checks are all >=,
so a new 3-entry payload also loads on an older binary.

This makes the flag effective for the first time: an inference tier with
embedding_cache_mode=True moves from serving a live shard block on a miss to
serving zeros. Motivated by an eval run where the live-block behavior scored
worse than baseline.

Differential Revision: D116871852


