### PR TITLE
Fix differing_executors health check failures in quantize tests

### DIFF
--- a/fbgemm_gpu/test/quantize/bfloat16_test.py
+++ b/fbgemm_gpu/test/quantize/bfloat16_test.py
@@ -12,7 +12,7 @@ from ctypes import c_float, c_int32, cast, POINTER, pointer
 import hypothesis.strategies as st
 import numpy as np
 import torch
-from hypothesis import given, HealthCheck, settings
+from hypothesis import given, settings
 
 from . import common  # noqa E402
 
@@ -27,7 +27,7 @@ class SparseNNOperatorsGPUTest(unittest.TestCase):
         k=st.integers(min_value=2, max_value=2),
         n=st.integers(min_value=2, max_value=2),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_dense_mlp_quantize_ops(
         self, precision: str, batch_size: int, k: int, n: int
     ) -> None:
@@ -64,7 +64,7 @@ class TestBfloat16QuantizationConversion(unittest.TestCase):
         nrows=st.integers(min_value=0, max_value=100),
         ncols=st.integers(min_value=0, max_value=100),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_op(self, nrows: int, ncols: int) -> None:
         input_data = torch.rand(nrows, ncols).float()
         quantized_data = torch.ops.fbgemm.FloatToBfloat16Quantized(input_data)
@@ -91,7 +91,7 @@ class TestBfloat16QuantizationConversion(unittest.TestCase):
         nrows=st.integers(min_value=0, max_value=100),
         ncols=st.integers(min_value=0, max_value=100),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_and_dequantize_op(self, nrows: int, ncols: int) -> None:
         input_data = torch.rand(nrows, ncols).float()
         quantized_data = torch.ops.fbgemm.FloatToBfloat16Quantized(input_data)
@@ -129,7 +129,7 @@ class TestBfloat16QuantizationConversion(unittest.TestCase):
     @given(
         ncols_nrows=st.sampled_from([(65540, 256), (256, 65540)]),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_and_dequantize_op_cuda_large_nrows_bf16(
         self, ncols_nrows: tuple[int, int]
     ) -> None:

--- a/fbgemm_gpu/test/quantize/common.py
+++ b/fbgemm_gpu/test/quantize/common.py
@@ -14,6 +14,7 @@ import fbgemm_gpu
 import numpy as np
 import numpy.typing as npt
 import torch
+from hypothesis import HealthCheck, settings
 
 # pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
 # pyre-fixme[35]: Target cannot be annotated.
@@ -25,6 +26,25 @@ try:
 
 except Exception:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
+
+suppressed_list: list[HealthCheck] = [
+    HealthCheck.filter_too_much,
+    HealthCheck.data_too_large,
+] + (
+    [HealthCheck.differing_executors]
+    if getattr(HealthCheck, "differing_executors", False)
+    else []
+)
+
+# Only the health checks are set here, deliberately. Registering this as the
+# `derandomize` profile (as `test/tbe/common.py` and `test/test_utils.py` do)
+# would also force `derandomize=True` onto `bfloat16_test` and `hfp8_test`,
+# the two quantize modules that do not import `test_utils` and therefore never
+# ran derandomized. Seeding behavior is unrelated to the health check fix.
+settings.register_profile(
+    "suppress_differing_executors_check", suppress_health_check=suppressed_list
+)
+settings.load_profile("suppress_differing_executors_check")
 
 # Eigen/Python round 0.5 away from 0, Numpy rounds to even
 round_to_nearest: Callable[[npt.NDArray], npt.NDArray] = np.vectorize(round)

--- a/fbgemm_gpu/test/quantize/fused_8bit_rowwise_test.py
+++ b/fbgemm_gpu/test/quantize/fused_8bit_rowwise_test.py
@@ -12,7 +12,7 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from hypothesis import assume, given, HealthCheck, settings
+from hypothesis import assume, given, settings
 
 from . import common  # noqa E402
 
@@ -50,7 +50,7 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
         is_half=st.booleans(),
         test_float_or_half_op=st.booleans(),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_op(
         self,
         nrows: int,
@@ -337,7 +337,7 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
         ),
         test_generic_op=st.booleans(),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_and_dequantize_op_cpu(  # noqa: C901
         self,
         nrows: int,
@@ -362,7 +362,7 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
         ),
         test_generic_op=st.booleans(),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_and_dequantize_op_cuda(  # noqa: C901
         self,
         nrows: int,

--- a/fbgemm_gpu/test/quantize/fused_nbit_rowwise_test.py
+++ b/fbgemm_gpu/test/quantize/fused_nbit_rowwise_test.py
@@ -12,7 +12,7 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from hypothesis import assume, given, HealthCheck, settings
+from hypothesis import assume, given, settings
 
 from . import common  # noqa E402
 
@@ -54,7 +54,7 @@ class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):
         is_half=st.booleans(),
         test_float_or_half_op=st.booleans(),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_op(
         self,
         nrows: int,
@@ -156,7 +156,7 @@ class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):
         test_meta=st.booleans(),
         test_cuda=st.booleans(),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_and_dequantize_op(
         self,
         nrows: int,
@@ -364,7 +364,7 @@ class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):
             [SparseType.BF16]
         ),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_and_dequantize_op_cpu_and_cuda(
         self,
         nrows: int,

--- a/fbgemm_gpu/test/quantize/hfp8_test.py
+++ b/fbgemm_gpu/test/quantize/hfp8_test.py
@@ -10,7 +10,7 @@ import unittest
 
 import hypothesis.strategies as st
 import torch
-from hypothesis import given, HealthCheck, settings
+from hypothesis import given, settings
 from torch import Tensor
 
 from . import common  # noqa E402
@@ -75,7 +75,7 @@ class TestHFP8QuantizationConversion(unittest.TestCase):
         ncols=st.integers(min_value=1, max_value=100),
         exponent_bias=st.integers(min_value=4, max_value=7),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_and_dequantize_op(
         self, nrows: int, ncols: int, exponent_bias: int
     ) -> None:

--- a/fbgemm_gpu/test/quantize/mixed_dim_int8_test.py
+++ b/fbgemm_gpu/test/quantize/mixed_dim_int8_test.py
@@ -12,7 +12,7 @@ import unittest
 import hypothesis.strategies as st
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from hypothesis import given, HealthCheck, settings
+from hypothesis import given, settings
 
 from . import common  # noqa E402
 
@@ -56,7 +56,7 @@ class TestMixedDimInt8DequantizationConversion(unittest.TestCase):
         min_dim=st.just(1),
         max_dim=st.just(100),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_mixed_dim_8bit_dequantize_op(
         self,
         B: int,
@@ -79,7 +79,7 @@ class TestMixedDimInt8DequantizationConversion(unittest.TestCase):
         min_dim=st.just(100),
         max_dim=st.just(1000),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_mixed_dim_8bit_dequantize_op_large_dims(
         self,
         B: int,
@@ -102,7 +102,7 @@ class TestMixedDimInt8DequantizationConversion(unittest.TestCase):
         min_dim=st.just(1),
         max_dim=st.just(100),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_mixed_dim_8bit_dequantize_op_large_rows(
         self,
         B: int,

--- a/fbgemm_gpu/test/quantize/msfp_test.py
+++ b/fbgemm_gpu/test/quantize/msfp_test.py
@@ -10,7 +10,7 @@ import unittest
 
 import hypothesis.strategies as st
 import torch
-from hypothesis import given, HealthCheck, settings
+from hypothesis import given, settings
 
 from . import common  # noqa E402
 
@@ -34,7 +34,7 @@ class TestMSFPQuantizationConversion(unittest.TestCase):
         nrows=st.integers(min_value=0, max_value=100),
         ncols=st.integers(min_value=0, max_value=100),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_op(self, nrows: int, ncols: int) -> None:
         ebits = 8
         mbits = 7


### PR DESCRIPTION
Summary:
`quantize:fused_8bit_rowwise` and `quantize:fused_nbit_rowwise` fail with 9 and
8 `hypothesis.errors.FailedHealthCheck` errors respectively:

```
hypothesis.errors.FailedHealthCheck: The method
TestFused8BitRowwiseQuantizationConversion.test_quantize_op was called from
multiple different executors.
```

Root cause: `optests.generate_opcheck_tests` wraps each `given` method with
`test_faketensor__` / `test_schema__` variants, which Hypothesis sees as
differing executors. `fbgemm_gpu/test/test_utils.py` already registers a profile
whose `suppress_health_check` covers `differing_executors`, but every affected
test carried a per-test override:

```
settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
```

`settings(suppress_health_check=...)` *replaces* the profile's list rather than
extending it, so the per-test override silently dropped `differing_executors`.
Exactly the two quantize files that combine `generate_opcheck_tests` with a
per-test override are the two that fail; `fp8_rowwise` and `mx4` also use
opcheck generation but have no override, and both pass.

Fix, mirroring what D108096684 did for `test/tbe`:

- Register the shared `suppressed_list` in `test/quantize/common.py`, so
  `quantize` is no longer the one suite without it.
- Drop the per-test `suppress_health_check` overrides across the quantize suite
  so the profile's list applies. `filter_too_much` and `data_too_large` remain
  suppressed via the profile, so behavior is preserved for tests that already
  passed.

**Profile shape: health checks only, no `derandomize`.** This follows
`test/jagged/common.py` and `test/sparse/common.py`, which register
`suppress_differing_executors_check` with only `suppress_health_check` -- not
`test/tbe/common.py` and `test/test_utils.py`, which register a `derandomize`
profile with `derandomize=True`. Using the `derandomize` shape here would also
have forced `derandomize=True` onto `bfloat16_test` and `hfp8_test`, the only
two quantize modules that do not import `test_utils` and therefore never ran
derandomized. Seeding behavior is unrelated to this fix, so it is left alone.

Measured effect on the resolved settings of all 48 Hypothesis-decorated tests
across the nine quantize modules, before vs after:

| Change | Count |
| --- | ---: |
| Tests that gained `filter_too_much` | 0 |
| Tests that lost `filter_too_much` | 0 |
| Tests that gained `differing_executors` + `data_too_large` | 33 |
| Tests whose `derandomize` changed | 0 |

The 33 are the six modules whose per-test overrides were removed. `comm_codec`
is unaffected (it does not import `common`); `fp8_rowwise` and `mx4` already
resolved to the full list via `test_utils`.

Reviewed By: gchalump

Differential Revision: D116987604


