### PR TITLE
Fix three -Wunused-variable sites in HIP-built sources

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/moe/index_shuffling.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/moe/index_shuffling.cu
@@ -634,7 +634,11 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> index_shuffling_torch(
   kernel = (void*)index_shuffling_kernel<DataType, IndexType, E, B, K>; \
   smem_size = sizeof(SharedStorage<DataType, IndexType, E, B, K>);
 
-        int storage_factor = top_k * num_experts;
+        // Used only by the CUDA `num_tokens_per_tile` computation below; the
+        // ROCm DISPATCH_E_* macros take it and discard it, so it is unused
+        // there. Marked rather than moved because both paths still name it
+        // as a macro argument.
+        [[maybe_unused]] int storage_factor = top_k * num_experts;
 
         if (num_experts == 16) {
           DISPATCH_E_16(kNumTokensPerTileFewExperts, top_k, storage_factor)

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/bf16_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/bf16_grouped_gemm.hip
@@ -479,7 +479,6 @@ at::Tensor bf16bf16bf16_grouped_dynamic(
   int64_t group_count = A.size(0);
   int64_t M = A.size(1);
   int64_t N = B.size(1);
-  int64_t K = B.size(2);
   TORCH_CHECK(A.is_cuda() && A.is_contiguous());
   TORCH_CHECK(A.dim() == 3, "Inputs must be 3D [G, M, K].");
   TORCH_CHECK(A.dtype() == at::kBFloat16, "Inputs must be type bfloat16.");

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cu
@@ -1128,8 +1128,8 @@ void invokeComputeScalesAndQuantizeMatrix(
 #endif
   auto const shmem_size = lda * sizeof(T_IN);
   if (shmem_size >= (48 << 10)) {
-    cudaError_t ret;
 #ifndef USE_ROCM
+    cudaError_t ret;
     if (stochastic_rounding) {
       ret = cudaFuncSetAttribute(
           dynamicQuantizeMatrixRowwiseStoc<SCALE, T_OUT, T_S, T_IN>,


### PR DESCRIPTION
Summary:
Fixes the `-Wunused-variable` diagnostics in HIP-built sources that are **not**
demoted by a `-Wno-error=` and therefore become hard errors once `-Werror` is
restored on HIP.

Each of the three needed a different fix, because "unused variable" meant something
different in each case. None of them are actually dead code in every configuration.

**1. `moe/index_shuffling.cu` -- `storage_factor` -> `[[maybe_unused]]`**

It *is* used on CUDA, by the `num_tokens_per_tile` computation, but that block sits
under `#ifndef USE_ROCM`; the ROCm branch keys off `num_experts` instead. Meanwhile
the ROCm `DISPATCH_E_*` macros take the value as parameter `S` and discard it. So the
variable is genuinely unused on ROCm and genuinely used on CUDA.

Marked rather than moved or `#ifdef`-ed: both paths still name it as a macro
argument, so relocating the declaration would mean duplicating it or widening the
guard around unrelated code.

**2. `quantize/quantize.cu` -- `ret` moved inside `#ifndef USE_ROCM`**

Declared just above the guard, but its only assignments and its only read
(`use_shmem = ret == cudaSuccess`) are all inside `#ifndef USE_ROCM`; the ROCm branch
just sets `use_shmem = false`. The declaration belongs in the block. This is a pure
move -- no `[[maybe_unused]]` needed, and the CUDA path is untouched.

**3. `ck_extensions/bf16_grouped/bf16_grouped_gemm.hip` -- dead `K` removed**

`int64_t K = B.size(2);` with no reader. `M` and `N` next to it are both used; `K`
only appears in `TORCH_CHECK` message strings, which are string literals and do not
reference the variable. HIP-only file, so no dual-path concern -- deleted.

**This is partial.** The census that scoped this covered only 13% of the build before
the ROCm job timed out, so more `-Wunused-variable` sites may appear once it
completes.

Reviewed By: cthi

Differential Revision: D115963368


