### PR TITLE
Register Meta kernels for get_unique_indices and get_unique_indices_with_inverse

### DIFF
--- a/fbgemm_gpu/src/split_embeddings_cache/common.h
+++ b/fbgemm_gpu/src/split_embeddings_cache/common.h
@@ -139,4 +139,16 @@ get_unique_indices_with_inverse_cpu(
     const bool compute_count,
     const bool compute_inverse_indices);
 
+std::tuple<Tensor, Tensor, std::optional<Tensor>> get_unique_indices_meta(
+    const Tensor& linear_indices,
+    const int64_t max_indices,
+    const bool compute_count);
+
+std::tuple<Tensor, Tensor, std::optional<Tensor>, std::optional<Tensor>>
+get_unique_indices_with_inverse_meta(
+    const Tensor& linear_indices,
+    const int64_t max_indices,
+    const bool compute_count,
+    const bool compute_inverse_indices);
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cpp
@@ -196,4 +196,43 @@ get_unique_indices_with_inverse_cpu(
       linear_indices, max_indices, compute_count, compute_inverse_indices);
 }
 
+DLL_PUBLIC
+std::tuple<Tensor, Tensor, std::optional<Tensor>, std::optional<Tensor>>
+get_unique_indices_with_inverse_meta(
+    const Tensor& linear_indices,
+    const int64_t /*max_indices*/,
+    const bool compute_count,
+    const bool compute_inverse_indices) {
+  TORCH_CHECK(linear_indices.dim() == 1, "linear_indices must be 1D");
+
+  // The unique count is data-dependent, but the buffers are not: both the CPU
+  // and CUDA kernels size unique_indices/count/inverse to the full input length
+  // and report the real count separately via unique_indices_length.
+  const auto N = linear_indices.numel();
+  const auto int_options = linear_indices.options().dtype(at::kInt);
+
+  return std::tuple{
+      at::empty_like(linear_indices),
+      at::empty({1}, int_options),
+      compute_count ? std::optional<Tensor>(at::empty({N}, int_options))
+                    : std::nullopt,
+      compute_inverse_indices
+          ? std::optional<Tensor>(at::empty({N}, int_options))
+          : std::nullopt};
+}
+
+DLL_PUBLIC
+std::tuple<Tensor, Tensor, std::optional<Tensor>> get_unique_indices_meta(
+    const Tensor& linear_indices,
+    const int64_t max_indices,
+    const bool compute_count) {
+  const auto ret = get_unique_indices_with_inverse_meta(
+      linear_indices,
+      max_indices,
+      compute_count,
+      /*compute_inverse_indices=*/false);
+
+  return {std::get<0>(ret), std::get<1>(ret), std::get<2>(ret)};
+}
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
@@ -75,6 +75,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 
   DISPATCH_TO_META("linearize_cache_indices", linearize_cache_indices_meta);
   DISPATCH_TO_META("lxu_cache_lookup", lxu_cache_lookup_meta);
+  DISPATCH_TO_META("get_unique_indices", get_unique_indices_meta);
+  DISPATCH_TO_META(
+      "get_unique_indices_with_inverse", get_unique_indices_with_inverse_meta);
 }
 
 auto raw_embedding_streamer =

--- a/fbgemm_gpu/test/quantize/bfloat16_test.py
+++ b/fbgemm_gpu/test/quantize/bfloat16_test.py
@@ -12,7 +12,7 @@ from ctypes import c_float, c_int32, cast, POINTER, pointer
 import hypothesis.strategies as st
 import numpy as np
 import torch
-from hypothesis import given, HealthCheck, settings
+from hypothesis import given, settings
 
 from . import common  # noqa E402
 
@@ -27,7 +27,7 @@ class SparseNNOperatorsGPUTest(unittest.TestCase):
         k=st.integers(min_value=2, max_value=2),
         n=st.integers(min_value=2, max_value=2),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_dense_mlp_quantize_ops(
         self, precision: str, batch_size: int, k: int, n: int
     ) -> None:
@@ -64,7 +64,7 @@ class TestBfloat16QuantizationConversion(unittest.TestCase):
         nrows=st.integers(min_value=0, max_value=100),
         ncols=st.integers(min_value=0, max_value=100),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_op(self, nrows: int, ncols: int) -> None:
         input_data = torch.rand(nrows, ncols).float()
         quantized_data = torch.ops.fbgemm.FloatToBfloat16Quantized(input_data)
@@ -91,7 +91,7 @@ class TestBfloat16QuantizationConversion(unittest.TestCase):
         nrows=st.integers(min_value=0, max_value=100),
         ncols=st.integers(min_value=0, max_value=100),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_and_dequantize_op(self, nrows: int, ncols: int) -> None:
         input_data = torch.rand(nrows, ncols).float()
         quantized_data = torch.ops.fbgemm.FloatToBfloat16Quantized(input_data)
@@ -129,7 +129,7 @@ class TestBfloat16QuantizationConversion(unittest.TestCase):
     @given(
         ncols_nrows=st.sampled_from([(65540, 256), (256, 65540)]),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_and_dequantize_op_cuda_large_nrows_bf16(
         self, ncols_nrows: tuple[int, int]
     ) -> None:

--- a/fbgemm_gpu/test/quantize/common.py
+++ b/fbgemm_gpu/test/quantize/common.py
@@ -14,6 +14,7 @@ import fbgemm_gpu
 import numpy as np
 import numpy.typing as npt
 import torch
+from hypothesis import HealthCheck, settings
 
 # pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
 # pyre-fixme[35]: Target cannot be annotated.
@@ -25,6 +26,20 @@ try:
 
 except Exception:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
+
+suppressed_list: list[HealthCheck] = [
+    HealthCheck.filter_too_much,
+    HealthCheck.data_too_large,
+] + (
+    [HealthCheck.differing_executors]
+    if getattr(HealthCheck, "differing_executors", False)
+    else []
+)
+
+settings.register_profile(
+    "derandomize", derandomize=True, suppress_health_check=suppressed_list
+)
+settings.load_profile("derandomize")
 
 # Eigen/Python round 0.5 away from 0, Numpy rounds to even
 round_to_nearest: Callable[[npt.NDArray], npt.NDArray] = np.vectorize(round)

--- a/fbgemm_gpu/test/quantize/fused_8bit_rowwise_test.py
+++ b/fbgemm_gpu/test/quantize/fused_8bit_rowwise_test.py
@@ -12,7 +12,7 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from hypothesis import assume, given, HealthCheck, settings
+from hypothesis import assume, given, settings
 
 from . import common  # noqa E402
 
@@ -50,7 +50,7 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
         is_half=st.booleans(),
         test_float_or_half_op=st.booleans(),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_op(
         self,
         nrows: int,
@@ -337,7 +337,7 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
         ),
         test_generic_op=st.booleans(),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_and_dequantize_op_cpu(  # noqa: C901
         self,
         nrows: int,
@@ -362,7 +362,7 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
         ),
         test_generic_op=st.booleans(),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_and_dequantize_op_cuda(  # noqa: C901
         self,
         nrows: int,

--- a/fbgemm_gpu/test/quantize/fused_nbit_rowwise_test.py
+++ b/fbgemm_gpu/test/quantize/fused_nbit_rowwise_test.py
@@ -12,7 +12,7 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from hypothesis import assume, given, HealthCheck, settings
+from hypothesis import assume, given, settings
 
 from . import common  # noqa E402
 
@@ -54,7 +54,7 @@ class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):
         is_half=st.booleans(),
         test_float_or_half_op=st.booleans(),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_op(
         self,
         nrows: int,
@@ -156,7 +156,7 @@ class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):
         test_meta=st.booleans(),
         test_cuda=st.booleans(),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_and_dequantize_op(
         self,
         nrows: int,
@@ -364,7 +364,7 @@ class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):
             [SparseType.BF16]
         ),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_and_dequantize_op_cpu_and_cuda(
         self,
         nrows: int,

--- a/fbgemm_gpu/test/quantize/hfp8_test.py
+++ b/fbgemm_gpu/test/quantize/hfp8_test.py
@@ -10,7 +10,7 @@ import unittest
 
 import hypothesis.strategies as st
 import torch
-from hypothesis import given, HealthCheck, settings
+from hypothesis import given, settings
 from torch import Tensor
 
 from . import common  # noqa E402
@@ -75,7 +75,7 @@ class TestHFP8QuantizationConversion(unittest.TestCase):
         ncols=st.integers(min_value=1, max_value=100),
         exponent_bias=st.integers(min_value=4, max_value=7),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_and_dequantize_op(
         self, nrows: int, ncols: int, exponent_bias: int
     ) -> None:

--- a/fbgemm_gpu/test/quantize/mixed_dim_int8_test.py
+++ b/fbgemm_gpu/test/quantize/mixed_dim_int8_test.py
@@ -12,7 +12,7 @@ import unittest
 import hypothesis.strategies as st
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from hypothesis import given, HealthCheck, settings
+from hypothesis import given, settings
 
 from . import common  # noqa E402
 
@@ -56,7 +56,7 @@ class TestMixedDimInt8DequantizationConversion(unittest.TestCase):
         min_dim=st.just(1),
         max_dim=st.just(100),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_mixed_dim_8bit_dequantize_op(
         self,
         B: int,
@@ -79,7 +79,7 @@ class TestMixedDimInt8DequantizationConversion(unittest.TestCase):
         min_dim=st.just(100),
         max_dim=st.just(1000),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_mixed_dim_8bit_dequantize_op_large_dims(
         self,
         B: int,
@@ -102,7 +102,7 @@ class TestMixedDimInt8DequantizationConversion(unittest.TestCase):
         min_dim=st.just(1),
         max_dim=st.just(100),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_mixed_dim_8bit_dequantize_op_large_rows(
         self,
         B: int,

--- a/fbgemm_gpu/test/quantize/msfp_test.py
+++ b/fbgemm_gpu/test/quantize/msfp_test.py
@@ -10,7 +10,7 @@ import unittest
 
 import hypothesis.strategies as st
 import torch
-from hypothesis import given, HealthCheck, settings
+from hypothesis import given, settings
 
 from . import common  # noqa E402
 
@@ -34,7 +34,7 @@ class TestMSFPQuantizationConversion(unittest.TestCase):
         nrows=st.integers(min_value=0, max_value=100),
         ncols=st.integers(min_value=0, max_value=100),
     )
-    @settings(deadline=None, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(deadline=None)
     def test_quantize_op(self, nrows: int, ncols: int) -> None:
         ebits = 8
         mbits = 7


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3095

`tbe:cache`, `tbe:forward` and `tbe:forward_backend_bc` fail their optest
faketensor/schema variants with:

```
NotImplementedError: fbgemm::get_unique_indices: attempted to run this operator
with Meta tensors, but there was no fake impl or Meta kernel registered.
```

`split_embeddings_cache_ops.cpp` registers Meta kernels for
`linearize_cache_indices` and `lxu_cache_lookup`, but never did for
`get_unique_indices` / `get_unique_indices_with_inverse`, so any
`test_faketensor__` / `test_schema__` variant that reaches them dies.

Both ops have fully static output shapes, so the Meta kernels are exact rather
than approximate. The unique *count* is data-dependent, but the *buffers* are
not: the CPU (`get_unique_indices_cpu_impl`) and CUDA
(`get_unique_indices_cuda_impl`) paths both size the outputs off the input
length and report the real count separately through `unique_indices_length`:

| Output | Shape | Dtype |
| --- | --- | --- |
| `unique_indices` | `(N,)` (`empty_like(linear_indices)`) | `linear_indices.dtype` |
| `unique_indices_length` | `(1,)` | `int32` |
| `unique_indices_count` (if `compute_count`) | `(N,)` | `int32` |
| `linear_index_positions_sorted` (if `compute_inverse_indices`) | `(N,)` | `int32` |

`get_unique_indices_meta` delegates to `get_unique_indices_with_inverse_meta`
with `compute_inverse_indices=false` and drops the trailing element, mirroring
how `get_unique_indices_cpu` delegates to `get_unique_indices_cpu_impl`.

Reviewed By: q10

Differential Revision: D116990337


