### PR TITLE
Skip the unused offsets arange on the CPU nobag TBE fast path (#6213)

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
@@ -388,11 +388,19 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
                 const int32_t output_stride = {{ "total_D" if not nobag else "adjusted_D" }};
 
                 {% if nobag %}
-                // Create virtual offsets for the nobag case. Lengths are all ones.
-                const auto offsets_nobag = at::arange(*offsets_begin_ptr, offsets_acc[(t + 1) * B] + 1, offsets.options());
-                const index_t* offsets_nobag_ptr = offsets_nobag.const_data_ptr<index_t>();
-                TORCH_CHECK(offsets_nobag.numel() == index_size + 1);
-                TORCH_CHECK(offsets_nobag_ptr[index_size] - offsets_nobag_ptr[0] == index_size);
+                TORCH_CHECK(index_size >= 0, "offsets must be non-decreasing, got index_size ", index_size, " for table ", t);
+                // Virtual offsets for the nobag case. Lengths are all ones. Materialized
+                // lazily: a kernel generated with no_bag gathers rows straight from
+                // `indices` and never dereferences offsets, so building them for those
+                // kernels is an allocation plus an index_size-sized fill of pure overhead.
+                Tensor offsets_nobag;
+                const auto make_virtual_offsets = [&]() {
+                  offsets_nobag = at::arange(*offsets_begin_ptr, offsets_acc[(t + 1) * B] + 1, offsets.options());
+                  const index_t* offsets_nobag_ptr = offsets_nobag.const_data_ptr<index_t>();
+                  TORCH_CHECK(offsets_nobag.numel() == index_size + 1);
+                  TORCH_CHECK(offsets_nobag_ptr[index_size] - offsets_nobag_ptr[0] == index_size);
+                  return offsets_nobag_ptr;
+                };
                 {% endif %}
 
                 const float* indice_weights_ptr = nullptr;
@@ -414,7 +422,16 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
                 {% endif %}
                 // TODO: merge nobag int8 path with normal asmjit dispatch
                 {% if nobag %}
-                    const index_t* offset_ptr = (output_is_int8)? offsets_begin_ptr: offsets_nobag_ptr;
+                    {% if use_fp8 %}
+                    // {{ kernel_name }} takes no no_bag argument, so it always runs the
+                    // bagged path and always dereferences offsets.
+                    const index_t* offset_ptr = make_virtual_offsets();
+                    {% else %}
+                    // {{ kernel_name }} is generated with /*no_bag=*/nobag_op below. Under
+                    // no_bag it ignores offsets, so hand it the real (unused) ones rather
+                    // than paying to build the virtual ones.
+                    const index_t* offset_ptr = nobag_op ? offsets_begin_ptr : make_virtual_offsets();
+                    {% endif %}
                 {% else %}
                     const index_t* offset_ptr = offsets_begin_ptr;
                 {% endif %}

--- a/fbgemm_gpu/test/tbe/inference/common.py
+++ b/fbgemm_gpu/test/tbe/inference/common.py
@@ -24,6 +24,7 @@ from fbgemm_gpu.tbe.utils import (
     b_indices,
     fake_quantize_embs,
     get_table_batched_offsets_from_dense,
+    quantize_embs,
     round_up,
     to_device,
 )
@@ -52,6 +53,19 @@ def get_nbit_weights_ty(draw) -> SparseType | None:
             ]
         )
     )
+
+
+FP8_EXPONENT_BITS: int = 4
+FP8_EXPONENT_BIAS: int = 7
+
+
+def nbit_output_to_float(output: torch.Tensor) -> torch.Tensor:
+    """Bring a TBE output tensor into a dtype that compares elementwise."""
+    if output.dtype == torch.quint4x2:
+        return torch.ops.fbgemm.FusedNBitRowwiseQuantizedSBHalfFrontToFloatOrHalf(
+            output.cpu(), bit_rate=4, output_dtype=0
+        )
+    return output.cpu().float()
 
 
 class NBitFowardTestCommon(unittest.TestCase):
@@ -357,3 +371,116 @@ class NBitFowardTestCommon(unittest.TestCase):
             atol=1.0e-2,
             rtol=1.0e-2,
         )
+
+    def _make_cpu_seq_op(
+        self,
+        weights_ty: SparseType,
+        output_dtype: SparseType,
+        T: int,
+        E: int,
+        D: int,
+    ) -> IntNBitTableBatchedEmbeddingBagsCodegen:
+        """A CPU sequence-mode TBE whose rows hold finite, reproducible values.
+
+        ``fill_random_weights`` writes random *bytes*, and for the float weight
+        types those decode to NaN often enough that an exact output comparison
+        is meaningless. Quantizing a fixed pseudo-random float matrix instead
+        keeps every row finite.
+        """
+        fp8_config = (
+            FP8QuantizationConfig(FP8_EXPONENT_BITS, FP8_EXPONENT_BIAS)
+            if weights_ty == SparseType.FP8
+            else None
+        )
+        op = IntNBitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                ("", E, D, weights_ty, EmbeddingLocation.HOST) for _ in range(T)
+            ],
+            pooling_mode=PoolingMode.NONE,
+            output_dtype=output_dtype,
+            device="cpu",
+            fp8_exponent_bits=FP8_EXPONENT_BITS if fp8_config is not None else None,
+            fp8_exponent_bias=FP8_EXPONENT_BIAS if fp8_config is not None else None,
+        )
+        op.fill_random_weights()
+
+        generator = torch.Generator().manual_seed(0)
+        for t in range(T):
+            quant_weights, quant_scale_shift = quantize_embs(
+                torch.rand((E, D), generator=generator) * 2 - 1,
+                weights_ty,
+                fp8_config,
+            )
+            weights, scale_shift = op.split_embedding_weights()[t]
+            weights.copy_(quant_weights)
+            if quant_scale_shift is not None:
+                self.assertIsNotNone(scale_shift)
+                scale_shift.copy_(quant_scale_shift)
+        return op
+
+    def _check_nbit_forward_cpu_seq_ragged_matches_flat(
+        self,
+        weights_ty: SparseType,
+        output_dtype: SparseType,
+    ) -> None:
+        """A sequence forward depends only on the flat index sequence.
+
+        How those indices are grouped into bags must not change the result. The
+        CPU nobag path hands some kernels the real per-bag offsets (their no_bag
+        fast path never dereferences offsets) and others a virtual offsets
+        tensor whose lengths are all ones. Feeding the same indices first as
+        ragged bags and then one index per bag makes those two tensors differ in
+        length and in content, so a kernel handed the wrong one cannot agree
+        with itself across the two groupings.
+        """
+        T, E, D = 3, 64, 32
+        # Ragged, including empty bags. Every table must see the same number of
+        # indices, otherwise the two groupings would not slice the flat index
+        # sequence into the same per-table ranges.
+        lengths = [[0, 3, 1, 4], [2, 0, 1, 5], [4, 4, 0, 0]]
+        indices_per_table = sum(lengths[0])
+        self.assertTrue(all(sum(row) == indices_per_table for row in lengths))
+
+        op = self._make_cpu_seq_op(weights_ty, output_dtype, T, E, D)
+
+        indices = torch.tensor(
+            [(i * 7 + 3) % E for i in range(T * indices_per_table)], dtype=torch.int
+        )
+        ragged_offsets: list[int] = [0]
+        for table_lengths in lengths:
+            for length in table_lengths:
+                ragged_offsets.append(ragged_offsets[-1] + length)
+        self.assertEqual(ragged_offsets[-1], indices.numel())
+
+        ragged_output = op(indices, torch.tensor(ragged_offsets, dtype=torch.int))
+        flat_output = op(indices, torch.arange(indices.numel() + 1, dtype=torch.int))
+
+        self.assertEqual(ragged_output.shape, flat_output.shape)
+        torch.testing.assert_close(
+            nbit_output_to_float(ragged_output),
+            nbit_output_to_float(flat_output),
+            rtol=0,
+            atol=0,
+            equal_nan=False,
+        )
+
+    def _check_nbit_forward_cpu_seq_no_indices(
+        self,
+        weights_ty: SparseType,
+        output_dtype: SparseType,
+    ) -> None:
+        """A sequence forward whose bags are all empty returns an empty output.
+
+        Every table has an index range of length zero here, which is the
+        boundary at which the nobag path decides whether to build virtual
+        offsets at all.
+        """
+        T, E, D, B = 2, 64, 32, 4
+
+        op = self._make_cpu_seq_op(weights_ty, output_dtype, T, E, D)
+
+        output = op(
+            torch.empty(0, dtype=torch.int), torch.zeros(T * B + 1, dtype=torch.int)
+        )
+
+        self.assertEqual(output.shape[0], 0)

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -1450,6 +1450,31 @@ class NBitFowardTest(NBitFowardTestCommon):
             output_dtype=SparseType.INT4,
         )
 
+    def test_nbit_forward_cpu_seq_ragged_matches_flat(self) -> None:
+        for weights_ty, output_dtype in [
+            # One pair per kernel family the offsets predicate branches on:
+            # nbit taking the no_bag fast path (offsets ignored), nbit bagged
+            # and FP8 bagged (offsets dereferenced), and the base family, which
+            # the other three do not reach.
+            (SparseType.INT4, SparseType.INT4),
+            (SparseType.INT4, SparseType.FP16),
+            (SparseType.FP8, SparseType.FP16),
+            (SparseType.INT8, SparseType.FP32),
+        ]:
+            with self.subTest(weights_ty=weights_ty, output_dtype=output_dtype):
+                self._check_nbit_forward_cpu_seq_ragged_matches_flat(
+                    weights_ty, output_dtype
+                )
+
+    def test_nbit_forward_cpu_seq_no_indices(self) -> None:
+        for weights_ty, output_dtype in [
+            (SparseType.INT4, SparseType.INT4),
+            (SparseType.INT4, SparseType.FP16),
+            (SparseType.FP8, SparseType.FP16),
+        ]:
+            with self.subTest(weights_ty=weights_ty, output_dtype=output_dtype):
+                self._check_nbit_forward_cpu_seq_no_indices(weights_ty, output_dtype)
+
     @unittest.skipIf(*gpu_unavailable)
     @given(
         nbit_weights_ty=st.sampled_from(


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3099

The CPU nobag TBE allocated an `at::arange` offsets tensor on every forward, but the `no_bag` branch of every kernel family never dereferences offsets — 128 KB allocated, filled, and freed per forward on the serving hot path with no consumer.

Moved the allocation behind a `make_virtual_offsets()` lambda, called only by kernel families that actually read offsets (FP8 always; base/nbit only when `nobag_op` is unset). An upfront `TORCH_CHECK(index_size >= 0)` replaces the two checks that lived inside the allocation.

Behavior unchanged.

Reviewed By: q10

Differential Revision: D117267417


