### PR TITLE
Plumb RES chunk size + consumer/copy-thread config knobs

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -144,6 +144,12 @@ class RESParams:
     table_sizes: list[int] = field(
         default_factory=list
     )  # table sizes for the global rows the TBE holds
+    res_chunk_size: int = 500000  # max rows copied into one enqueued chunk
+    res_num_consumers: int = 8  # threads draining the stream queue
+    # parallel chunk-copy threads per stream() call on the UVM cache-hit lane
+    res_num_uvm_hit_copy_threads: int = 4
+    # parallel chunk-copy threads for the dedicated HBM drain path
+    res_num_hbm_copy_threads: int = 4
     res_enabled_tables: list[str] = field(
         default_factory=list
     )  # table names that are enabled for RES (empty means all enabled)
@@ -1563,6 +1569,10 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 self.res_params.table_names,
                 self.res_params.table_offsets,
                 self.res_params.table_sizes,
+                self.res_params.res_chunk_size,
+                self.res_params.res_num_consumers,
+                self.res_params.res_num_uvm_hit_copy_threads,
+                self.res_params.res_num_hbm_copy_threads,
             )
             self._register_res_enabled_feature_mask()
             logging.info(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3010

Frontend (Python) half of the C++/Python split (FBGEMM guide: backend and frontend ship in separate FBPKGs, so they land as separate diffs, backend first).

Adds four RES knobs to `RESParams` -- `res_chunk_size`, `res_num_consumers`, `res_num_uvm_hit_copy_threads`, `res_num_hbm_copy_threads` -- and passes them to the `RawEmbeddingStreamer` ctor, mirroring the existing `res_store_shards` path. Args are appended at the end (append-only) and defaulted in C++, so behavior is unchanged until a model opts in.

Land after D113752426, which lifts the ctor from 10 args to 11. The torchrec + MVAI half that emits these into `fused_params` is a separate diff and lands after this one.

Differential Revision: D114283366


