### PR TITLE
Fix an off-by-one in the nbit nobag bounds check (#6215)

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
@@ -388,11 +388,19 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
                 const int32_t output_stride = {{ "total_D" if not nobag else "adjusted_D" }};
 
                 {% if nobag %}
-                // Create virtual offsets for the nobag case. Lengths are all ones.
-                const auto offsets_nobag = at::arange(*offsets_begin_ptr, offsets_acc[(t + 1) * B] + 1, offsets.options());
-                const index_t* offsets_nobag_ptr = offsets_nobag.const_data_ptr<index_t>();
-                TORCH_CHECK(offsets_nobag.numel() == index_size + 1);
-                TORCH_CHECK(offsets_nobag_ptr[index_size] - offsets_nobag_ptr[0] == index_size);
+                TORCH_CHECK(index_size >= 0, "offsets must be non-decreasing, got index_size ", index_size, " for table ", t);
+                // Virtual offsets for the nobag case. Lengths are all ones. Materialized
+                // lazily: a kernel generated with no_bag gathers rows straight from
+                // `indices` and never dereferences offsets, so building them for those
+                // kernels is an allocation plus an index_size-sized fill of pure overhead.
+                Tensor offsets_nobag;
+                const auto make_virtual_offsets = [&]() {
+                  offsets_nobag = at::arange(*offsets_begin_ptr, offsets_acc[(t + 1) * B] + 1, offsets.options());
+                  const index_t* offsets_nobag_ptr = offsets_nobag.const_data_ptr<index_t>();
+                  TORCH_CHECK(offsets_nobag.numel() == index_size + 1);
+                  TORCH_CHECK(offsets_nobag_ptr[index_size] - offsets_nobag_ptr[0] == index_size);
+                  return offsets_nobag_ptr;
+                };
                 {% endif %}
 
                 const float* indice_weights_ptr = nullptr;
@@ -414,7 +422,16 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
                 {% endif %}
                 // TODO: merge nobag int8 path with normal asmjit dispatch
                 {% if nobag %}
-                    const index_t* offset_ptr = (output_is_int8)? offsets_begin_ptr: offsets_nobag_ptr;
+                    {% if use_fp8 %}
+                    // {{ kernel_name }} takes no no_bag argument, so it always runs the
+                    // bagged path and always dereferences offsets.
+                    const index_t* offset_ptr = make_virtual_offsets();
+                    {% else %}
+                    // {{ kernel_name }} is generated with /*no_bag=*/nobag_op below. Under
+                    // no_bag it ignores offsets, so hand it the real (unused) ones rather
+                    // than paying to build the virtual ones.
+                    const index_t* offset_ptr = nobag_op ? offsets_begin_ptr : make_virtual_offsets();
+                    {% endif %}
                 {% else %}
                     const index_t* offset_ptr = offsets_begin_ptr;
                 {% endif %}

--- a/fbgemm_gpu/test/tbe/inference/common.py
+++ b/fbgemm_gpu/test/tbe/inference/common.py
@@ -24,6 +24,7 @@ from fbgemm_gpu.tbe.utils import (
     b_indices,
     fake_quantize_embs,
     get_table_batched_offsets_from_dense,
+    quantize_embs,
     round_up,
     to_device,
 )
@@ -52,6 +53,19 @@ def get_nbit_weights_ty(draw) -> SparseType | None:
             ]
         )
     )
+
+
+FP8_EXPONENT_BITS: int = 4
+FP8_EXPONENT_BIAS: int = 7
+
+
+def nbit_output_to_float(output: torch.Tensor) -> torch.Tensor:
+    """Bring a TBE output tensor into a dtype that compares elementwise."""
+    if output.dtype == torch.quint4x2:
+        return torch.ops.fbgemm.FusedNBitRowwiseQuantizedSBHalfFrontToFloatOrHalf(
+            output.cpu(), bit_rate=4, output_dtype=0
+        )
+    return output.cpu().float()
 
 
 class NBitFowardTestCommon(unittest.TestCase):
@@ -357,3 +371,116 @@ class NBitFowardTestCommon(unittest.TestCase):
             atol=1.0e-2,
             rtol=1.0e-2,
         )
+
+    def _make_cpu_seq_op(
+        self,
+        weights_ty: SparseType,
+        output_dtype: SparseType,
+        T: int,
+        E: int,
+        D: int,
+    ) -> IntNBitTableBatchedEmbeddingBagsCodegen:
+        """A CPU sequence-mode TBE whose rows hold finite, reproducible values.
+
+        ``fill_random_weights`` writes random *bytes*, and for the float weight
+        types those decode to NaN often enough that an exact output comparison
+        is meaningless. Quantizing a fixed pseudo-random float matrix instead
+        keeps every row finite.
+        """
+        fp8_config = (
+            FP8QuantizationConfig(FP8_EXPONENT_BITS, FP8_EXPONENT_BIAS)
+            if weights_ty == SparseType.FP8
+            else None
+        )
+        op = IntNBitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                ("", E, D, weights_ty, EmbeddingLocation.HOST) for _ in range(T)
+            ],
+            pooling_mode=PoolingMode.NONE,
+            output_dtype=output_dtype,
+            device="cpu",
+            fp8_exponent_bits=FP8_EXPONENT_BITS if fp8_config is not None else None,
+            fp8_exponent_bias=FP8_EXPONENT_BIAS if fp8_config is not None else None,
+        )
+        op.fill_random_weights()
+
+        generator = torch.Generator().manual_seed(0)
+        for t in range(T):
+            quant_weights, quant_scale_shift = quantize_embs(
+                torch.rand((E, D), generator=generator) * 2 - 1,
+                weights_ty,
+                fp8_config,
+            )
+            weights, scale_shift = op.split_embedding_weights()[t]
+            weights.copy_(quant_weights)
+            if quant_scale_shift is not None:
+                self.assertIsNotNone(scale_shift)
+                scale_shift.copy_(quant_scale_shift)
+        return op
+
+    def _check_nbit_forward_cpu_seq_ragged_matches_flat(
+        self,
+        weights_ty: SparseType,
+        output_dtype: SparseType,
+    ) -> None:
+        """A sequence forward depends only on the flat index sequence.
+
+        How those indices are grouped into bags must not change the result. The
+        CPU nobag path hands some kernels the real per-bag offsets (their no_bag
+        fast path never dereferences offsets) and others a virtual offsets
+        tensor whose lengths are all ones. Feeding the same indices first as
+        ragged bags and then one index per bag makes those two tensors differ in
+        length and in content, so a kernel handed the wrong one cannot agree
+        with itself across the two groupings.
+        """
+        T, E, D = 3, 64, 32
+        # Ragged, including empty bags. Every table must see the same number of
+        # indices, otherwise the two groupings would not slice the flat index
+        # sequence into the same per-table ranges.
+        lengths = [[0, 3, 1, 4], [2, 0, 1, 5], [4, 4, 0, 0]]
+        indices_per_table = sum(lengths[0])
+        self.assertTrue(all(sum(row) == indices_per_table for row in lengths))
+
+        op = self._make_cpu_seq_op(weights_ty, output_dtype, T, E, D)
+
+        indices = torch.tensor(
+            [(i * 7 + 3) % E for i in range(T * indices_per_table)], dtype=torch.int
+        )
+        ragged_offsets: list[int] = [0]
+        for table_lengths in lengths:
+            for length in table_lengths:
+                ragged_offsets.append(ragged_offsets[-1] + length)
+        self.assertEqual(ragged_offsets[-1], indices.numel())
+
+        ragged_output = op(indices, torch.tensor(ragged_offsets, dtype=torch.int))
+        flat_output = op(indices, torch.arange(indices.numel() + 1, dtype=torch.int))
+
+        self.assertEqual(ragged_output.shape, flat_output.shape)
+        torch.testing.assert_close(
+            nbit_output_to_float(ragged_output),
+            nbit_output_to_float(flat_output),
+            rtol=0,
+            atol=0,
+            equal_nan=False,
+        )
+
+    def _check_nbit_forward_cpu_seq_no_indices(
+        self,
+        weights_ty: SparseType,
+        output_dtype: SparseType,
+    ) -> None:
+        """A sequence forward whose bags are all empty returns an empty output.
+
+        Every table has an index range of length zero here, which is the
+        boundary at which the nobag path decides whether to build virtual
+        offsets at all.
+        """
+        T, E, D, B = 2, 64, 32, 4
+
+        op = self._make_cpu_seq_op(weights_ty, output_dtype, T, E, D)
+
+        output = op(
+            torch.empty(0, dtype=torch.int), torch.zeros(T * B + 1, dtype=torch.int)
+        )
+
+        self.assertEqual(output.shape[0], 0)

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -1450,6 +1450,31 @@ class NBitFowardTest(NBitFowardTestCommon):
             output_dtype=SparseType.INT4,
         )
 
+    def test_nbit_forward_cpu_seq_ragged_matches_flat(self) -> None:
+        for weights_ty, output_dtype in [
+            # One pair per kernel family the offsets predicate branches on:
+            # nbit taking the no_bag fast path (offsets ignored), nbit bagged
+            # and FP8 bagged (offsets dereferenced), and the base family, which
+            # the other three do not reach.
+            (SparseType.INT4, SparseType.INT4),
+            (SparseType.INT4, SparseType.FP16),
+            (SparseType.FP8, SparseType.FP16),
+            (SparseType.INT8, SparseType.FP32),
+        ]:
+            with self.subTest(weights_ty=weights_ty, output_dtype=output_dtype):
+                self._check_nbit_forward_cpu_seq_ragged_matches_flat(
+                    weights_ty, output_dtype
+                )
+
+    def test_nbit_forward_cpu_seq_no_indices(self) -> None:
+        for weights_ty, output_dtype in [
+            (SparseType.INT4, SparseType.INT4),
+            (SparseType.INT4, SparseType.FP16),
+            (SparseType.FP8, SparseType.FP16),
+        ]:
+            with self.subTest(weights_ty=weights_ty, output_dtype=output_dtype):
+                self._check_nbit_forward_cpu_seq_no_indices(weights_ty, output_dtype)
+
     @unittest.skipIf(*gpu_unavailable)
     @given(
         nbit_weights_ty=st.sampled_from(

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -27,7 +27,11 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     SplitTableBatchedEmbeddingBagsCodegen,
 )
 from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
-from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
+from fbgemm_gpu.tbe.config.embedding_config import (
+    BoundsCheckMode,
+    EmbeddingLocation,
+    PoolingMode,
+)
 from fbgemm_gpu.tbe.utils import (
     b_indices,
     dequantize_embs,
@@ -1449,6 +1453,38 @@ class NBitFowardTest(NBitFowardTestCommon):
             indices_dtype=indices_dtype,
             output_dtype=SparseType.INT4,
         )
+
+    def test_nbit_forward_cpu_seq_rejects_index_at_row_count(self) -> None:
+        """The sequence gather rejects an index equal to the table's row count.
+
+        ``BoundsCheckMode.NONE`` is load bearing: the frontend bounds check
+        clamps against the *logical* row count, which is never larger than the
+        *padded* row count the kernel checks against, so with it enabled this
+        boundary is unreachable and the op cannot be tested here at all.
+        """
+        E, D = 64, 128
+        op = IntNBitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[("", E, D, SparseType.INT4, EmbeddingLocation.HOST)],
+            pooling_mode=PoolingMode.NONE,
+            output_dtype=SparseType.INT4,
+            bounds_check_mode=BoundsCheckMode.NONE,
+            device="cpu",
+        )
+        op.fill_random_weights()
+
+        # Derive what the kernel uses as data_size rather than assuming it is E:
+        # it divides the whole cacheline-padded weight buffer by the fused row
+        # size, and this table's slice runs to the end of that buffer.
+        row_bytes = op.split_embedding_weights_with_scale_bias(0)[0][0].shape[1]
+        num_rows = op.weights_host.numel() // row_bytes
+        self.assertGreaterEqual(num_rows, E)
+
+        offsets = torch.tensor([0, 1], dtype=torch.int)
+        # Positive control: the last row the buffer actually holds.
+        op(torch.tensor([num_rows - 1], dtype=torch.int), offsets)
+
+        with self.assertRaisesRegex(RuntimeError, "out of bounds"):
+            op(torch.tensor([num_rows], dtype=torch.int), offsets)
 
     def test_nbit_forward_cpu_seq_ragged_matches_flat(self) -> None:
         for weights_ty, output_dtype in [

--- a/src/EmbeddingSpMDMAutovec.cc
+++ b/src/EmbeddingSpMDMAutovec.cc
@@ -374,15 +374,8 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
   const bool use_tuned_l1_prefetch = l1_distance > 0;
   const bool use_l2_prefetch =
       tbe_use_l2_prefetch(l2_distance, input_stride, data_size);
-  constexpr int64_t max_prefetch_bytes = 4096; // cap based on CPU cache size
-  // L1 look-ahead: tuned distance if set, default if unset, 0 if disabled.
-  const int64_t l1_prefetch_distance = std::min(
-      use_tuned_l1_prefetch ? l1_distance
-          : l1_distance == -1
-          ? std::min(
-                DEFAULT_L1_PREFETCH_DISTANCE, max_prefetch_bytes / input_stride)
-          : 0,
-      index_size);
+  const int64_t l1_prefetch_distance =
+      tbe_resolve_l1_prefetch_distance(l1_distance, input_stride, index_size);
   const int64_t l2_prefetch_distance = std::min(l2_distance, index_size);
   const int64_t last_index = std::max<int64_t>(index_size - 1, 0);
 
@@ -423,10 +416,29 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
       return false;
     }
 
+    // The preamble above only warms indices [0, l1_prefetch_distance), so
+    // without a rolling prefetch every row past that is a cold, dependent load:
+    // the gather is one scattered row per iteration over a table far larger
+    // than the TLB reach, with no arithmetic to hide the latency behind.
     for (int64_t i = 0; i < output_size; ++i) {
       const auto idx = indices[i];
       if (idx < 0 || idx > data_size) {
         return false;
+      }
+      // Stop once there is no row left to look ahead to: tbe_prefetch_row
+      // clamps to last_index, so past this point every iteration would
+      // re-prefetch the final row for no benefit. The preamble above has
+      // already warmed indices [0, l1_prefetch_distance), so between them every
+      // row is prefetched exactly once.
+      if (l1_prefetch_distance > 0 && i + l1_prefetch_distance < output_size) {
+        tbe_prefetch_row<prefetch_row_l1>(
+            input,
+            indices,
+            i,
+            last_index,
+            input_stride,
+            data_size,
+            l1_prefetch_distance);
       }
       const uint8_t* input_row = input + input_stride * idx;
       memcpy(out, input_row, sizeof(uint8_t) * input_stride);

--- a/src/EmbeddingSpMDMAutovec.cc
+++ b/src/EmbeddingSpMDMAutovec.cc
@@ -422,7 +422,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
     // than the TLB reach, with no arithmetic to hide the latency behind.
     for (int64_t i = 0; i < output_size; ++i) {
       const auto idx = indices[i];
-      if (idx < 0 || idx > data_size) {
+      if (idx < 0 || idx >= data_size) {
         return false;
       }
       // Stop once there is no row left to look ahead to: tbe_prefetch_row

--- a/src/EmbeddingSpMDMPrefetch.h
+++ b/src/EmbeddingSpMDMPrefetch.h
@@ -65,6 +65,30 @@ inline void do_tlb_prime([[maybe_unused]] const void* addr) {
 }
 #endif
 
+// L1 look-ahead in rows: the tuned distance when
+// FBGEMM_TBE_L1_PREFETCH_DISTANCE is set, DEFAULT_L1_PREFETCH_DISTANCE when it
+// is unset (-1), 0 when it is explicitly disabled. The default is capped so the
+// rows in flight stay within about one 4 KiB page's worth of line fills, which
+// matters for wide rows where 16 rows would be far more than the L1 can hold.
+inline int64_t tbe_resolve_l1_prefetch_distance(
+    int64_t l1_distance,
+    int64_t input_stride,
+    int64_t index_size) {
+  // Guards the division below, and a non-positive row size means there is
+  // nothing to prefetch anyway.
+  if (input_stride <= 0) {
+    return 0;
+  }
+  constexpr int64_t max_prefetch_bytes = 4096;
+  return std::min(
+      l1_distance > 0 ? l1_distance
+          : l1_distance == -1
+          ? std::min(
+                DEFAULT_L1_PREFETCH_DISTANCE, max_prefetch_bytes / input_stride)
+          : 0,
+      index_size);
+}
+
 template <void (*PrefetchRow)(const uint8_t*, int64_t), typename IndexType>
 inline void tbe_prefetch_row(
     const uint8_t* input,

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -1482,7 +1482,7 @@ bool EmbeddingSpMDMNBit_ref(
     const int64_t last_index = std::max<int64_t>(output_size - 1, 0);
     for (int64_t i = 0; i < output_size; ++i) {
       const auto idx = indices[i];
-      if (idx < 0 || idx > data_size) {
+      if (idx < 0 || idx >= data_size) {
         return false;
       }
       // Stop once there is no row left to look ahead to: tbe_prefetch_row

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -9,6 +9,7 @@
 #define FBGEMM_EXPORTS
 #include "./RefImplementations.h" // @manual
 
+#include "./EmbeddingSpMDMPrefetch.h" // @manual
 #include "fbgemm/FbgemmBuild.h"
 #include "fbgemm/FbgemmConvert.h"
 #include "fbgemm/FloatConversion.h"
@@ -1471,10 +1472,33 @@ bool EmbeddingSpMDMNBit_ref(
       WARN_ONCE("no_bag is only supported for int4 to int4");
       return false;
     }
+    // This loop is not reference-only on x86: the asmjit nbit generator is
+    // gated on !no_bag and the autovec one needs SVE2, so the sequence gather
+    // lands here and this is its only chance to prefetch. Each iteration is one
+    // scattered row from a table far larger than the TLB reach, with no
+    // arithmetic to hide the miss behind, so look ahead by whole rows.
+    const int64_t prefetch_distance = tbe_resolve_l1_prefetch_distance(
+        tbe_l1_prefetch_distance(), input_stride, output_size);
+    const int64_t last_index = std::max<int64_t>(output_size - 1, 0);
     for (int64_t i = 0; i < output_size; ++i) {
       const auto idx = indices[i];
       if (idx < 0 || idx > data_size) {
         return false;
+      }
+      // Stop once there is no row left to look ahead to: tbe_prefetch_row
+      // clamps to last_index, so past this point every iteration would
+      // re-prefetch the final row for no benefit. Short batches, where the
+      // distance is clamped to the index count, would otherwise prefetch that
+      // one row on every single iteration.
+      if (prefetch_distance > 0 && i + prefetch_distance < output_size) {
+        tbe_prefetch_row<prefetch_row_l1>(
+            input,
+            indices,
+            i,
+            last_index,
+            input_stride,
+            data_size,
+            prefetch_distance);
       }
       const uint8_t* input_row = input + input_stride * idx;
       memcpy(out, input_row, sizeof(uint8_t) * input_stride);

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -1227,6 +1227,69 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, fp16NoBagNegativeIndexTest) {
                         << " bit_rate=" << bit_rate;
 }
 
+// int4 -> int4 is the only combination the nbit no_bag gather supports, so it
+// is the one configuration whose bounds check is reachable. Regression guard
+// for an off-by-one: the check read `idx > data_size`, so `idx == data_size`
+// passed and the gather memcpy'd a row from one past the end of the table.
+TEST(
+    FusedNBitRowwiseEmbeddingLookupBoundsTest,
+    NoBagRejectsIndexEqualToRowCount) {
+  constexpr int kBitRate = 4;
+  constexpr int64_t kNumRows = 100;
+  constexpr int64_t kEmbeddingDim = 32;
+  constexpr int64_t kOutputSize = 10;
+  constexpr int64_t kPackedDim = kEmbeddingDim / (8 / kBitRate);
+  constexpr int64_t kFusedDim = kPackedDim + 2 * sizeof(float16);
+
+  const vector<uint8_t> table(kNumRows * kFusedDim, 1);
+  vector<int64_t> offsets(kOutputSize + 1);
+  iota(offsets.begin(), offsets.end(), 0);
+  vector<uint8_t> output(kOutputSize * kFusedDim);
+
+  // DISPATCH_DEFAULT reaches EmbeddingSpMDMNBit_ref here, since the asmjit
+  // generator is gated on !no_bag; DISPATCH_AUTOVEC reaches the autovec copy of
+  // the same loop. Both carried the off-by-one.
+  for (const auto kernel_choice : {DISPATCH_DEFAULT, DISPATCH_AUTOVEC}) {
+    ScopedKernelOverride kernel_override(kernel_choice);
+    const auto kernel =
+        GenerateEmbeddingSpMDMNBitWithStrides<int64_t, int64_t, uint8_t>(
+            kBitRate,
+            kEmbeddingDim,
+            /*has_weight=*/false,
+            /*normalize_by_lengths=*/false,
+            /*prefetch=*/16,
+            /*is_weight_positional=*/false,
+            /*use_offsets=*/true,
+            /*output_stride=*/-1,
+            /*input_stride=*/-1,
+            /*scale_bias_last=*/true,
+            /*is_bf16_out=*/false,
+            /*no_bag=*/true,
+            /*output_bit_rate=*/kBitRate);
+
+    const auto gather_with = [&](int64_t probe_index) {
+      vector<int64_t> indices(kOutputSize, 0);
+      indices[kOutputSize / 2] = probe_index;
+      return kernel(
+          kOutputSize,
+          kOutputSize,
+          kNumRows,
+          table.data(),
+          indices.data(),
+          offsets.data(),
+          nullptr,
+          output.data());
+    };
+
+    EXPECT_TRUE(gather_with(kNumRows - 1))
+        << "last valid row was rejected, kernel_choice=" << kernel_choice;
+    EXPECT_FALSE(gather_with(kNumRows))
+        << "row one past the end was accepted, kernel_choice=" << kernel_choice;
+    EXPECT_FALSE(gather_with(-1))
+        << "negative index was accepted, kernel_choice=" << kernel_choice;
+  }
+}
+
 TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
   vector<vector<int>> inputs(GetInputs_());
 

--- a/test/EmbeddingSpMDMPrefetchTest.cc
+++ b/test/EmbeddingSpMDMPrefetchTest.cc
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "src/EmbeddingSpMDMPrefetch.h" // @manual
+
+using namespace fbgemm;
+
+namespace {
+// An INT4 D=128 row: narrow enough that the in-flight byte cap never binds.
+constexpr int64_t kNarrowStride = 68;
+// More indices than any look-ahead tested here, so the clamp never binds.
+constexpr int64_t kManyIndices = 1000;
+} // namespace
+
+TEST(EmbeddingSpMDMPrefetchTest, TunedDistanceIsHonored) {
+  EXPECT_EQ(
+      tbe_resolve_l1_prefetch_distance(32, kNarrowStride, kManyIndices), 32);
+}
+
+TEST(EmbeddingSpMDMPrefetchTest, UnsetDistanceUsesDefault) {
+  EXPECT_EQ(
+      tbe_resolve_l1_prefetch_distance(-1, kNarrowStride, kManyIndices),
+      DEFAULT_L1_PREFETCH_DISTANCE);
+}
+
+TEST(EmbeddingSpMDMPrefetchTest, ZeroDisablesPrefetching) {
+  EXPECT_EQ(
+      tbe_resolve_l1_prefetch_distance(0, kNarrowStride, kManyIndices), 0);
+}
+
+TEST(EmbeddingSpMDMPrefetchTest, DistanceNeverExceedsIndexCount) {
+  // Looking further ahead than there are indices would walk off the array.
+  EXPECT_EQ(tbe_resolve_l1_prefetch_distance(32, kNarrowStride, 8), 8);
+  EXPECT_EQ(tbe_resolve_l1_prefetch_distance(-1, kNarrowStride, 8), 8);
+  EXPECT_EQ(tbe_resolve_l1_prefetch_distance(32, kNarrowStride, 0), 0);
+}
+
+TEST(EmbeddingSpMDMPrefetchTest, NonPositiveStrideDisablesPrefetching) {
+  // A zero stride would otherwise divide by zero while capping the default.
+  EXPECT_EQ(tbe_resolve_l1_prefetch_distance(-1, 0, kManyIndices), 0);
+  EXPECT_EQ(tbe_resolve_l1_prefetch_distance(32, 0, kManyIndices), 0);
+  EXPECT_EQ(tbe_resolve_l1_prefetch_distance(-1, -8, kManyIndices), 0);
+}
+
+TEST(EmbeddingSpMDMPrefetchTest, WideRowsCapTheDefaultButNotATunedValue) {
+  // The default is capped to roughly 4 KiB of rows in flight, so a 1 KiB row
+  // gets 4 of them rather than the default 16.
+  EXPECT_EQ(tbe_resolve_l1_prefetch_distance(-1, 1024, kManyIndices), 4);
+  // A row wider than the whole budget turns the default off entirely.
+  EXPECT_EQ(tbe_resolve_l1_prefetch_distance(-1, 8192, kManyIndices), 0);
+  // An explicitly tuned distance opts out of the cap.
+  EXPECT_EQ(tbe_resolve_l1_prefetch_distance(32, 8192, kManyIndices), 32);
+}


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3101

The nobag gather in `EmbeddingSpMDMNBit_ref` and `EmbeddingSpMDMNBit_autovec`
rejected an index with `idx < 0 || idx > data_size`, so `idx == data_size`
passed and the loop memcpy'd `input_stride` bytes from one row past the end of
the table. For the last table in a batch that is a heap over-read; for any other
table it silently returns a row belonging to the next table.

These were the only two `> data_size` bounds checks left in fbgemm -- the other
41, including the bagged branch of the very same `EmbeddingSpMDMNBit_ref`, all
use `>=`. `report_embedding_error`, which the CPU TBE calls when a kernel returns
false, also already requires `idx < hash_size`, so the kernel disagreed with its
own error path.

Not reachable from the TBE frontend at default settings: it runs
`bounds_check_indices` on every forward, clamping against `rows_per_table`, and
that logical row count is never larger than the padded `data_size` the kernel
checks against. Reachable with `bounds_check_mode=BoundsCheckMode.NONE`, and by
anything calling the fbgemm C++ API directly.

Behavior change: an index equal to the row count now returns false and surfaces
as the `report_embedding_error` `TORCH_CHECK` ("Index N is out of bounds")
instead of silently serving a garbage row.

Reviewed By: q10

Differential Revision: D117267412


