### PR TITLE
Remove unreachable ROCm warp instantiations

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -808,6 +808,8 @@ hip_mixed_d_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc
     embedding_backward_split_template.cu
 */
 
+{#- /* hip_mixed_d_only emits only the hip_mixed_d kernel, for configs that the
+      generic warp kernel is never dispatched with. */ #}
 {%- macro template_instantiation(
       emb_type,
       grad_type,
@@ -816,11 +818,13 @@ hip_mixed_d_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc
       ph_type_combo,
       kFixedMaxVecsPerThread,
       kThreadGroupSize,
-      kUseVecBlocking
+      kUseVecBlocking,
+      hip_mixed_d_only=False
     )
 %}
 
 {%- set gwddesc = "_gwd" if is_gwd_kernel else "" %}
+{%- if not hip_mixed_d_only %}
 template __global__ __launch_bounds__(kBackwardMaxThreads) void
 {%- if is_index_select %}
 batch_index_select_dim0_codegen_backward_kernel_warp_per_row
@@ -916,7 +920,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row
     }}
     {%- endif %}
 );
-
+{%- endif %}
 {%- if has_hip_optimized_support  %}
 
 template __global__ __launch_bounds__(kBackwardMaxThreads) void
@@ -997,7 +1001,7 @@ hip_mixed_d_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc
 {%- endif %}
 {%- endmacro %}
 
-{%- macro bulk_template_instantiations(kFixedMaxVecsPerThread, kThreadGroupSize, kUseVecBlocking) %}
+{%- macro bulk_template_instantiations(kFixedMaxVecsPerThread, kThreadGroupSize, kUseVecBlocking, hip_mixed_d_only=False) %}
     {%- for grad_type in ['float', 'at::Half', 'at::BFloat16'] %}
     {%- for emb_type in (['float', 'at::Half'] + (['at::Float8_e4m3fnuz'] if is_rocm else ['at::Float8_e4m3fn'])) %}
     {%- for cache_type in ['float', 'at::Half'] %}
@@ -1011,7 +1015,8 @@ hip_mixed_d_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc
             ph_type_combo,
             kFixedMaxVecsPerThread,
             kThreadGroupSize,
-            kUseVecBlocking
+            kUseVecBlocking,
+            hip_mixed_d_only
           )
         }}
     {%- endfor %}
@@ -1077,15 +1082,16 @@ hip_mixed_d_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc
     Please see get_max_vecs_template_configs in
     codegen/embedding_common_code_generator.py for more details
 */ #}
-
-{#- /* ROCm never defines FBGEMM_USE_SUBWARP_SHUFFLE, so this is the branch it compiles.
-      It still needs the sub-warp configs: the max_D <= 128 override in the dispatch
-      selects the <1, 32, false> instantiation of hip_mixed_d_warp, which only exists
-      when use_subwarp_shuffle=True. Mirrors the CTA template's is_rocm split. */ #}
-{%- if is_rocm %}
-{{ instantiate_templates(use_subwarp_shuffle=True) }}
-{%- else %}
 {{ instantiate_templates(use_subwarp_shuffle=False) }}
+{#- /* ROCm never defines FBGEMM_USE_SUBWARP_SHUFFLE, so the dispatch macro only ever
+      selects kThreadGroupSize == kWarpSize. The one exception is the max_D <= 128
+      override, which hardcodes the <1, 32, false> instantiation of hip_mixed_d_warp,
+      so that single config is emitted here. Requesting it via
+      use_subwarp_shuffle=True instead would also emit the unreachable group sizes
+      8 and 16, and the generic warp kernel for all three -- ~19 MB of dead device
+      code per backend, enough to overflow PC32 relocations when linked. */ #}
+{%- if is_rocm %}
+{{ bulk_template_instantiations(1, 32, 'false', hip_mixed_d_only=True) }}
 {%- endif %}
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3087

# TLDR;
- Forward fix for a link-time relocation overflow introduced by D102946325.
- That diff added the `hip_mixed_d` warp kernel, whose `max_D <= 128` override
  hardcodes a `<1, 32, false>` instantiation. To make that instantiation exist on
  ROCm, the non-subwarp branch was switched to `use_subwarp_shuffle=True`. That
  also emits `kThreadGroupSize` 8 and 16, plus the generic warp kernel for all
  three -- none of which the ROCm dispatch can ever select.
- ROCm never defines `FBGEMM_USE_SUBWARP_SHUFFLE` (see `cuda_prelude.cuh`), so
  `DISPATCH_OPTIMAL_KERNEL` only ever selects `kThreadGroupSize == kWarpSize`.
  The single exception is the hardcoded override above.
- The dead device code grew `.hip_fatbin` to 2.11 GiB, placing `.rodata` 2.15 GiB
  from `.text` and overflowing `R_X86_64_PC32` (limit 2 GiB) when linking
  `libdeeplearning_fbgemm_fbgemm_gpu_codegen.so`.

## Root cause
`hip_mixed_d` is emitted inside `template_instantiation`, the same macro body as
the generic warp kernel, so both share one config list produced by
`instantiate_templates(use_subwarp_shuffle)`. There was no way to request one
extra config for `hip_mixed_d` without also widening it for the generic kernel,
which is defined in all 65 warp files versus 4 for `hip_mixed_d`.

## Changes
- `embedding_backward_split_kernel_warp_template.cu`
  - Add a `hip_mixed_d_only` parameter to `template_instantiation` and
    `bulk_template_instantiations`; when set, skip the generic warp kernel and
    emit only the `hip_mixed_d` kernel.
  - On ROCm, emit `instantiate_templates(use_subwarp_shuffle=False)` plus a single
    explicit `bulk_template_instantiations(1, 32, 'false', hip_mixed_d_only=True)`
    instead of `use_subwarp_shuffle=True`.

## Instantiation counts (ROCm-compiled `#else` arm)

| family | | pre-D102946325 | post-D102946325 | with this fix |
| --- | --- | --- | --- | --- |
| generic | definitions | 65 | 65 | 65 |
| | configs | 3 | **6** | 3 |
| | instantiations | 7,236 | **14,472** | 7,236 |
| `hip_mixed_d` | definitions | 0 | 4 | 4 |
| | configs | -- | **6** | **4** |
| | instantiations | 0 | 864 | 576 |
| `hip_warp` | definitions | 2 | 2 | 2 |
| | configs | 3 | 3 | 3 |
| | instantiations | 3,888 | 3,888 | 3,888 |
| **total definitions** | | **67** | **71** | **71** |
| **total instantiations** | | **11,124** | **19,224** | **11,700** |

Plus 1,656 generic instantiations from the `is_experimental_optimizer` path,
identical in all three (it sits outside the `#ifdef`), giving compiled totals of
12,780 / 20,880 / 13,356.

## Configs per family

| family | pre-D102946325 | post-D102946325 | with this fix |
| --- | --- | --- | --- |
| generic | `(2,64,t)` `(1,64,f)` `(2,64,f)` | + `(1,8,f)` `(1,16,f)` `(1,32,f)` | `(2,64,t)` `(1,64,f)` `(2,64,f)` |
| `hip_mixed_d` | -- | same 6 as generic | `(2,64,t)` `(1,64,f)` `(2,64,f)` `(1,32,f)` |
| `hip_warp` | `(2,64,t)` `(1,64,f)` `(2,64,f)` | unchanged | unchanged |

`hip_warp` is untouched throughout -- it has its own macro chain
(`hip_instantiate_templates`) which still passes `use_subwarp_shuffle=False`.

## Effect
- Removes 7,524 unreachable instantiations: 7,236 generic at `kThreadGroupSize`
  8/16/32, and 288 `hip_mixed_d` at 8/16.
- generic returns to exactly its pre-diff count; the only lasting addition is
  `hip_mixed_d` at its 4 reachable configs: +576 over pre-diff (+4.5%), versus
  +8,100 (+63%) before this fix.
- ROCm warp generated source: 112.3 MB -> 93.2 MB (-17.0%); all codegen -9.0%.
- CUDA codegen byte-identical to master -- AMD-only change.
- No functional or performance change: every removed instantiation is
  unreachable from `DISPATCH_OPTIMAL_KERNEL` on ROCm, and the `max_D <= 128`
  optimization is preserved.

Differential Revision: D116989939


