### PR TITLE
Record every row a lookup touched for HBM streaming (#6200)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -1635,6 +1635,9 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         )
         self.register_buffer(
             "res_count",
+            # new_unified_tensor mallocs and ignores the input tensor's
+            # contents, so torch.zeros below does NOT zero the result -- it
+            # only supplies dtype and device. C++ reads this as a row count.
             torch.ops.fbgemm.new_unified_tensor(
                 torch.zeros(
                     1,
@@ -1643,11 +1646,15 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 ),
                 (1,),
                 is_host_mapped=self.uvm_host_mapped,
-            ),
+            ).zero_(),
             persistent=False,  # RES buffer is not checkpointed since it is used as intermediate buffer for copying
         )
         self.register_buffer(
             "res_copy_done",
+            # Unzeroed for the same reason as res_count above. The C++ poll
+            # reads any nonzero as "the GPU is done writing the RES buffers"
+            # and then resets it, so garbage here desyncs the handshake by one
+            # iteration for the rest of the run, not just the first drain.
             torch.ops.fbgemm.new_unified_tensor(
                 torch.zeros(
                     1,
@@ -1656,7 +1663,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 ),
                 (1,),
                 is_host_mapped=self.uvm_host_mapped,
-            ),
+            ).zero_(),
             persistent=False,  # RES buffer is not checkpointed since it is used as intermediate buffer for copying
         )
 

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -147,6 +147,9 @@ class RESParams:
     res_enabled_tables: list[str] = field(
         default_factory=list
     )  # table names that are enabled for RES (empty means all enabled)
+    # Streams DEVICE-placed tables named in `res_enabled_tables`, which the
+    # cache lane cannot reach. Costs a byte per row of the shard, so it is opt-in.
+    enable_hbm_streaming: bool = False
 
 
 class PrefetchedInfo:
@@ -725,6 +728,12 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.table_names: list[str] | None = table_names
         self.logging_table_name: str = self.get_table_name_for_logging(table_names)
         self.enable_raw_embedding_streaming: bool = enable_raw_embedding_streaming
+        # Precomputed: `_prefetch` is not `@torch.jit.ignore`, and TorchScript
+        # cannot resolve `res_params` there, so we read it here instead.
+        self._res_hbm_streaming: bool = bool(
+            enable_raw_embedding_streaming
+            and (res_params or RESParams()).enable_hbm_streaming
+        )
         self.pooling_mode = pooling_mode
         self.is_nobag: bool = self.pooling_mode == PoolingMode.NONE
 
@@ -1565,6 +1574,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 self.res_params.table_sizes,
             )
             self._register_res_enabled_feature_mask()
+            if self.res_params.enable_hbm_streaming:
+                self._register_res_hbm_buffers()
             logging.info(
                 f"{self.uuid} raw embedding streaming enabled with {self.res_params=}, {self._res_require_copy=}, {self._res_sync_copy=}"
             )
@@ -1749,6 +1760,64 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             "res_enabled_feature_mask", enabled_feature_mask, persistent=False
         )
         self._res_all_features_enabled: bool = bool(enabled_feature_mask.all())
+
+    @torch.jit.ignore
+    def _register_res_hbm_buffers(self) -> None:
+        """Allocate the map of rows touched since the last drain.
+
+        Written during prefetch from the unfiltered `linearize_cache_indices`
+        output, so every looked-up row lands here whatever its placement or
+        allowlist status. Narrowing that down is the drain's job.
+        """
+        assert (
+            self.enable_raw_embedding_streaming
+        ), "Should not register res hbm buffers when raw embedding streaming is not enabled"
+
+        # +1: the kernel dumps indices it cannot place -- pruned rows among
+        # them -- on total_hash_size, so that slot gets written and has to exist.
+        linear_size = self.total_hash_size + 1
+        self.register_buffer(
+            "_res_rows_seen",
+            torch.zeros(linear_size, device=self.current_device, dtype=torch.bool),
+            persistent=False,  # RES buffer is not checkpointed
+        )
+
+    @torch.jit.ignore
+    def _mark_res_hbm_rows(
+        self,
+        indices: Tensor,
+        offsets: Tensor,
+        vbe_metadata: invokers.lookup_args.VBEMetadata | None,
+    ) -> None:
+        """Record every row this lookup touched, whatever its placement.
+
+        Must run before `_prefetch`'s `lxu_cache_weights.numel()` guard: a TBE
+        holding only DEVICE tables has an empty `lxu_cache_weights`, so nothing
+        past that guard runs for DEVICE-placed tables.
+        """
+        if not self._res_hbm_streaming:
+            return
+        # hash_size_cumsum, not cache_hash_size_cumsum: the latter is a
+        # 1-element stub on a cacheless TBE and holds -1 for every non-cached
+        # feature, which the kernel routes to the sentinel -- a whole DEVICE
+        # table collapsing onto one slot. It is also the index space
+        # `_res_rows_seen` is sized against.
+        linearize_indices = torch.ops.fbgemm.linearize_cache_indices(
+            self.hash_size_cumsum,
+            indices,
+            offsets,
+            vbe_metadata.B_offsets if vbe_metadata is not None else None,
+            vbe_metadata.max_B if vbe_metadata is not None else -1,
+        )
+        # index_fill_ asserts on out-of-range indices in release builds, so an
+        # unclamped index kills the rank instead of writing a wrong row.
+        # Reachable only under bounds_check_mode=NONE. Upper bound only: the
+        # kernel already routes negatives to the sentinel. In place -- the
+        # tensor is local and feeds nothing but the fill.
+        linearize_indices.clamp_(max=self.total_hash_size)
+        # index_fill_ rather than setitem: assigning a Python scalar into a
+        # CUDA tensor forces a host sync.
+        self._res_rows_seen.index_fill_(0, linearize_indices, True)
 
     @torch.jit.ignore
     def _get_enabled_feature_mask_and_indices(
@@ -3123,6 +3192,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             # Mutations of nn.Module attr forces dynamo restart of Analysis which increases compilation time
             self.timestep += 1
             self.timesteps_prefetched.append(self.timestep)
+
+        self._mark_res_hbm_rows(indices, offsets, vbe_metadata)
 
         # pyre-fixme[29]: `(self: TensorBase) -> int | Module | Tensor` is not
         #  a function.

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
@@ -97,6 +97,9 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
   /// not interfere with cache-hit streaming at the dispatch or copy level. Only
   /// the ship path (consumer_executor_) stays shared. Defaults false (main
   /// path) -- inert until an out-of-scope caller opts in.
+  /// @param expected_flag_value when set, wait for copy_done_flag to equal
+  /// exactly this value and do not reset it, instead of waiting for any
+  /// nonzero and resetting. Must be in [1, 2^31-1]. See poll_copy_done_flag.
   ///
   /// @return None
   void stream(
@@ -108,7 +111,8 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
       bool require_tensor_copy,
       bool blocking_tensor_copy = true,
       std::optional<at::Tensor> copy_done_flag = std::nullopt,
-      bool use_hbm = false);
+      bool use_hbm = false,
+      std::optional<int64_t> expected_flag_value = std::nullopt);
 
   /*
    * Join the pending dispatch future (which resolves only after all copies for
@@ -228,9 +232,19 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
       int64_t end);
 
   // Waits (spinning) for copy_done_flag to signal the source tensors are safe
-  // to read, resetting it. Returns false on timeout. Shared by the blocking
-  // stream() path and dispatch_copy_task.
-  bool poll_copy_done_flag(const std::optional<at::Tensor>& copy_done_flag);
+  // to read. Returns false on timeout. Shared by the blocking stream() path and
+  // dispatch_copy_task.
+  //
+  // By default the flag is a boolean: the producer writes any nonzero and this
+  // resets it to 0. Passing expected_flag_value instead waits for the flag to
+  // equal exactly that value and leaves it in place. Prefer that where
+  // possible -- a boolean poll that times out leaves the flag set, so the next
+  // drain reads it as already signalled and copies the source tensors while
+  // they are still being written. The boolean form is kept for backward
+  // compatibility.
+  bool poll_copy_done_flag(
+      const std::optional<at::Tensor>& copy_done_flag,
+      std::optional<int64_t> expected_flag_value);
 
   // Coroutine form of the non-blocking dispatch (poll_copy_done_flag +
   // chunked_copy_and_enqueue). Args are taken by value so nothing dangles once
@@ -244,7 +258,8 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
       std::optional<at::Tensor> runtime_meta,
       at::Tensor count,
       std::optional<at::Tensor> copy_done_flag,
-      bool use_hbm);
+      bool use_hbm,
+      std::optional<int64_t> expected_flag_value);
 #endif
 };
 

--- a/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
@@ -133,6 +133,41 @@ inline int64_t get_maybe_uvm_scalar(const at::Tensor& tensor) {
       : *(tensor.const_data_ptr<int32_t>());
 }
 
+/// Called from stream(), not poll_copy_done_flag: the non-blocking path polls
+/// from a coroutine that swallows exceptions.
+void validate_copy_done_flag(
+    const std::optional<at::Tensor>& copy_done_flag,
+    std::optional<int64_t> expected_flag_value) {
+  // 0 is the boolean reset value and the state of an untouched buffer; past
+  // int32 max the comparison narrows.
+  constexpr int64_t kMaxFlagValue = 2147483647;
+  if (expected_flag_value.has_value()) {
+    TORCH_CHECK(
+        *expected_flag_value >= 1 && *expected_flag_value <= kMaxFlagValue,
+        "expected_flag_value must be in [1, ",
+        kMaxFlagValue,
+        "], got ",
+        *expected_flag_value);
+    // Without a flag there is nothing to wait on: poll_copy_done_flag returns
+    // true immediately, so a caller that set only this would get no
+    // synchronisation and no log.
+    TORCH_CHECK(
+        copy_done_flag.has_value(),
+        "expected_flag_value requires copy_done_flag");
+  }
+  // No device check: the production flag is host-mapped and need not report
+  // device CPU.
+  if (copy_done_flag.has_value()) {
+    TORCH_CHECK(
+        copy_done_flag->scalar_type() == at::kInt &&
+            copy_done_flag->numel() == 1,
+        "copy_done_flag must be a 1-element int32 tensor, got ",
+        copy_done_flag->numel(),
+        " element(s) of ",
+        copy_done_flag->scalar_type());
+  }
+}
+
 #endif
 
 } // namespace
@@ -388,7 +423,8 @@ void RawEmbeddingStreamer::stream(
     bool require_tensor_copy [[maybe_unused]],
     bool blocking_tensor_copy [[maybe_unused]],
     std::optional<at::Tensor> copy_done_flag [[maybe_unused]],
-    bool use_hbm [[maybe_unused]]) {
+    bool use_hbm [[maybe_unused]],
+    std::optional<int64_t> expected_flag_value [[maybe_unused]]) {
   if (!enable_raw_embedding_streaming_) {
     return;
   }
@@ -404,8 +440,10 @@ void RawEmbeddingStreamer::stream(
         count));
     return;
   }
-  auto poll_flag = [this, copy_done_flag]() {
-    return poll_copy_done_flag(copy_done_flag);
+  validate_copy_done_flag(copy_done_flag, expected_flag_value);
+
+  auto poll_flag = [this, copy_done_flag, expected_flag_value]() {
+    return poll_copy_done_flag(copy_done_flag, expected_flag_value);
   };
 
   // Select the lane's executors once: the HBM path runs on its own dispatch +
@@ -468,7 +506,8 @@ void RawEmbeddingStreamer::stream(
                             std::move(runtime_meta),
                             count,
                             std::move(copy_done_flag),
-                            use_hbm))
+                            use_hbm,
+                            expected_flag_value))
                         .start();
   rec->record.end();
 #endif
@@ -627,24 +666,41 @@ folly::coro::Task<void> RawEmbeddingStreamer::chunked_copy_and_enqueue(
 }
 
 bool RawEmbeddingStreamer::poll_copy_done_flag(
-    const std::optional<at::Tensor>& copy_done_flag) {
-  if (copy_done_flag.has_value()) {
-    auto* ptr = static_cast<volatile int32_t*>(copy_done_flag->data_ptr());
-    folly::stop_watch<std::chrono::microseconds> poll_watch;
-    while (*ptr == 0) {
-      std::this_thread::yield();
-      // At shutdown the producing GPU work is abandoned, so the flag may never
-      // be set.
-      if (stop_.load(std::memory_order_relaxed)) {
-        return false;
-      }
-      if (poll_watch.elapsed().count() > kCopyDonePollTimeoutUs) {
-        LOG(ERROR) << "[TBE_ID" << unique_id_
-                   << "] copy_done_flag poll timed out after "
-                   << kCopyDonePollTimeoutUs / 1'000'000 << "s";
-        return false;
-      }
+    const std::optional<at::Tensor>& copy_done_flag,
+    std::optional<int64_t> expected_flag_value) {
+  if (!copy_done_flag.has_value()) {
+    return true;
+  }
+  auto* ptr = static_cast<volatile int32_t*>(copy_done_flag->data_ptr());
+  // Sequence protocol waits for one exact value; boolean protocol waits for any
+  // nonzero.
+  const auto signalled = [ptr, expected_flag_value]() {
+    return expected_flag_value.has_value()
+        ? *ptr == static_cast<int32_t>(*expected_flag_value)
+        : *ptr != 0;
+  };
+  folly::stop_watch<std::chrono::microseconds> poll_watch;
+  while (!signalled()) {
+    std::this_thread::yield();
+    // At shutdown the producing GPU work is abandoned, so the flag may never
+    // be set.
+    if (stop_.load(std::memory_order_relaxed)) {
+      return false;
     }
+    if (poll_watch.elapsed().count() > kCopyDonePollTimeoutUs) {
+      LOG(ERROR) << "[TBE_ID" << unique_id_
+                 << "] copy_done_flag poll timed out after "
+                 << kCopyDonePollTimeoutUs / 1'000'000 << "s, expected "
+                 << (expected_flag_value.has_value()
+                         ? std::to_string(*expected_flag_value)
+                         : "nonzero")
+                 << ", observed " << *ptr;
+      return false;
+    }
+  }
+  // Only the boolean protocol consumes the signal; resetting a sequence value
+  // would reopen the stale-flag window the sequence exists to close.
+  if (!expected_flag_value.has_value()) {
     *ptr = 0;
   }
   return true;
@@ -657,8 +713,9 @@ folly::coro::Task<void> RawEmbeddingStreamer::dispatch_copy_task(
     std::optional<at::Tensor> runtime_meta,
     at::Tensor count,
     std::optional<at::Tensor> copy_done_flag,
-    bool use_hbm) {
-  if (!poll_copy_done_flag(copy_done_flag)) {
+    bool use_hbm,
+    std::optional<int64_t> expected_flag_value) {
+  if (!poll_copy_done_flag(copy_done_flag, expected_flag_value)) {
     co_return;
   }
   // Log at failure time instead of letting the exception ride dispatch_future_

--- a/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
@@ -125,6 +125,7 @@ auto raw_embedding_streamer =
                 torch::arg("blocking_tensor_copy"),
                 torch::arg("copy_done_flag") = std::nullopt,
                 torch::arg("use_hbm") = false,
+                torch::arg("expected_flag_value") = std::nullopt,
             })
         // The exposed name is kept as-is for backward compatibility: frozen
         // fbgemm clones bundled with published models (pyper_models/.../

--- a/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
@@ -996,6 +996,313 @@ TEST(RawEmbeddingStreamerTest, TestStreamWithCopyDoneFlagNonBlockingCopy) {
   EXPECT_EQ(copy_done_flag.item<int32_t>(), 0);
 }
 
+TEST(RawEmbeddingStreamerTest, TestExpectedFlagValueSequenceIsNotReset) {
+  // Sequence protocol: the producer writes a monotonically increasing value and
+  // the poll waits for that exact value, leaving it in place. A reset here
+  // would reopen the stale-flag window the sequence protocol closes.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_flag_sequence", true, table_names, table_offsets, table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2, 1, 150, 170, 230, 280},
+      at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  // A sequence value that is neither 0 nor 1, so a legacy "wait nonzero, then
+  // reset" poll would be visibly wrong.
+  constexpr int32_t kSeq = 7;
+  auto copy_done_flag =
+      at::full({1}, kSeq, at::TensorOptions().device(at::kCPU).dtype(at::kInt));
+
+  // Stop the dequeue thread to get an accurate, stable queue size.
+  streamer->join_weights_stream_thread();
+
+  streamer->stream(
+      indices,
+      weights,
+      std::nullopt,
+      std::nullopt,
+      count,
+      /*require_tensor_copy=*/true,
+      /*blocking_tensor_copy=*/false,
+      copy_done_flag,
+      /*use_hbm=*/false,
+      /*expected_flag_value=*/kSeq);
+
+  streamer->join_dispatch_and_workers();
+  EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 1);
+  EXPECT_EQ(copy_done_flag.item<int32_t>(), kSeq);
+}
+
+TEST(RawEmbeddingStreamerTest, TestExpectedFlagValueSequenceOnBlockingPath) {
+  // The blocking path polls the flag inline rather than on the dispatch
+  // coroutine, so it needs its own coverage that the sequence value is matched
+  // and left in place.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_flag_sequence_block",
+      true,
+      table_names,
+      table_offsets,
+      table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2, 1, 150, 170, 230, 280},
+      at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  constexpr int32_t kSeq = 42;
+  auto copy_done_flag =
+      at::full({1}, kSeq, at::TensorOptions().device(at::kCPU).dtype(at::kInt));
+
+  streamer->join_weights_stream_thread();
+
+  streamer->stream(
+      indices,
+      weights,
+      std::nullopt,
+      std::nullopt,
+      count,
+      /*require_tensor_copy=*/true,
+      /*blocking_tensor_copy=*/true,
+      copy_done_flag,
+      /*use_hbm=*/false,
+      /*expected_flag_value=*/kSeq);
+
+  EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 1);
+  EXPECT_EQ(copy_done_flag.item<int32_t>(), kSeq);
+}
+
+TEST(RawEmbeddingStreamerTest, TestExpectedFlagValueWaitsForWrongNonzero) {
+  // The other sequence tests pre-arm the flag with the awaited value, so they
+  // pass even against a poll that only tests "nonzero". Start at a nonzero
+  // value that is NOT the awaited one -- the only state where the two differ.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_flag_sequence_wait", true, table_names, table_offsets, table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2, 1, 150, 170, 230, 280},
+      at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  constexpr int32_t kSeq = 7;
+  auto copy_done_flag = at::full(
+      {1}, kSeq - 1, at::TensorOptions().device(at::kCPU).dtype(at::kInt));
+
+  streamer->join_weights_stream_thread();
+
+  streamer->stream(
+      indices,
+      weights,
+      std::nullopt,
+      std::nullopt,
+      count,
+      /*require_tensor_copy=*/true,
+      /*blocking_tensor_copy=*/false,
+      copy_done_flag,
+      /*use_hbm=*/false,
+      /*expected_flag_value=*/kSeq);
+
+  // Fixed wait rather than a poll loop: the assertion is a negative, so there
+  // is nothing to poll for. Failing to wait long enough can only make this
+  // test pass spuriously, never fail spuriously.
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 0);
+
+  // Release the poll before joining -- join_dispatch_and_workers() waits on
+  // the dispatch coroutine, which is still spinning until the flag matches.
+  copy_done_flag.fill_(kSeq);
+  streamer->join_dispatch_and_workers();
+  EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 1);
+  EXPECT_EQ(copy_done_flag.item<int32_t>(), kSeq);
+}
+
+TEST(RawEmbeddingStreamerTest, TestExpectedFlagValueRejectsOutOfRange) {
+  // Both bounds of stream()'s [1, int32 max] guard.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_flag_range", true, table_names, table_offsets, table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto copy_done_flag =
+      at::full({1}, 1, at::TensorOptions().device(at::kCPU).dtype(at::kInt));
+
+  const auto stream_with = [&](int64_t expected_flag_value,
+                               bool blocking_tensor_copy = true) {
+    streamer->stream(
+        indices,
+        weights,
+        std::nullopt,
+        std::nullopt,
+        count,
+        /*require_tensor_copy=*/true,
+        blocking_tensor_copy,
+        copy_done_flag,
+        /*use_hbm=*/false,
+        expected_flag_value);
+  };
+
+  EXPECT_THROW(stream_with(0), c10::Error);
+  // Narrows to 5, which is in range: rejecting it is what pins the check
+  // ahead of the cast rather than after it.
+  EXPECT_THROW(stream_with((int64_t{1} << 32) + 5), c10::Error);
+  // Non-blocking too, so the check cannot be moved into poll_copy_done_flag --
+  // there it would be swallowed by the dispatch coroutine.
+  EXPECT_THROW(stream_with(0, /*blocking_tensor_copy=*/false), c10::Error);
+}
+
+TEST(RawEmbeddingStreamerTest, TestExpectedFlagValueRequiresCopyDoneFlag) {
+  // An expected value with no flag to read it from polls nothing: the caller
+  // believes it is synchronised and is not.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_flag_required", true, table_names, table_offsets, table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  EXPECT_THROW(
+      streamer->stream(
+          indices,
+          weights,
+          std::nullopt,
+          std::nullopt,
+          count,
+          /*require_tensor_copy=*/true,
+          /*blocking_tensor_copy=*/true,
+          /*copy_done_flag=*/std::nullopt,
+          /*use_hbm=*/false,
+          /*expected_flag_value=*/1),
+      c10::Error);
+}
+
+TEST(RawEmbeddingStreamerTest, TestCopyDoneFlagRejectsWrongShapeOrDtype) {
+  // The poll reinterprets the buffer as int32 and reads one element, so a flag
+  // of another dtype or width is read as garbage. Checked for both protocols;
+  // this drives the boolean one, which is the live path.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_flag_dtype", true, table_names, table_offsets, table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  const auto stream_with_flag = [&](const at::Tensor& copy_done_flag) {
+    streamer->stream(
+        indices,
+        weights,
+        std::nullopt,
+        std::nullopt,
+        count,
+        /*require_tensor_copy=*/true,
+        /*blocking_tensor_copy=*/true,
+        copy_done_flag,
+        /*use_hbm=*/false,
+        /*expected_flag_value=*/std::nullopt);
+  };
+
+  EXPECT_THROW(
+      stream_with_flag(
+          at::full(
+              {1}, 1, at::TensorOptions().device(at::kCPU).dtype(at::kLong))),
+      c10::Error);
+  EXPECT_THROW(
+      stream_with_flag(
+          at::full(
+              {2}, 1, at::TensorOptions().device(at::kCPU).dtype(at::kInt))),
+      c10::Error);
+}
+
+TEST(RawEmbeddingStreamerTest, TestExpectedFlagValueAcceptsLowerBound) {
+  // 1 is in range and must be accepted: a sequence counter starts there, so a
+  // guard that rejected it would throw on the first drain of every process.
+  // The other sequence tests all use larger values and miss that.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_flag_lower_bound", true, table_names, table_offsets, table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2, 1, 150, 170, 230, 280},
+      at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  constexpr int32_t kSeq = 1;
+  auto copy_done_flag =
+      at::full({1}, kSeq, at::TensorOptions().device(at::kCPU).dtype(at::kInt));
+
+  streamer->join_weights_stream_thread();
+
+  EXPECT_NO_THROW(streamer->stream(
+      indices,
+      weights,
+      std::nullopt,
+      std::nullopt,
+      count,
+      /*require_tensor_copy=*/true,
+      /*blocking_tensor_copy=*/true,
+      copy_done_flag,
+      /*use_hbm=*/false,
+      /*expected_flag_value=*/kSeq));
+
+  EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 1);
+  EXPECT_EQ(copy_done_flag.item<int32_t>(), kSeq);
+}
+
 TEST(RawEmbeddingStreamerTest, TestStreamHbmLaneE2E) {
   // The blocking copy path is lane-agnostic: passing use_hbm=true
   // still ships through the SAME consumer_executor_ as the main path (blocking

--- a/fbgemm_gpu/test/tbe/training/res_enabled_tables_test.py
+++ b/fbgemm_gpu/test/tbe/training/res_enabled_tables_test.py
@@ -106,6 +106,180 @@ class ResEnabledTablesTest(unittest.TestCase):
         mask = tbe.get_buffer("res_enabled_feature_mask")
         self.assertEqual(mask.tolist(), [True, True, True])
 
+    def _build_mixed_tbe(
+        self,
+        table_names: list[str],
+        locations: list[EmbeddingLocation],
+        res_enabled_tables: list[str],
+        enable_hbm_streaming: bool = True,
+        heights: list[int] | None = None,
+        feature_table_map: list[int] | None = None,
+        dim: int = 16,
+    ) -> SplitTableBatchedEmbeddingBagsCodegen:
+        """One table per name, each with its own placement and row count."""
+        n = len(table_names)
+        rows = heights if heights is not None else [64] * n
+        offsets = []
+        running = 0
+        for h in rows:
+            offsets.append(running)
+            running += h
+        res_params = RESParams(
+            res_store_shards=1,
+            table_names=list(table_names),
+            table_offsets=offsets,
+            table_sizes=list(rows),
+            res_enabled_tables=list(res_enabled_tables),
+            enable_hbm_streaming=enable_hbm_streaming,
+        )
+        return SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (h, dim, loc, ComputeDevice.CUDA) for h, loc in zip(rows, locations)
+            ],
+            enable_raw_embedding_streaming=True,
+            res_params=res_params,
+            feature_table_map=feature_table_map,
+        )
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_buffers_not_allocated_when_lane_disabled(self) -> None:
+        # The buffers span the whole linear index space, so a RES model that leaves
+        # the lane off must not pay for them.
+        tbe = self._build_mixed_tbe(
+            ["t0"],
+            [EmbeddingLocation.DEVICE],
+            res_enabled_tables=[],
+            enable_hbm_streaming=False,
+        )
+        # hasattr, not just named_buffers: registering it as a plain attribute
+        # would keep the buffer assertion green while still paying the whole
+        # allocation this test exists to prevent.
+        self.assertNotIn("_res_rows_seen", dict(tbe.named_buffers()))
+        self.assertFalse(hasattr(tbe, "_res_rows_seen"))
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_mark_records_every_touched_row(self) -> None:
+        # The mark is unconditional on cache state: t1 is DEVICE-placed and so
+        # never hits the cache, and its row must still be recorded.
+        rows = 64
+        tbe = self._build_mixed_tbe(
+            ["t0", "t1"],
+            [EmbeddingLocation.MANAGED_CACHING, EmbeddingLocation.DEVICE],
+            res_enabled_tables=["t1"],
+            heights=[rows, rows],
+        )
+        device = torch.cuda.current_device()
+        tbe._prefetch(
+            torch.tensor([3, 5], device=device, dtype=torch.int64),
+            torch.tensor([0, 1, 2], device=device, dtype=torch.int64),
+        )
+        present = tbe.get_buffer("_res_rows_seen").tolist()
+        self.assertEqual(len(present), 2 * rows + 1)
+        self.assertEqual([i for i, p in enumerate(present) if p], [3, rows + 5])
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_prefetch_with_lane_off(self) -> None:
+        # The buffer does not exist when the lane is off, so the mark must be
+        # gated rather than guarded -- an ungated index_fill_ is AttributeError
+        # on every RES model that leaves the lane off. Drives _prefetch, which
+        # is where the mark lives; calling _store_prefetched_tensors here would
+        # exercise a method the mark is no longer in.
+        rows = 64
+        tbe = self._build_mixed_tbe(
+            ["t0", "t1"],
+            [EmbeddingLocation.MANAGED_CACHING, EmbeddingLocation.DEVICE],
+            res_enabled_tables=["t1"],
+            enable_hbm_streaming=False,
+            heights=[rows, rows],
+        )
+        device = torch.cuda.current_device()
+        tbe._prefetch(
+            torch.tensor([3, 5], device=device, dtype=torch.int64),
+            torch.tensor([0, 1, 2], device=device, dtype=torch.int64),
+        )
+        self.assertNotIn("_res_rows_seen", dict(tbe.named_buffers()))
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_mark_fires_through_prefetch(self) -> None:
+        # Drives _prefetch rather than calling _store_prefetched_tensors by
+        # hand: the mark has to survive the cacheless early-return, and a test
+        # that invokes the inner method directly cannot see that guard at all.
+        # The DEVICE-only TBE is the shape TorchRec actually builds for a
+        # DEVICE table, and the only shape this lane exists to serve.
+        rows = 64
+        device = torch.cuda.current_device()
+        indices = torch.tensor([3], device=device, dtype=torch.int64)
+        offsets = torch.tensor([0, 1], device=device, dtype=torch.int64)
+
+        for location in (
+            EmbeddingLocation.MANAGED_CACHING,  # positive control: has a cache
+            EmbeddingLocation.DEVICE,  # no cache, so no _prefetch tail
+        ):
+            with self.subTest(location=location):
+                tbe = self._build_mixed_tbe(
+                    ["t0"], [location], res_enabled_tables=["t0"], heights=[rows]
+                )
+                tbe._prefetch(indices, offsets)
+                self.assertEqual(
+                    [
+                        i
+                        for i, p in enumerate(tbe.get_buffer("_res_rows_seen").tolist())
+                        if p
+                    ],
+                    [3],
+                )
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_mark_clamps_out_of_range_into_the_sentinel(self) -> None:
+        # _prefetch sits below prepare_inputs, so bounds_check_indices has not
+        # run and index 999 into 64 rows reaches the clamp raw. Without the
+        # clamp this is a device-side assert, not a wrong row.
+        rows = 64
+        device = torch.cuda.current_device()
+        tbe = self._build_mixed_tbe(
+            ["t0"],
+            [EmbeddingLocation.DEVICE],
+            res_enabled_tables=["t0"],
+            heights=[rows],
+        )
+        tbe._prefetch(
+            torch.tensor([999], device=device, dtype=torch.int64),
+            torch.tensor([0, 1], device=device, dtype=torch.int64),
+        )
+        present = [
+            i for i, p in enumerate(tbe.get_buffer("_res_rows_seen").tolist()) if p
+        ]
+        self.assertEqual(present, [rows])
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_mark_negative_index_never_reaches_the_clamp(self) -> None:
+        # Why the clamp is upper-bound only: linearize_cache_indices guards both
+        # its write sites on `indices[index] >= 0`
+        # (linearize_cache_indices.cu:57 and :165) and routes anything negative
+        # to the sentinel, so a negative input arrives here already in range.
+        rows = 64
+        device = torch.cuda.current_device()
+        tbe = self._build_mixed_tbe(
+            ["t0"],
+            [EmbeddingLocation.DEVICE],
+            res_enabled_tables=["t0"],
+            heights=[rows],
+        )
+        tbe._prefetch(
+            torch.tensor([-1], device=device, dtype=torch.int64),
+            torch.tensor([0, 1], device=device, dtype=torch.int64),
+        )
+        present = [
+            i for i, p in enumerate(tbe.get_buffer("_res_rows_seen").tolist()) if p
+        ]
+        self.assertEqual(present, [rows])
+
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_subset_allowlist_builds_feature_mask(self) -> None:

--- a/fbgemm_gpu/test/tbe/training/res_enabled_tables_test.py
+++ b/fbgemm_gpu/test/tbe/training/res_enabled_tables_test.py
@@ -43,8 +43,10 @@ class ResEnabledTablesTest(unittest.TestCase):
         res_enabled_tables: list[str],
         rows: int = 64,
         dim: int = 16,
+        location: EmbeddingLocation = EmbeddingLocation.DEVICE,
+        uvm_host_mapped: bool = False,
     ) -> SplitTableBatchedEmbeddingBagsCodegen:
-        """One DEVICE table per name (one feature per table), RES enabled."""
+        """One table per name (one feature per table), RES enabled."""
         n = len(table_names)
         res_params = RESParams(
             res_store_shards=1,
@@ -55,12 +57,36 @@ class ResEnabledTablesTest(unittest.TestCase):
         )
         return SplitTableBatchedEmbeddingBagsCodegen(
             embedding_specs=[
-                (rows, dim, EmbeddingLocation.DEVICE, ComputeDevice.CUDA)
-                for _ in range(n)
+                (rows, dim, location, ComputeDevice.CUDA) for _ in range(n)
             ],
             enable_raw_embedding_streaming=True,
             res_params=res_params,
+            uvm_host_mapped=uvm_host_mapped,
         )
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_res_count_and_copy_done_start_zero(self) -> None:
+        # new_unified_tensor hands back an unzeroed allocation. res_count is
+        # read as a row count by a std::copy that does not bound check, and any
+        # nonzero copy_done reads as "the GPU is done writing" -- so an unzeroed
+        # pair makes the first drain over-read and ship mid-write.
+        # Both arguments are load-bearing, and the test is vacuous without
+        # either. MANAGED_CACHING, not DEVICE: a DEVICE table has no UVM cache,
+        # so cache_size is 0 and _register_res_buffers takes the empty branch,
+        # which allocates with plain torch.zeros. uvm_host_mapped, because only
+        # that branch of new_unified_tensor allocates with malloc; the default
+        # cudaMallocManaged branch hands back fresh zeroed pages, so the
+        # unzeroed value is never observed there.
+        tbe = self._build_tbe(
+            ["t0"],
+            ["t0"],
+            location=EmbeddingLocation.MANAGED_CACHING,
+            uvm_host_mapped=True,
+        )
+        self.assertGreater(tbe.get_buffer("lxu_cache_weights").size(0), 0)
+        self.assertEqual(tbe.get_buffer("res_count").tolist(), [0])
+        self.assertEqual(tbe.get_buffer("res_copy_done").tolist(), [0])
 
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3089

Adds a map of which rows each lookup touched, and the mark that writes it. Written in `_prefetch` above the `lxu_cache_weights.numel()` early return, because TBE holding only DEVICE tables has an empty `lxu_cache_weights` and nothing past that guard runs. The mark is unfiltered, cached rows, non-allowlisted tables and the pruning sentinel all get marked because the drain has to apply that scope anyway, and masking in both places would only complicate this diff. Gated on a new `RESParams.enable_hbm_streaming`, default off with no setter.

Reviewed By: chouxi

Differential Revision: D116893818


