### PR TITLE
[fbgemm_gpu] Add opt-in device sync before permute_2D / jagged_to_pad…

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_to_padded_dense_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_to_padded_dense_forward.cu
@@ -13,6 +13,21 @@
 
 #include <cub/device/device_scan.cuh>
 
+#include <cstdlib>
+
+namespace {
+// Opt-in device-wide sync before jagged->dense kernel launches, gated by the
+// FBGEMM_GPU_DEVICE_SYNC_BEFORE_LAUNCH environment variable. Disabled by
+// default (zero behavior/perf change). Same cross-stream read-after-write
+// rationale as sparse_permute_2d.cu.
+inline bool fbgemm_sync_before_jagged_launch() {
+  static const int val = std::getenv("FBGEMM_GPU_DEVICE_SYNC_BEFORE_LAUNCH")
+      ? std::atoi(std::getenv("FBGEMM_GPU_DEVICE_SYNC_BEFORE_LAUNCH"))
+      : 0;
+  return val != 0;
+}
+} // namespace
+
 using Tensor = at::Tensor;
 
 namespace fbgemm_gpu {
@@ -31,6 +46,16 @@ at::Tensor jagged_to_padded_dense_forward(
       " != num_jagged_dim, ",
       num_jagged_dim);
   CUDA_DEVICE_GUARD(values);
+
+  // Opt-in guard for cross-stream read-after-write hazards: values/offsets
+  // may be produced by kernels on a different stream (e.g. a custom
+  // embedding lookup stream) with no explicit stream dependency; calling
+  // recordStream() on the inputs does not prevent premature reads. Enabled
+  // only when FBGEMM_GPU_DEVICE_SYNC_BEFORE_LAUNCH=1; otherwise this is a
+  // single branch on a cached static bool.
+  if (fbgemm_sync_before_jagged_launch()) {
+    cudaDeviceSynchronize();
+  }
 
   const Tensor values_canonicalized = values.view(
       {values.size(0),

--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
@@ -10,6 +10,20 @@
 
 #include "common.cuh"
 
+namespace {
+// Opt-in device-wide sync before permute kernel launches, gated by the
+// FBGEMM_GPU_DEVICE_SYNC_BEFORE_LAUNCH environment variable. Disabled by
+// default (zero behavior/perf change). See the launch site in
+// permute_2D_sparse_preallocated_out_cuda for the cross-stream
+// read-after-write rationale.
+inline bool fbgemm_sync_before_permute_launch() {
+  static const int val = std::getenv("FBGEMM_GPU_DEVICE_SYNC_BEFORE_LAUNCH")
+      ? std::atoi(std::getenv("FBGEMM_GPU_DEVICE_SYNC_BEFORE_LAUNCH"))
+      : 0;
+  return val != 0;
+}
+} // namespace
+
 using Tensor = at::Tensor;
 
 namespace fbgemm_gpu {
@@ -345,6 +359,20 @@ permute_2D_sparse_preallocated_out_cuda(
         indices_contig,
         lengths.size(0),
         weights);
+  }
+
+  // Opt-in guard for cross-stream read-after-write hazards.
+  //
+  // When the input tensors are produced by kernels on a DIFFERENT stream
+  // (e.g. a custom embedding-table / hierarchical-KV lookup stream) and are
+  // consumed here on the current stream with no explicit stream dependency,
+  // the permute kernels may start reading before the producer stream has
+  // finished writing, causing an illegal memory access on some platforms.
+  // recordStream() alone does NOT fix this (it prevents premature free, not
+  // premature read). Setting FBGEMM_GPU_DEVICE_SYNC_BEFORE_LAUNCH=1 waits
+  // for all streams at this op point before any kernel is launched.
+  if (fbgemm_sync_before_permute_launch()) {
+    cudaDeviceSynchronize();
   }
 
   Tensor permuted_lengths;


### PR DESCRIPTION
# PR: Opt-in device sync guard for cross-stream read-after-write hazards in permute_2D / jagged_to_padded_dense

> 提交目标仓库：`pytorch/FBGEMM`（main 分支）
> 建议 PR 标题：`[fbgemm_gpu] Add opt-in device sync before permute_2D / jagged_to_padded_dense kernel launches (cross-stream RAW hazard workaround)`

---

## Summary

Adds an **opt-in, environment-variable-gated** `cudaDeviceSynchronize()` guard before the kernel launches in `permute_2D_sparse_data_cuda` and `jagged_to_padded_dense_forward`, controlled by `FBGEMM_GPU_DEVICE_SYNC_BEFORE_LAUNCH` (default off; zero behavior or performance change when unset).

## Motivation

We hit a reproducible illegal-memory-access crash in a large-scale production recommendation-model training pipeline (16-GPU DDP, torchrec + fbgemm_gpu, ~900 embedding tables, real data):

- Crash site: `fbgemm_gpu::permute_2D_data_kernel<false, long, long, std::nullptr_t>`, illegal store to address `0x0` (`IllegalAddress #700` / `LaunchFailure` / SIGSEGV depending on where the async error surfaced)
- Trigger: async launch mode (`CUDA_LAUNCH_BLOCKING=0`) only; disappears under any serialization or observation (classic Heisenbug)
- The input tensors (`permute` / `lengths` / `indices` / `values` / `offsets`) are produced by kernels on a **different stream** (a hierarchical-KV embedding lookup/reserve path in our stack) and consumed by these ops on the current stream, with no explicit cross-stream dependency

This is a **cross-stream read-after-write (RAW) hazard**: the consumer kernels may start reading before the producer stream finishes writing. Any pipeline that produces sparse inputs on a side stream and feeds them to these ops on another stream without an explicit event dependency is exposed to the same hazard class; on our platform it manifests as a hard crash at scale.

### Why `recordStream()` is not the fix (verified)

We first tried the allocator-level remedy: `c10::cuda::CUDACachingAllocator::recordStream()` on every input. The crash persisted (and surfaced earlier). This is expected in hindsight: **`recordStream` only prevents premature *free* (use-after-free); it cannot prevent premature *read* (read-after-write)**. A raw hazard requires stream synchronization, not allocator bookkeeping. We believe this distinction is worth documenting for the community, as `recordStream` is commonly reached for first in cross-stream crash investigations.

## Design

- Gate: `FBGEMM_GPU_DEVICE_SYNC_BEFORE_LAUNCH=1` enables a `cudaDeviceSynchronize()` at the two op entry points, before kernel launch. The value is parsed once per process into a `static const` (hot path is a single predicted branch when disabled).
- Scope: only `permute_2D_sparse_data_cuda` (the observed crash op) and `jagged_to_padded_dense_forward` (same consumer pattern; confirmed as a second crash site when only the first op was guarded).
- Default off: no codegen/behavior/perf change for existing users.

We are aware a device-wide sync is heavier than ideal, and that the *ideal* fix is an explicit producer-stream event wait. However:

1. PyTorch does not expose a tensor's producing stream, and these ops have no stream/event parameter today, so the consumer cannot construct the precise dependency without an API change.
2. The TBE ops precedent (`forward_stream` parameter for prefetch on a separate stream) suggests an optional `producer_stream`/event parameter would be the right long-term API; we are happy to pursue that in a follow-up and would welcome maintainer guidance.
3. Until then, an opt-in sync at op granularity is strictly narrower than `CUDA_LAUNCH_BLOCKING=1` (which serializes *every* kernel) and unblocks affected deployments.

Measured on our deployment with the guard enabled: training stable end-to-end (previously crashed at step 0), **+7.4% per-step latency** — vs **+45%** for the `CUDA_LAUNCH_BLOCKING=1` workaround.

## Test Plan

- `FBGEMM_GPU_DEVICE_SYNC_BEFORE_LAUNCH` unset: no behavior change (guard parses to false once; single branch).
- `=1`: device sync executes before both op kernel launches; validated in 16-GPU DDP training (24 passes + eval, previously crashed at step 0).
- Environment: torch 2.9 / CUDA 12.9 / fbgemm_gpu 1.6.0 source tree; also verified neutral on standard NVIDIA CUDA (sync is redundant but correct there).

Happy to add a unit test harness if maintainers can point to a preferred location, though reproducing the hazard requires genuine multi-stream concurrent producers.

## Alternatives Considered

- `recordStream` on all inputs — verified insufficient (see Motivation).
- Sync at the producer side in our stack — attempted (`cudaStreamSynchronize` around the KV capacity-expansion path); crash persisted at the same kernel, because every write (not only expansion) needs ordering.
- Unconditional sync in these ops — rejected by design: unacceptable perf regression for all users.
- Long-term: optional `producer_stream` / CUDA-event parameter (mirroring the TBE `forward_stream` precedent) — proposed as follow-up.

---
