### PR TITLE
Resolve remaining checked-in unused parameters (#6201)

### DIFF
--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_cpu.cpp
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_cpu.cpp
@@ -44,7 +44,6 @@ void split_embedding_forward_cpu_kernel(
     Tensor weights,
     Tensor weights_offsets,
     Tensor D_offsets,
-    c10::SymInt total_D,
     Tensor hash_size_cumsum,
     Tensor indices,
     Tensor offsets,
@@ -241,7 +240,6 @@ Tensor split_embedding_codegen_forward_cpu(
                               weights,
                               weights_offsets,
                               D_offsets,
-                              total_D,
                               hash_size_cumsum,
                               indices,
                               offsets,
@@ -257,13 +255,13 @@ Tensor split_embedding_codegen_forward_cpu(
 
 Tensor split_embedding_codegen_forward_cpu_meta(
     Tensor weights,
-    Tensor weights_offsets,
+    [[maybe_unused]] Tensor weights_offsets,
     Tensor D_offsets,
     c10::SymInt total_D,
-    Tensor hash_size_cumsum,
-    Tensor indices,
+    [[maybe_unused]] Tensor hash_size_cumsum,
+    [[maybe_unused]] Tensor indices,
     Tensor offsets,
-    int64_t pooling_mode,
+    [[maybe_unused]] int64_t pooling_mode,
     Tensor indice_weights,
     int64_t output_dtype) {
   c10::SymInt T = D_offsets.sym_numel() - 1;

--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
@@ -198,7 +198,7 @@ void _bounds_check_indices_cuda_v1(
     Tensor& offsets,
     BoundsCheckMode bounds_check_mode,
     Tensor& warning,
-    const std::optional<Tensor>& weights,
+    const std::optional<Tensor>& /*weights*/,
     const std::optional<Tensor>& B_offsets,
     int64_t max_B,
     const std::optional<Tensor>& /*b_t_map*/,

--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
@@ -215,7 +215,7 @@ void _bounds_check_indices_cuda_v2(
     Tensor& offsets,
     BoundsCheckMode bounds_check_mode,
     Tensor& warning,
-    const std::optional<Tensor>& weights,
+    const std::optional<Tensor>& /*weights*/,
     const std::optional<Tensor>& B_offsets,
     int64_t /*max_B*/,
     const std::optional<Tensor>& b_t_map,

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/bf16_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/bf16_grouped_gemm.hip
@@ -17,6 +17,7 @@
 #include <unordered_map>
 
 #include <ATen/ATen.h>
+#include <c10/cuda/CUDAException.h>
 #include <c10/hip/HIPStream.h>
 
 #include "ck/ck.hpp"
@@ -217,11 +218,11 @@ void set_static_kernel_args(
       ggemm_kargs.push_back(group_args);
     }
     // Copy data onto device.
-    hipMemcpy(
+    C10_CUDA_CHECK(hipMemcpy(
         kernel_args.data_ptr(), // Destination
         ggemm_kargs.data(), // Source
         sizeof(KernelArguments) * group_count, // Number of bytes
-        hipMemcpyHostToDevice); // Copy Type
+        hipMemcpyHostToDevice)); // Copy Type
   } else {
     // Launch a kernel for each group to set kernel memory on device.
     // Using multiple kernels this way allows us to support arbitrary M,N,K.

--- a/fbgemm_gpu/src/faster_hash_ops/faster_hash.cpp
+++ b/fbgemm_gpu/src/faster_hash_ops/faster_hash.cpp
@@ -324,7 +324,7 @@ std::tuple<Tensor, Tensor> zero_collision_hash_cpu(
     int64_t opt_in_prob,
     int64_t num_reserved_slots,
     const std::optional<Tensor>& opt_in_rands,
-    const std::optional<Tensor>& runtime_meta) {
+    const std::optional<Tensor>& /* runtime_meta */) {
   TORCH_CHECK(exp_hours == -1);
   TORCH_CHECK(readonly);
   TORCH_CHECK(metadata.has_value() == false);

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops.cu
@@ -65,7 +65,7 @@ Tensor permute_pooled_embs_gpu_impl(
     const Tensor& offset_dim_list,
     const Tensor& permute_list,
     const Tensor& inv_offset_dim_list,
-    const Tensor& inv_permute_list,
+    [[maybe_unused]] const Tensor& inv_permute_list,
     const bool& allow_duplicates = false) {
   if (pooled_embs.numel() == 0) {
     return pooled_embs;

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split.cu
@@ -65,7 +65,7 @@ Tensor permute_pooled_embs_split_gpu_impl(
     const Tensor& offset_dim_list,
     const Tensor& permute_list,
     const Tensor& inv_offset_dim_list,
-    const Tensor& inv_permute_list,
+    [[maybe_unused]] const Tensor& inv_permute_list,
     const bool& allow_duplicates) {
   if (pooled_embs.numel() == 0) {
     return pooled_embs;

--- a/fbgemm_gpu/src/quantize_ops/quantize_msfp.cu
+++ b/fbgemm_gpu/src/quantize_ops/quantize_msfp.cu
@@ -204,9 +204,9 @@ DLL_PUBLIC at::Tensor _float_to_msfp_gpu(
 /// @return A new tensor with values from the input tensor converted to `float`.
 DLL_PUBLIC at::Tensor _msfp_to_float_gpu(
     const at::Tensor& input,
-    const int64_t ebits,
-    const int64_t mbits,
-    const int64_t bias) {
+    [[maybe_unused]] const int64_t ebits,
+    [[maybe_unused]] const int64_t mbits,
+    [[maybe_unused]] const int64_t bias) {
   TENSOR_ON_CUDA_GPU(input);
 
   // Because float_to_msfp is a fakequant operator,


### PR DESCRIPTION
Summary:
NOTE: No linked task. Please associate a task with this diff.

Resolve the remaining handwritten and static-TBE unused-parameter warnings.

This covers the static CPU/Meta forward path, both bounds-check variants, paired permute-pooled implementations, MSFP conversion, and faster-hash fallback. The required faster-hash umbrella dependency is marked `# manual` so autodeps retains the header provider.

X-link: https://github.com/facebookresearch/FBGEMM/pull/3106


GitHub PR: https://github.com/pytorch/FBGEMM/pull/6201

Reviewed By: gchalump

Differential Revision: D117024950


