### PR TITLE
Add variant-aware declaration-surface metadata to TBE codegen (#6199)

### DIFF
--- a/fbgemm_gpu/codegen/genscript/optimizer_args.py
+++ b/fbgemm_gpu/codegen/genscript/optimizer_args.py
@@ -12,8 +12,9 @@
 
 
 import itertools
-from collections.abc import Callable
-from dataclasses import dataclass
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
 
 
@@ -23,6 +24,62 @@ try:
 except ImportError:
     # pyre-ignore[21]
     from torch_type_utils import arg_type_to_tensor_type, ArgType, TensorType
+
+
+######################################################################
+# Declaration Surfaces
+######################################################################
+
+
+class DeclSurface(str, Enum):
+    """The C++ declaration surfaces an optimizer argument is projected onto.
+
+    One optimizer argument spec is rendered into several different C++
+    declarations, and an argument that a contract requires is not necessarily
+    read by every one of them: a meta function must accept the same arguments
+    as the CUDA op it shadows without touching optimizer state, and the PT2
+    CUDA wrapper accepts the host-side tensors of the unified argument list
+    without forwarding them. Naming the surfaces makes that difference
+    expressible in the argument metadata instead of in per-template text.
+    """
+
+    CPU_KERNEL = "cpu_kernel"
+    GPU_KERNEL = "gpu_kernel"
+    HOST_FUNCTION = "host_function"
+    META = "meta"
+    AUTOGRAD = "autograd"
+    PT2_CPU = "pt2_cpu"
+    PT2_CUDA = "pt2_cuda"
+
+
+def decl_surfaces(
+    values: Iterable[DeclSurface | str] | None,
+) -> frozenset[DeclSurface]:
+    """Normalize a declaration-surface policy, rejecting unknown surfaces."""
+    if values is None:
+        return frozenset()
+    known = {surface.value: surface for surface in DeclSurface}
+    resolved = set()
+    for value in values:
+        if isinstance(value, DeclSurface):
+            resolved.add(value)
+            continue
+        if value not in known:
+            raise ValueError(
+                f"unknown declaration surface {value!r}; "
+                f"expected one of {sorted(known)}"
+            )
+        resolved.add(known[value])
+    return frozenset(resolved)
+
+
+def annotate_unused_declaration(
+    declaration: str,
+    unused_on: frozenset[DeclSurface],
+    surface: DeclSurface,
+) -> str:
+    """Prefix a C++ parameter declaration when it is unused on `surface`."""
+    return f"[[maybe_unused]] {declaration}" if surface in unused_on else declaration
 
 
 ######################################################################
@@ -38,6 +95,15 @@ class OptimizerArgsSetItem:
     default: float | ArgType = 0  # DEFAULT_ARG_VAL
     ph_tys: list[ArgType] | None = None  # placeholder types
     is_optional: bool = False  # optional variable
+    # Declaration surfaces on which this argument is intentionally not read.
+    # Empty (the default) means the argument is used everywhere it appears.
+    unused_on: frozenset[DeclSurface] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:
+        self.unused_on = decl_surfaces(self.unused_on)
+
+    def is_unused_on(self, surface: DeclSurface) -> bool:
+        return surface in self.unused_on
 
 
 # Alias b/c the name is too long
@@ -305,6 +371,20 @@ def make_kernel_arg(
     name: str,
     default: int | float | None,
     pass_by_ref: bool = False,
+    *,
+    unused_on: frozenset[DeclSurface] = frozenset(),
+    surface: DeclSurface = DeclSurface.GPU_KERNEL,
+) -> str:
+    return annotate_unused_declaration(
+        _kernel_arg(ty, name, default, pass_by_ref), unused_on, surface
+    )
+
+
+def _kernel_arg(
+    ty: ArgType,
+    name: str,
+    default: int | float | None,
+    pass_by_ref: bool = False,
 ) -> str:
     return {
         ArgType.TENSOR: lambda x: acc_cache_tensor_arg(x, pass_by_ref=pass_by_ref),
@@ -349,7 +429,20 @@ def make_kernel_arg_constructor(ty: ArgType, name: str) -> str:
     }[ty](name)
 
 
-def make_cpu_kernel_arg(ty: ArgType, name: str, default: int | float) -> str:
+def make_cpu_kernel_arg(
+    ty: ArgType,
+    name: str,
+    default: int | float,
+    *,
+    unused_on: frozenset[DeclSurface] = frozenset(),
+    surface: DeclSurface = DeclSurface.CPU_KERNEL,
+) -> str:
+    return annotate_unused_declaration(
+        _cpu_kernel_arg(ty, name, default), unused_on, surface
+    )
+
+
+def _cpu_kernel_arg(ty: ArgType, name: str, default: int | float) -> str:
     return {
         ArgType.TENSOR: lambda x: acc_cache_tensor_arg(x, gpu=False),
         ArgType.INT_TENSOR: lambda x: int_tensor_arg(x, gpu=False),
@@ -378,6 +471,20 @@ def make_cpu_kernel_arg_constructor(ty: ArgType, name: str) -> str:
 
 
 def make_function_arg(
+    ty: ArgType,
+    name: str,
+    default: int | float | None,
+    is_optional: bool = False,
+    *,
+    unused_on: frozenset[DeclSurface] = frozenset(),
+    surface: DeclSurface = DeclSurface.HOST_FUNCTION,
+) -> str:
+    return annotate_unused_declaration(
+        _function_arg(ty, name, default, is_optional), unused_on, surface
+    )
+
+
+def _function_arg(
     ty: ArgType,
     name: str,
     default: int | float | None,
@@ -804,6 +911,13 @@ class OptimizerArgs:
     split_function_args_autograd: list[str]
     split_function_arg_names_autograd: list[str]
     split_saved_tensors_optional: list[str]
+    # `split_function_args` / `split_function_args_no_defaults` rendered once
+    # per DeclSurface, keyed by the surface's value. A template that shares a
+    # projection with another surface -- the meta shadow of the CUDA host
+    # function, or the PT2 CPU and CUDA wrappers over the unified argument list
+    # -- reads its own entry here so the two can annotate differently.
+    split_function_args_by_surface: dict[str, list[str]]
+    split_function_args_no_defaults_by_surface: dict[str, list[str]]
     split_function_args_v1: str | None = None
     split_function_schemas_v1: str | None = None
 
@@ -827,7 +941,9 @@ class OptimizerArgs:
         for i, s in enumerate(kernel_split_arg_spec):
             if s.name == "learning_rate_tensor":
                 # pyre-ignore[6]
-                kernel_split_arg_spec[i] = OptimItem(ArgType.FLOAT, "learning_rate")
+                kernel_split_arg_spec[i] = OptimItem(
+                    ArgType.FLOAT, "learning_rate", unused_on=s.unused_on
+                )
             if s.is_optional:
                 has_optional_tensors = True
 
@@ -924,17 +1040,19 @@ class OptimizerArgs:
         return OptimizerArgs(
             # GPU kernel args
             split_kernel_args=[
-                make_kernel_arg(s.ty, s.name, s.default) for s in kernel_split_arg_spec
+                make_kernel_arg(s.ty, s.name, s.default, unused_on=s.unused_on)
+                for s in kernel_split_arg_spec
             ],
             split_kernel_args_no_defaults=[
-                make_kernel_arg(s.ty, s.name, None) for s in kernel_split_arg_spec
+                make_kernel_arg(s.ty, s.name, None, unused_on=s.unused_on)
+                for s in kernel_split_arg_spec
             ],
             split_kernel_arg_constructors=[
                 make_kernel_arg_constructor(s.ty, s.name) for s in kernel_split_arg_spec
             ],
             # CPU kernel args
             split_cpu_kernel_args=[
-                make_cpu_kernel_arg(s.ty, s.name, s.default)
+                make_cpu_kernel_arg(s.ty, s.name, s.default, unused_on=s.unused_on)
                 for s in kernel_split_arg_spec
             ],
             split_cpu_kernel_arg_constructors=[
@@ -943,11 +1061,35 @@ class OptimizerArgs:
             ],
             # Function args
             split_function_args=[
-                make_function_arg(s.ty, s.name, s.default) for s in split_arg_spec
+                make_function_arg(s.ty, s.name, s.default, unused_on=s.unused_on)
+                for s in split_arg_spec
             ],
             split_function_args_no_defaults=[
-                make_function_arg(s.ty, s.name, None) for s in split_arg_spec
+                make_function_arg(s.ty, s.name, None, unused_on=s.unused_on)
+                for s in split_arg_spec
             ],
+            split_function_args_by_surface={
+                surface.value: [
+                    make_function_arg(
+                        s.ty,
+                        s.name,
+                        s.default,
+                        unused_on=s.unused_on,
+                        surface=surface,
+                    )
+                    for s in split_arg_spec
+                ]
+                for surface in DeclSurface
+            },
+            split_function_args_no_defaults_by_surface={
+                surface.value: [
+                    make_function_arg(
+                        s.ty, s.name, None, unused_on=s.unused_on, surface=surface
+                    )
+                    for s in split_arg_spec
+                ]
+                for surface in DeclSurface
+            },
             # Helper values
             split_tensors=[
                 s.name
@@ -984,7 +1126,9 @@ class OptimizerArgs:
             ],
             split_variables=["Variable()" for _ in split_arg_spec],
             split_ref_kernel_args=[
-                make_kernel_arg(s.ty, s.name, s.default, pass_by_ref=True)
+                make_kernel_arg(
+                    s.ty, s.name, s.default, pass_by_ref=True, unused_on=s.unused_on
+                )
                 for s in kernel_split_arg_spec
             ],
             placeholder_tensor_names=ph_tensor_names,
@@ -996,7 +1140,14 @@ class OptimizerArgs:
                 for s in kernel_split_arg_spec
             ],
             split_function_args_autograd=[
-                make_function_arg(s.ty, s.name, s.default, s.is_optional)
+                make_function_arg(
+                    s.ty,
+                    s.name,
+                    s.default,
+                    s.is_optional,
+                    unused_on=s.unused_on,
+                    surface=DeclSurface.AUTOGRAD,
+                )
                 for s in frontend_split_arg_spec
             ],
             split_function_arg_names_autograd=[s.name for s in frontend_split_arg_spec],
@@ -1032,7 +1183,9 @@ class OptimizerArgsSet:
                 or s.name == "learning_rate_tensor"
             ):
                 # pyre-fixme[19]: Expected 1 positional argument.
-                split_arg_spec.append(OptimItem(s.ty, s.name, s.default))
+                split_arg_spec.append(
+                    OptimItem(s.ty, s.name, s.default, unused_on=s.unused_on)
+                )
             else:
                 assert s.ty in (ArgType.TENSOR, ArgType.PLACEHOLDER_TENSOR)
                 # Treat PLACEHOLDER_TENSOR as TENSOR for CPU
@@ -1044,19 +1197,31 @@ class OptimizerArgsSet:
         name = spec.name
         default = spec.default
         is_optional = spec.is_optional
+        unused_on = spec.unused_on
         return [
             # pyre-fixme[19]: Expected 1 positional argument.
-            OptimItem(ArgType.TENSOR, f"{name}_host", default, is_optional=is_optional),
+            OptimItem(
+                ArgType.TENSOR,
+                f"{name}_host",
+                default,
+                is_optional=is_optional,
+                unused_on=unused_on,
+            ),
             # pyre-fixme[19]: Expected 1 positional argument.
             OptimItem(
                 ArgType.INT_TENSOR,
                 f"{name}_placements",
                 default,
                 is_optional=is_optional,
+                unused_on=unused_on,
             ),
             # pyre-fixme[19]: Expected 1 positional argument.
             OptimItem(
-                ArgType.LONG_TENSOR, f"{name}_offsets", default, is_optional=is_optional
+                ArgType.LONG_TENSOR,
+                f"{name}_offsets",
+                default,
+                is_optional=is_optional,
+                unused_on=unused_on,
             ),
         ]
 
@@ -1067,21 +1232,27 @@ class OptimizerArgsSet:
         ty = spec.ty
         ph_tys = spec.ph_tys
         is_optional = spec.is_optional
+        unused_on = spec.unused_on
         return [
             # pyre-fixme[19]: Expected 1 positional argument.
-            OptimItem(ty, f"{name}_dev", default, ph_tys, is_optional),
+            OptimItem(ty, f"{name}_dev", default, ph_tys, is_optional, unused_on),
             # pyre-fixme[19]: Expected 1 positional argument.
-            OptimItem(ty, f"{name}_uvm", default, ph_tys, is_optional),
+            OptimItem(ty, f"{name}_uvm", default, ph_tys, is_optional, unused_on),
             # pyre-fixme[19]: Expected 1 positional argument.
             OptimItem(
                 ArgType.INT_TENSOR,
                 f"{name}_placements",
                 default,
                 is_optional=is_optional,
+                unused_on=unused_on,
             ),
             # pyre-fixme[19]: Expected 1 positional argument.
             OptimItem(
-                ArgType.LONG_TENSOR, f"{name}_offsets", default, is_optional=is_optional
+                ArgType.LONG_TENSOR,
+                f"{name}_offsets",
+                default,
+                is_optional=is_optional,
+                unused_on=unused_on,
             ),
         ]
 
@@ -1092,23 +1263,49 @@ class OptimizerArgsSet:
         ty = spec.ty
         ph_tys = spec.ph_tys
         is_optional = spec.is_optional
+        unused_on = spec.unused_on
         return [
             # pyre-fixme[19]: Expected 1 positional argument.
-            OptimItem(ArgType.TENSOR, f"{name}_host", default, is_optional=is_optional),
+            OptimItem(
+                ArgType.TENSOR,
+                f"{name}_host",
+                default,
+                is_optional=is_optional,
+                unused_on=unused_on,
+            ),
             # pyre-fixme[19]: Expected 1 positional argument.
-            OptimItem(ty, f"{name}_dev", default, ph_tys, is_optional=is_optional),
+            OptimItem(
+                ty,
+                f"{name}_dev",
+                default,
+                ph_tys,
+                is_optional=is_optional,
+                unused_on=unused_on,
+            ),
             # pyre-fixme[19]: Expected 1 positional argument.
-            OptimItem(ty, f"{name}_uvm", default, ph_tys, is_optional=is_optional),
+            OptimItem(
+                ty,
+                f"{name}_uvm",
+                default,
+                ph_tys,
+                is_optional=is_optional,
+                unused_on=unused_on,
+            ),
             # pyre-fixme[19]: Expected 1 positional argument.
             OptimItem(
                 ArgType.INT_TENSOR,
                 f"{name}_placements",
                 default,
                 is_optional=is_optional,
+                unused_on=unused_on,
             ),
             # pyre-fixme[19]: Expected 1 positional argument.
             OptimItem(
-                ArgType.LONG_TENSOR, f"{name}_offsets", default, is_optional=is_optional
+                ArgType.LONG_TENSOR,
+                f"{name}_offsets",
+                default,
+                is_optional=is_optional,
+                unused_on=unused_on,
             ),
         ]
 

--- a/fbgemm_gpu/codegen/genscript/tests/test_optimizer_args.py
+++ b/fbgemm_gpu/codegen/genscript/tests/test_optimizer_args.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+from deeplearning.fbgemm.fbgemm_gpu.codegen.genscript.optimizer_args import (
+    decl_surfaces,
+    DeclSurface,
+    make_cpu_kernel_arg,
+    make_function_arg,
+    make_kernel_arg,
+    OptimizerArgsSet,
+    OptimizerArgsSetItem as OptimItem,
+)
+from deeplearning.fbgemm.fbgemm_gpu.codegen.genscript.torch_type_utils import ArgType
+
+
+def _rowwise_adagrad_spec() -> list[OptimItem]:
+    """The argument spec of an optimizer with tensor, placeholder and scalar args."""
+    return [
+        OptimItem(ArgType.TENSOR, "momentum1"),
+        OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
+        OptimItem(ArgType.FLOAT, "eps"),
+        OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
+    ]
+
+
+class DeclSurfaceTest(unittest.TestCase):
+    def test_every_surface_named_by_the_plan_exists(self) -> None:
+        self.assertEqual(
+            sorted(surface.value for surface in DeclSurface),
+            [
+                "autograd",
+                "cpu_kernel",
+                "gpu_kernel",
+                "host_function",
+                "meta",
+                "pt2_cpu",
+                "pt2_cuda",
+            ],
+        )
+
+    def test_strings_normalize_to_surfaces(self) -> None:
+        self.assertEqual(
+            decl_surfaces(["meta", DeclSurface.PT2_CUDA]),
+            frozenset({DeclSurface.META, DeclSurface.PT2_CUDA}),
+        )
+
+    def test_an_unknown_surface_is_rejected(self) -> None:
+        # A typo must fail generation rather than silently annotate nothing.
+        with self.assertRaises(ValueError) as caught:
+            decl_surfaces(["gpu_kernels"])
+        self.assertIn("gpu_kernels", str(caught.exception))
+
+    def test_an_unknown_surface_on_an_item_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            OptimItem(ArgType.FLOAT, "eps", unused_on=["cuda_kernel"])
+
+    def test_the_default_policy_is_empty(self) -> None:
+        item = OptimItem(ArgType.FLOAT, "eps")
+        self.assertEqual(item.unused_on, frozenset())
+        for surface in DeclSurface:
+            self.assertFalse(item.is_unused_on(surface))
+
+
+class DeclarationRendererTest(unittest.TestCase):
+    def test_default_policy_renders_the_bare_declaration(self) -> None:
+        self.assertEqual(make_function_arg(ArgType.FLOAT, "eps", None), "double eps")
+        self.assertEqual(make_kernel_arg(ArgType.FLOAT, "eps", None), "float eps")
+        self.assertEqual(
+            make_cpu_kernel_arg(ArgType.FLOAT, "eps", 0.0), "float eps = 0.0"
+        )
+        self.assertEqual(
+            make_kernel_arg(ArgType.INT_TENSOR, "momentum1_placements", None),
+            "at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> "
+            "momentum1_placements",
+        )
+
+    def test_a_selected_surface_is_prefixed(self) -> None:
+        self.assertEqual(
+            make_function_arg(
+                ArgType.FLOAT,
+                "eps",
+                None,
+                unused_on=frozenset({DeclSurface.META}),
+                surface=DeclSurface.META,
+            ),
+            "[[maybe_unused]] double eps",
+        )
+
+    def test_an_unselected_surface_is_untouched(self) -> None:
+        self.assertEqual(
+            make_function_arg(
+                ArgType.FLOAT,
+                "eps",
+                None,
+                unused_on=frozenset({DeclSurface.META}),
+                surface=DeclSurface.HOST_FUNCTION,
+            ),
+            "double eps",
+        )
+
+
+class OptimizerArgsPolicyTest(unittest.TestCase):
+    def test_default_projections_are_unchanged(self) -> None:
+        args = OptimizerArgsSet.create(_rowwise_adagrad_spec()).cuda
+        for rendered in (
+            args.split_function_args
+            + args.split_function_args_no_defaults
+            + args.split_kernel_args
+            + args.split_cpu_kernel_args
+            + args.split_function_args_autograd
+        ):
+            self.assertNotIn("[[maybe_unused]]", rendered)
+        for surface in DeclSurface:
+            self.assertEqual(
+                args.split_function_args_by_surface[surface.value],
+                args.split_function_args,
+            )
+            self.assertEqual(
+                args.split_function_args_no_defaults_by_surface[surface.value],
+                args.split_function_args_no_defaults,
+            )
+
+    def test_marking_one_surface_changes_only_that_declaration(self) -> None:
+        spec = _rowwise_adagrad_spec()
+        spec[2] = OptimItem(ArgType.FLOAT, "eps", unused_on=[DeclSurface.META])
+        args = OptimizerArgsSet.create(spec).cuda
+        baseline = OptimizerArgsSet.create(_rowwise_adagrad_spec()).cuda
+
+        meta = args.split_function_args_no_defaults_by_surface["meta"]
+        self.assertIn("[[maybe_unused]] double eps", meta)
+        self.assertEqual(
+            [decl.replace("[[maybe_unused]] ", "") for decl in meta],
+            baseline.split_function_args_no_defaults,
+        )
+
+        # Schemas, call-site names, and kernel constructors are contract text
+        # and must never pick up the annotation.
+        self.assertEqual(args.split_function_schemas, baseline.split_function_schemas)
+        self.assertEqual(
+            args.split_function_arg_names, baseline.split_function_arg_names
+        )
+        self.assertEqual(
+            args.split_kernel_arg_constructors, baseline.split_kernel_arg_constructors
+        )
+        self.assertEqual(args.split_kernel_arg_names, baseline.split_kernel_arg_names)
+        self.assertEqual(
+            args.unified_pt2.split_function_schemas,
+            baseline.unified_pt2.split_function_schemas,
+        )
+        # Every other declaration surface is untouched.
+        self.assertEqual(
+            args.split_function_args_no_defaults_by_surface["host_function"],
+            baseline.split_function_args_no_defaults,
+        )
+
+    def test_cpu_and_gpu_projections_can_differ(self) -> None:
+        spec = _rowwise_adagrad_spec()
+        spec[0] = OptimItem(
+            ArgType.TENSOR, "momentum1", unused_on=[DeclSurface.CPU_KERNEL]
+        )
+        argsset = OptimizerArgsSet.create(spec)
+
+        annotated_cpu = [
+            decl
+            for decl in argsset.cpu.split_cpu_kernel_args
+            if "[[maybe_unused]]" in decl
+        ]
+        self.assertEqual(len(annotated_cpu), 3)  # host, placements, offsets
+        self.assertTrue(
+            all("momentum1" in decl for decl in annotated_cpu), annotated_cpu
+        )
+        self.assertEqual(
+            [
+                decl
+                for decl in argsset.cuda.split_kernel_args
+                if "[[maybe_unused]]" in decl
+            ],
+            [],
+        )
+
+    def test_expansion_preserves_the_policy_on_every_derived_projection(self) -> None:
+        spec = [
+            OptimItem(
+                ArgType.PLACEHOLDER_TENSOR,
+                "row_counter",
+                ph_tys=[ArgType.FLOAT_TENSOR],
+                is_optional=True,
+                unused_on=[DeclSurface.PT2_CUDA],
+            ),
+            OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
+        ]
+        argsset = OptimizerArgsSet.create(spec)
+
+        expected = {
+            "cpu": [
+                "row_counter_host",
+                "row_counter_placements",
+                "row_counter_offsets",
+            ],
+            "cuda": [
+                "row_counter_dev",
+                "row_counter_uvm",
+                "row_counter_placements",
+                "row_counter_offsets",
+            ],
+            "any": [
+                "row_counter_host",
+                "row_counter_dev",
+                "row_counter_uvm",
+                "row_counter_placements",
+                "row_counter_offsets",
+            ],
+        }
+        for projection, names in expected.items():
+            rendered = getattr(argsset, projection).split_function_args_by_surface[
+                "pt2_cuda"
+            ]
+            annotated = [decl for decl in rendered if "[[maybe_unused]]" in decl]
+            self.assertEqual(len(annotated), len(names), (projection, rendered))
+            for name in names:
+                self.assertTrue(
+                    any(decl.endswith(f" {name}") for decl in annotated),
+                    (projection, name, annotated),
+                )
+            # learning_rate_tensor carries no policy and is never annotated.
+            self.assertTrue(
+                all("learning_rate_tensor" not in decl for decl in annotated)
+            )
+
+    def test_a_generated_common_argument_is_declared_not_inferred_from_its_name(
+        self,
+    ) -> None:
+        # `generate_index_select.py` builds a synthetic `OptimItem(FLOAT,
+        # "unused")` purely to satisfy the shared TBE templates. The metadata,
+        # not the spelling of the name, is what marks it unread.
+        by_name_only = OptimizerArgsSet.create([OptimItem(ArgType.FLOAT, "unused")])
+        self.assertEqual(
+            by_name_only.cuda.split_function_args_by_surface["gpu_kernel"],
+            ["double unused = 0"],
+        )
+
+        declared = OptimizerArgsSet.create(
+            [
+                OptimItem(
+                    ArgType.FLOAT,
+                    "unused",
+                    unused_on=list(DeclSurface),
+                )
+            ]
+        )
+        for surface in DeclSurface:
+            self.assertEqual(
+                declared.cuda.split_function_args_by_surface[surface.value],
+                ["[[maybe_unused]] double unused = 0"],
+            )
+        self.assertEqual(
+            declared.cuda.split_function_schemas,
+            by_name_only.cuda.split_function_schemas,
+        )

--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
@@ -64,18 +64,24 @@ inline void parallel_for_table_threads(
   bool have_err = false;
   std::exception_ptr eptr;
 
+  #ifdef _OPENMP
   #pragma omp parallel num_threads(num_threads)
+  #endif
   {
     try {
         const at::ThreadLocalStateGuard tls_guard(tls);
+        #ifdef _OPENMP
         #pragma omp for schedule(dynamic) nowait
+        #endif
         for (int t = begin; t < end; ++t) {
             try {
                 f(t, t + 1);
             } catch (...) {
                 // std::exception_ptr is not atomic,
                 // hence we need a critical section here in case multiple threads have exceptions
+                #ifdef _OPENMP
                 #pragma omp critical(tbe_table_threads_err)
+                #endif
                 {
                     if (!have_err) {
                         have_err = true;
@@ -85,7 +91,9 @@ inline void parallel_for_table_threads(
             }
         }
     } catch (...) {
+        #ifdef _OPENMP
         #pragma omp critical(tbe_table_threads_err)
+        #endif
         {
             if (!have_err) {
                 have_err = true;

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
@@ -167,7 +167,9 @@ struct __attribute__((visibility("hidden"))) KernelLauncher {
 
   constexpr inline void checkThreadCountNotExceeded(
       const cudaDeviceProp& properties,
-      const dim3& grid,
+      // Read only by the total-thread bound check below, which is compiled for
+      // HIP and pre-SM70 CUDA.
+      [[maybe_unused]] const dim3& grid,
       const dim3& block) const {
     const uint64_t threads_per_block =
         U64(block.x) * U64(block.y) * U64(block.z);

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -47,7 +47,6 @@ inline bool walk_down_tensor_storage_tree_except_last_(
   // compute coorindates
   int jagged_coords[NUM_JAGGED_DIM];
   int j_temp = flattened_jagged_idx;
-#pragma unroll
   for (int d = NUM_JAGGED_DIM - 2; d >= 0; --d) {
     const auto jagged_size = jagged_dims[d + 1];
     jagged_coords[d] = j_temp % jagged_size;
@@ -55,7 +54,6 @@ inline bool walk_down_tensor_storage_tree_except_last_(
   }
 
   bool is_zero = false;
-#pragma unroll
   for (int d = 0; d < NUM_JAGGED_DIM - 1; ++d) {
     const auto begin = x_offsets[d][offset];
     const auto end = x_offsets[d][offset + 1];

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -594,7 +594,9 @@ void radix_sort_kernel(
     local_histogram[i] = 0;
   }
 
+#ifdef _OPENMP
 #pragma omp for schedule(static)
+#endif
   for (int64_t i = 0; i < elements_count_4; i += 4) {
     const auto key_1 = input_keys[i];
     const auto key_2 = input_keys[i + 1];
@@ -612,7 +614,9 @@ void radix_sort_kernel(
       local_histogram[(key >> (pass * 8)) & 0xFF]++;
     }
   }
+#ifdef _OPENMP
 #pragma omp barrier
+#endif
   // Step 2: prefix sum
   if (tid == 0) {
     if (pass_with_sign_bit) {
@@ -623,10 +627,14 @@ void radix_sort_kernel(
       combine_prefix_sum(nthreads, elements_count, histogram, histogram_ps);
     }
   }
+#ifdef _OPENMP
 #pragma omp barrier
+#endif
 
   // Step 3: scatter
+#ifdef _OPENMP
 #pragma omp for schedule(static)
+#endif
   for (int64_t i = 0; i < elements_count_4; i += 4) {
     const auto key_1 = input_keys[i];
     const auto key_2 = input_keys[i + 1];
@@ -700,7 +708,9 @@ std::pair<K*, V*> radix_sort_parallel(
 
   const unsigned int num_passes = (num_bits + 7) / 8;
 
+#ifdef _OPENMP
 #pragma omp parallel
+#endif
   {
     K* input_keys = inp_key_buf;
     V* input_values = inp_value_buf;
@@ -721,7 +731,9 @@ std::pair<K*, V*> radix_sort_parallel(
 
       std::swap(input_keys, output_keys);
       std::swap(input_values, output_values);
+#ifdef _OPENMP
 #pragma omp barrier
+#endif
       {
       }
     }


### PR DESCRIPTION
Summary:

NOTE: No linked task. Please associate a task with this diff.

Subplan 12 diff 12.4, phase 4A. Adds the representation the rest of the stack
needs and migrates no warning site: generation is byte-for-byte identical.

The diff 12.1 census attributes 2,357 open `-Wunused-parameter` rows to
generated TBE sources. They are not 2,357 independent mistakes. One
`OptimizerArgsSetItem` is projected into a CPU kernel declaration, a GPU kernel
declaration, a host function, a meta shadow, an autograd wrapper, and the PT2
CPU and CUDA wrappers, and a contract-required argument is not necessarily read
by all seven. `optimizer_args.py` had no way to say so, which is why the debt
is spread across generated output instead of being stated once.

**`DeclSurface`.** A `str`-backed enum naming exactly the seven projections the
generator already produces: `cpu_kernel`, `gpu_kernel`, `host_function`,
`meta`, `autograd`, `pt2_cpu`, `pt2_cuda`. `decl_surfaces()` normalizes a
policy and raises `ValueError` on an unrecognized name, so a typo fails
generation instead of silently annotating nothing. No free-form Jinja
predicate is introduced anywhere.

**`OptimizerArgsSetItem.unused_on`.** A `frozenset[DeclSurface]`, defaulting to
empty, meaning "read wherever it appears". It is the last field, so the
existing positional constructions in `extend_for_cuda()` keep working.
`__post_init__` normalizes strings to enum members.

**Renderers.** `make_kernel_arg()`, `make_cpu_kernel_arg()`, and
`make_function_arg()` each take a keyword-only `unused_on` and `surface` and
delegate to a single `annotate_unused_declaration()` helper that prefixes
`[[maybe_unused]] `. The type-dispatch bodies moved unchanged into private
`_kernel_arg()` / `_cpu_kernel_arg()` / `_function_arg()` helpers. Only these
three declaration renderers consult the policy: `make_function_schema_arg()`,
`make_kernel_arg_constructor()`, `make_cpu_kernel_arg_constructor()`,
`split_function_arg_names`, and `PT2ArgsSet` packing are contract text and are
untouched by design.

**Per-surface projections.** `OptimizerArgs` gains
`split_function_args_by_surface` and
`split_function_args_no_defaults_by_surface`, each a dict keyed by
`DeclSurface.value`. This exists because a single projection object serves more
than one surface: `gen_args.cuda` feeds both the CUDA host template and the
meta template, and `gen_args.any` feeds both PT2 wrappers. Without a per-surface
rendering the meta shadow could not annotate differently from the host function
it mirrors. The pre-existing scalar fields keep rendering at their natural
surface (`split_kernel_args*` at `gpu_kernel`, `split_cpu_kernel_args` at
`cpu_kernel`, `split_function_args*` at `host_function`,
`split_function_args_autograd` at `autograd`), so no template has to change to
keep its current output.

**Propagation.** `extend_for_cpu()`, `extend_for_cuda()`, `extend_for_any()`,
the scalar/`learning_rate_tensor` path in `create_optim_args()`, and the
`learning_rate_tensor` to `learning_rate` kernel substitution all carry the
policy onto every derived item, so marking `momentum1` unused on a surface
reaches `momentum1_host`, `_dev`, `_uvm`, `_placements`, and `_offsets` in
every projection rather than silently applying to none of them.

A new `//deeplearning/fbgemm/fbgemm_gpu/codegen/genscript:optimizer_args`
`python_library` exposes the module to tests; the five generator binaries are
untouched.

Deliberately deferred, so this diff stays a no-op on output: no optimizer spec
in `optimizers.py` sets a policy, no template reads the new dicts, and
`generate_index_select.py`'s synthetic `OptimItem(ArgType.FLOAT, "unused")`
keeps its current form. Its migration lands in diff 12.7 with the forward and
index-select templates that consume it; the metadata's ability to express it is
tested here.

Differential Revision: D117024952


