### PR TITLE
[DO NOT MERGE][DEBUG] Probe GPU round-trip latency on the MI350 VF runner

### DIFF
--- a/.github/scripts/vf_latency_probe.py
+++ b/.github/scripts/vf_latency_probe.py
@@ -15,6 +15,10 @@ Hypotheses under test:
   H4  small device->host copies are slow
   H5  host access to managed memory is slow (in FBGEMM's advised config)
   H7  allocation is slow
+  H8  deallocation is slow (only managed free was ever measured)
+  H9  pinned host allocation is slow
+  H10 allocation churn at varying sizes is slow
+  H11 the slow test's actual hot loop: sort + unique_consecutive + D->H sync
 """
 
 import ctypes
@@ -82,6 +86,8 @@ if hip is not None:
     hip.hipMemcpy.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int]
     hip.hipMemAdvise.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int, ctypes.c_int]
     hip.hipDeviceSynchronize.argtypes = []
+    hip.hipHostMalloc.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t, ctypes.c_uint]
+    hip.hipHostFree.argtypes = [ctypes.c_void_p]
 
 
 def require_hip(tag):
@@ -439,6 +445,131 @@ def h7_alloc(iters=200):
 
 # Each test runs in its own process with a wall-clock budget, so one wedged HIP
 # call cannot take the suite down or discard the results already collected.
+# --------------------------------------------------------------------------- #
+# H8 - deallocation.  H7 timed allocation only; the one free that was measured
+# (managed memory, in the UVM ladder) was 119x slower on the VF.  Ordinary
+# device free has never been timed, and every caching-allocator eviction hits it.
+# --------------------------------------------------------------------------- #
+
+def h8_device_free(iters=300, size=1 << 20):
+    print("-- H8  hipFree of device memory " + "-" * 44)
+    if not require_hip("H8_device_free"):
+        return
+    allocs, frees = [], []
+    for _ in range(iters):
+        p = ctypes.c_void_p()
+        t0 = ns()
+        rc = hip.hipMalloc(ctypes.byref(p), size)
+        allocs.append(ns() - t0)
+        if rc != 0:
+            continue
+        t0 = ns()
+        hip.hipFree(p)
+        frees.append(ns() - t0)
+    am, _, ap = stats(allocs)
+    fm, fmean, fp = stats(frees)
+    result("H8_device_free", iters=iters, size_MiB=size // 2**20,
+           alloc_median_us=f"{am:.2f}", free_median_us=f"{fm:.2f}",
+           free_mean_us=f"{fmean:.2f}", free_p99_us=f"{fp:.2f}")
+    histogram(frees, "H8 hipFree device")
+    print()
+
+
+# --------------------------------------------------------------------------- #
+# H9 - pinned host memory.  Never measured, and it is the other host-adjacent
+# allocator besides managed memory.
+# --------------------------------------------------------------------------- #
+
+def h9_pinned(iters=200, size=1 << 20):
+    print("-- H9  hipHostMalloc / hipHostFree (pinned) " + "-" * 32)
+    if not require_hip("H9_pinned"):
+        return
+    allocs, frees = [], []
+    for _ in range(iters):
+        p = ctypes.c_void_p()
+        t0 = ns()
+        rc = hip.hipHostMalloc(ctypes.byref(p), size, 0)
+        allocs.append(ns() - t0)
+        if rc != 0:
+            result("H9_pinned", status=f"hipHostMalloc failed rc={rc}")
+            print()
+            return
+        t0 = ns()
+        hip.hipHostFree(p)
+        frees.append(ns() - t0)
+    am, _, ap = stats(allocs)
+    fm, _, fp = stats(frees)
+    result("H9_pinned", iters=iters, size_MiB=size // 2**20,
+           alloc_median_us=f"{am:.2f}", alloc_p99_us=f"{ap:.2f}",
+           free_median_us=f"{fm:.2f}", free_p99_us=f"{fp:.2f}")
+    print()
+
+
+# --------------------------------------------------------------------------- #
+# H10 - allocation churn at torch level, with sizes that vary per iteration so
+# the caching allocator cannot simply hand back the same block.  This is what
+# gradcheck does and what the H1 steady-state loop never did.
+# --------------------------------------------------------------------------- #
+
+def h10_alloc_churn(iters=2000):
+    print("-- H10  torch alloc/free churn, varying sizes " + "-" * 30)
+    import torch
+    for _ in range(50):
+        torch.empty(1024, device="cuda")
+    torch.cuda.synchronize()
+    samples = []
+    for i in range(iters):
+        n = 1024 + (i % 97) * 512          # varies, defeats block reuse
+        t0 = ns()
+        x = torch.empty(n, device="cuda")
+        del x
+        samples.append(ns() - t0)
+    med, mean, p99 = stats(samples)
+    result("H10_alloc_churn", iters=iters, median_us=f"{med:.2f}",
+           mean_us=f"{mean:.2f}", p99_us=f"{p99:.2f}")
+    histogram(samples, "H10 torch alloc+free")
+    print()
+
+
+# --------------------------------------------------------------------------- #
+# H11 - the actual hot loop of the slow test.
+#
+# index_select_dim0's backward calls at::unique_consecutive, which the FBGEMM
+# source itself documents as doing a D->H transfer that forces host-device
+# synchronization (sparse_index_add.cu:144-152), followed by allocations whose
+# size is only known after that sync.  gradcheck runs this thousands of times.
+# at::unique_consecutive is torch.unique_consecutive in Python, so this needs no
+# compiler and no FBGEMM - which matters, because this step runs before the
+# FBGEMM wheel is installed.
+# --------------------------------------------------------------------------- #
+
+def h11_unique_consecutive_loop(iters=500, n=32, u=33):
+    print("-- H11  sort + unique_consecutive + D->H sync loop " + "-" * 25)
+    import torch
+    idx = torch.randint(u, (n,), device="cuda")
+    for _ in range(20):
+        s, _o = idx.sort()
+        uq, cnt = torch.unique_consecutive(s, return_counts=True)
+        _ = uq.numel()
+    torch.cuda.synchronize()
+
+    samples = []
+    for _ in range(iters):
+        t0 = ns()
+        sorted_indices, orig_indices = idx.sort()
+        unique_indices, unique_count = torch.unique_consecutive(
+            sorted_indices, return_counts=True)
+        num_unique = unique_indices.numel()      # D->H transfer
+        offsets = unique_count.cumsum(0)         # size depends on the above
+        samples.append(ns() - t0)
+    med, mean, p99 = stats(samples)
+    result("H11_unique_consec", iters=iters, n=n,
+           median_us=f"{med:.1f}", mean_us=f"{mean:.1f}", p99_us=f"{p99:.1f}",
+           est_84k_calls_s=f"{mean * 84000 / 1e6:.1f}")
+    histogram(samples, "H11 unique_consecutive iteration")
+    print()
+
+
 TESTS = {
     "fingerprint": (fingerprint, 120),
     "c1": (c1_cpu_control, 180),
@@ -449,6 +580,10 @@ TESTS = {
     "h4": (h4_small_copy, 180),
     "h5": (h5_managed_host_access, 300),
     "h7": (h7_alloc, 240),
+    "h8": (h8_device_free, 240),
+    "h9": (h9_pinned, 240),
+    "h10": (h10_alloc_churn, 240),
+    "h11": (h11_unique_consecutive_loop, 300),
 }
 
 

--- a/.github/scripts/vf_latency_probe.py
+++ b/.github/scripts/vf_latency_probe.py
@@ -28,19 +28,69 @@ import time
 # HIP bindings via ctypes - keeps this independent of any compiler or framework
 # --------------------------------------------------------------------------- #
 
-hip = ctypes.CDLL("libamdhip64.so")
+def _load_hip():
+    """Locate libamdhip64 without assuming the loader path resolves it.
+
+    The unversioned .so is often only present in the -dev package, so the plain
+    soname can fail on a runtime-only image.  Prefer the copy PyTorch bundles:
+    it is guaranteed to exist wherever this script can run at all, and because
+    torch has already dlopen'd it, we get the same handle and therefore the same
+    HIP context rather than a second runtime in the process.
+
+    Returns (handle, description).  A None handle is not fatal - the tests that
+    need raw HIP report themselves skipped, and the torch-only tests, which are
+    the ones that matter most, still run.
+    """
+    candidates = []
+    try:
+        import torch
+        candidates.append(os.path.join(os.path.dirname(torch.__file__), "lib",
+                                       "libamdhip64.so"))
+    except Exception:
+        pass
+    candidates += [
+        "/opt/rocm/lib/libamdhip64.so",
+        "libamdhip64.so",
+        "libamdhip64.so.7",
+        "libamdhip64.so.6",
+    ]
+    for path in candidates:
+        try:
+            return ctypes.CDLL(path), path
+        except OSError:
+            continue
+    # Last resort: torch links against it, so the symbols may already be global.
+    try:
+        h = ctypes.CDLL(None)
+        h.hipMalloc  # probe for the symbol; raises AttributeError if absent
+        return h, "(already-loaded global symbols)"
+    except Exception as e:
+        return None, f"NOT FOUND ({e})"
+
+
+hip, HIP_LIB_PATH = _load_hip()
 
 hipMemAdviseSetPreferredLocation = 3
 hipMemAdviseSetAccessedBy = 5
 hipMemcpyDeviceToHost = 2
 hipCpuDeviceId = -1
 
-hip.hipMalloc.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]
-hip.hipMallocManaged.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t, ctypes.c_uint]
-hip.hipFree.argtypes = [ctypes.c_void_p]
-hip.hipMemcpy.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int]
-hip.hipMemAdvise.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int, ctypes.c_int]
-hip.hipDeviceSynchronize.argtypes = []
+if hip is not None:
+    hip.hipMalloc.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]
+    hip.hipMallocManaged.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t, ctypes.c_uint]
+    hip.hipFree.argtypes = [ctypes.c_void_p]
+    hip.hipMemcpy.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int]
+    hip.hipMemAdvise.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int, ctypes.c_int]
+    hip.hipDeviceSynchronize.argtypes = []
+
+
+def require_hip(tag):
+    """Report a raw-HIP test as skipped rather than crashing the run."""
+    if hip is None:
+        result(tag, status=f"SKIPPED - libamdhip64 unavailable: {HIP_LIB_PATH}")
+        print()
+        return False
+    return True
 
 
 def hip_check(rc, what):
@@ -96,6 +146,7 @@ def fingerprint():
     print("=" * 78)
     print("ENVIRONMENT")
     print("=" * 78)
+    print(f"  libamdhip64     : {HIP_LIB_PATH}")
     import torch
     dev = torch.cuda.current_device()
     props = torch.cuda.get_device_properties(dev)
@@ -276,6 +327,8 @@ def h3_interrupt_vs_polling():
 
 def h4_small_copy(iters=1000):
     print("-- H4  4-byte device->host copy " + "-" * 44)
+    if not require_hip("H4_d2h_4B"):
+        return
     dptr = ctypes.c_void_p()
     hip_check(hip.hipMalloc(ctypes.byref(dptr), 4), "hipMalloc")
     host = ctypes.create_string_buffer(4)
@@ -310,6 +363,8 @@ def h5_managed_host_access(pages=4096):
     Both configurations are measured so the advises can be shown to matter or not.
     """
     print("-- H5  host access to managed memory " + "-" * 39)
+    if not require_hip("H5_managed"):
+        return
     PAGE = 4096
     size = pages * PAGE
 
@@ -359,6 +414,8 @@ def h5_managed_host_access(pages=4096):
 
 def h7_alloc(iters=200):
     print("-- H7  allocation latency " + "-" * 50)
+    if not require_hip("H7_alloc"):
+        return
     for label, fn, sz in (("hipMalloc_1MiB", "malloc", 1 << 20),
                           ("hipMallocManaged_1MiB", "managed", 1 << 20)):
         samples = []

--- a/.github/scripts/vf_latency_probe.py
+++ b/.github/scripts/vf_latency_probe.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""
+Standalone GPU virtualization latency probe.  No FBGEMM, no pytest, no compiler.
+
+Run the same script on a bare-metal GPU and on the virtualized CI runner and diff
+the output.  Every test prints one RESULT line so the two logs can be compared
+mechanically.
+
+Hypotheses under test:
+  C1  the guest CPU is slow                      (control - must rule out first)
+  C2  the guest gets a fraction of the GPU       (control)
+  H1  fixed cost per host<->device round trip
+  H2  the cost is in completion, not submission
+  H3  the cost is interrupt delivery to the guest
+  H4  small device->host copies are slow
+  H5  host access to managed memory is slow (in FBGEMM's advised config)
+  H7  allocation is slow
+"""
+
+import ctypes
+import os
+import statistics
+import subprocess
+import sys
+import time
+
+# --------------------------------------------------------------------------- #
+# HIP bindings via ctypes - keeps this independent of any compiler or framework
+# --------------------------------------------------------------------------- #
+
+hip = ctypes.CDLL("libamdhip64.so")
+
+hipMemAdviseSetPreferredLocation = 3
+hipMemAdviseSetAccessedBy = 5
+hipMemcpyDeviceToHost = 2
+hipCpuDeviceId = -1
+
+hip.hipMalloc.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]
+hip.hipMallocManaged.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t, ctypes.c_uint]
+hip.hipFree.argtypes = [ctypes.c_void_p]
+hip.hipMemcpy.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int]
+hip.hipMemAdvise.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int, ctypes.c_int]
+hip.hipDeviceSynchronize.argtypes = []
+
+
+def hip_check(rc, what):
+    if rc != 0:
+        raise RuntimeError(f"{what} failed with hipError {rc}")
+
+
+def ns():
+    return time.perf_counter_ns()
+
+
+def stats(samples_ns):
+    """Return (median, mean, p99) in microseconds."""
+    s = sorted(samples_ns)
+    n = len(s)
+    return (
+        s[n // 2] / 1e3,
+        sum(s) / n / 1e3,
+        s[min(n - 1, int(n * 0.99))] / 1e3,
+    )
+
+
+def result(tag, **kv):
+    body = "  ".join(f"{k}={v}" for k, v in kv.items())
+    print(f"RESULT {tag:22} {body}", flush=True)
+
+
+def histogram(samples_ns, tag):
+    """Log-spaced histogram.  A scheduling quantum shows up as a spike, and as
+    multiples of that spike - a mean would hide exactly that structure."""
+    edges = [0, 10e3, 30e3, 100e3, 300e3, 1e6, 3e6, 6e6, 12e6, 24e6, 48e6, float("inf")]
+    labels = ["<10us", "10-30us", "30-100us", "0.1-0.3ms", "0.3-1ms", "1-3ms",
+              "3-6ms", "6-12ms", "12-24ms", "24-48ms", ">48ms"]
+    counts = [0] * (len(edges) - 1)
+    for v in samples_ns:
+        for i in range(len(edges) - 1):
+            if edges[i] <= v < edges[i + 1]:
+                counts[i] += 1
+                break
+    total = max(1, len(samples_ns))
+    print(f"  histogram[{tag}]")
+    for lab, c in zip(labels, counts):
+        if c:
+            bar = "#" * max(1, int(60 * c / total))
+            print(f"    {lab:>10} {c:6d}  {bar}")
+
+
+# --------------------------------------------------------------------------- #
+# Fingerprint
+# --------------------------------------------------------------------------- #
+
+def fingerprint():
+    print("=" * 78)
+    print("ENVIRONMENT")
+    print("=" * 78)
+    import torch
+    dev = torch.cuda.current_device()
+    props = torch.cuda.get_device_properties(dev)
+    # The " VF" suffix on the marketing name is how a virtual function is
+    # distinguished from a physical one, so report every source of it.
+    print(f"  device name     : {torch.cuda.get_device_name(dev) or '(empty)'}")
+    print(f"  props.name      : {getattr(props, 'name', None) or '(empty)'}")
+    try:
+        smi = subprocess.run(["rocm-smi", "--showproductname"],
+                             capture_output=True, text=True, timeout=30).stdout
+        for line in smi.splitlines():
+            if "Card Series" in line or "Market Name" in line:
+                print(f"  rocm-smi        : {line.strip()}")
+                break
+    except Exception:
+        pass
+    print(f"  gcnArchName     : {props.gcnArchName}")
+    print(f"  CUs             : {props.multi_processor_count}")
+    print(f"  total memory    : {props.total_memory / 2**30:.1f} GiB")
+    print(f"  torch           : {torch.__version__}")
+    print(f"  HIP             : {torch.version.hip}")
+    for var in ("HSA_ENABLE_INTERRUPT", "HSA_XNACK", "AMD_SERIALIZE_KERNEL",
+                "HIP_VISIBLE_DEVICES", "HIP_LAUNCH_BLOCKING"):
+        print(f"  {var:16}: {os.environ.get(var, '(unset)')}")
+    # Is this a VM?  Is the GPU a virtual function?
+    try:
+        out = subprocess.run(["lscpu"], capture_output=True, text=True).stdout
+        for line in out.splitlines():
+            if any(k in line for k in ("Hypervisor vendor", "Virtualization type",
+                                       "Model name", "CPU(s):")):
+                print(f"  lscpu           : {line.strip()}")
+    except Exception as e:
+        print(f"  lscpu           : unavailable ({e})")
+    print()
+
+
+# --------------------------------------------------------------------------- #
+# C1 - CPU control.  If the guest CPU is slow, every host-loop-heavy test is
+# slow for reasons that have nothing to do with the GPU.
+# --------------------------------------------------------------------------- #
+
+def c1_cpu_control():
+    print("-- C1  CPU control (no GPU) " + "-" * 48)
+    t0 = ns()
+    acc = 0
+    for i in range(5_000_000):
+        acc += i * i % 7
+    pure_python_ms = (ns() - t0) / 1e6
+
+    import numpy as np
+    a = np.random.rand(1024, 1024).astype(np.float32)
+    b = np.random.rand(1024, 1024).astype(np.float32)
+    a @ b  # warm
+    t0 = ns()
+    for _ in range(10):
+        a @ b
+    numpy_ms = (ns() - t0) / 1e6 / 10
+
+    result("C1_cpu", python_loop_ms=f"{pure_python_ms:.0f}", numpy_1k_matmul_ms=f"{numpy_ms:.2f}")
+    print()
+
+
+# --------------------------------------------------------------------------- #
+# C2 - Bulk GPU throughput.  Rules out "we only get a slice of the GPU".
+# --------------------------------------------------------------------------- #
+
+def c2_gpu_throughput():
+    print("-- C2  bulk GPU throughput " + "-" * 49)
+    import torch
+    n = 8192
+    a = torch.randn(n, n, device="cuda", dtype=torch.float16)
+    b = torch.randn(n, n, device="cuda", dtype=torch.float16)
+    for _ in range(3):
+        a @ b
+    torch.cuda.synchronize()
+    t0 = ns()
+    iters = 20
+    for _ in range(iters):
+        a @ b
+    torch.cuda.synchronize()
+    dt = (ns() - t0) / 1e9
+    tflops = (2 * n**3 * iters) / dt / 1e12
+    result("C2_gemm", size=n, tflops=f"{tflops:.1f}", per_iter_ms=f"{dt/iters*1e3:.2f}")
+    del a, b
+    torch.cuda.empty_cache()
+    print()
+
+
+# --------------------------------------------------------------------------- #
+# H1 - round-trip latency: the headline number.
+# --------------------------------------------------------------------------- #
+
+def h1_roundtrip(iters=2000, show_hist=True):
+    print("-- H1  kernel launch + synchronize round trip " + "-" * 30)
+    import torch
+    t = torch.ones(1, device="cuda")
+    for _ in range(50):
+        t.add_(1.0)
+    torch.cuda.synchronize()
+
+    samples = []
+    for _ in range(iters):
+        t0 = ns()
+        t.add_(1.0)
+        torch.cuda.synchronize()
+        samples.append(ns() - t0)
+
+    med, mean, p99 = stats(samples)
+    result("H1_roundtrip", iters=iters, median_us=f"{med:.1f}",
+           mean_us=f"{mean:.1f}", p99_us=f"{p99:.1f}")
+    if show_hist:
+        histogram(samples, "H1 launch+sync")
+    print()
+    return med
+
+
+# --------------------------------------------------------------------------- #
+# H2 - is the cost in submission or in completion?
+# --------------------------------------------------------------------------- #
+
+def h2_submit_vs_complete(iters=2000):
+    print("-- H2  submission vs completion " + "-" * 44)
+    import torch
+    t = torch.ones(1, device="cuda")
+    for _ in range(50):
+        t.add_(1.0)
+    torch.cuda.synchronize()
+
+    # N launches, ONE sync at the end -> amortized submission cost
+    t0 = ns()
+    for _ in range(iters):
+        t.add_(1.0)
+    submit_only_ns = ns() - t0          # queueing only, sync excluded
+    torch.cuda.synchronize()
+    total_ns = ns() - t0
+
+    per_submit_us = submit_only_ns / iters / 1e3
+    per_total_us = total_ns / iters / 1e3
+    result("H2_submit", iters=iters, per_submit_us=f"{per_submit_us:.2f}",
+           per_iter_batched_us=f"{per_total_us:.2f}")
+
+    # A bare synchronize on an idle queue -> pure completion-path cost
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(500):
+        t0 = ns()
+        torch.cuda.synchronize()
+        samples.append(ns() - t0)
+    med, mean, p99 = stats(samples)
+    result("H2_idle_sync", median_us=f"{med:.2f}", mean_us=f"{mean:.2f}", p99_us=f"{p99:.2f}")
+    print()
+
+
+# --------------------------------------------------------------------------- #
+# H3 - interrupt delivery.  Re-runs H1 in a child process with interrupts off.
+# HSA_ENABLE_INTERRUPT is read once at ROCr init, so it must be a new process.
+# --------------------------------------------------------------------------- #
+
+def h3_interrupt_vs_polling():
+    print("-- H3  interrupt vs polling completion " + "-" * 37)
+    env = dict(os.environ)
+    env["HSA_ENABLE_INTERRUPT"] = "0"
+    env["VF_PROBE_CHILD"] = "1"
+    out = subprocess.run([sys.executable, os.path.abspath(__file__)],
+                         env=env, capture_output=True, text=True)
+    line = [l for l in out.stdout.splitlines() if l.startswith("RESULT H1_roundtrip")]
+    if line:
+        print(f"  with HSA_ENABLE_INTERRUPT=0 -> {line[0]}")
+    else:
+        print("  child run failed; stderr tail:")
+        print("   ", (out.stderr or "(empty)").strip().splitlines()[-3:])
+    print()
+
+
+# --------------------------------------------------------------------------- #
+# H4 - small device->host copy latency
+# --------------------------------------------------------------------------- #
+
+def h4_small_copy(iters=1000):
+    print("-- H4  4-byte device->host copy " + "-" * 44)
+    dptr = ctypes.c_void_p()
+    hip_check(hip.hipMalloc(ctypes.byref(dptr), 4), "hipMalloc")
+    host = ctypes.create_string_buffer(4)
+    for _ in range(20):
+        hip.hipMemcpy(host, dptr, 4, hipMemcpyDeviceToHost)
+    samples = []
+    for _ in range(iters):
+        t0 = ns()
+        hip.hipMemcpy(host, dptr, 4, hipMemcpyDeviceToHost)
+        samples.append(ns() - t0)
+    med, mean, p99 = stats(samples)
+    result("H4_d2h_4B", iters=iters, median_us=f"{med:.2f}",
+           mean_us=f"{mean:.2f}", p99_us=f"{p99:.2f}")
+    hip.hipFree(dptr)
+    print()
+
+
+# --------------------------------------------------------------------------- #
+# H5 - host access to managed memory, one touch per 4 KiB page
+# --------------------------------------------------------------------------- #
+
+def h5_managed_host_access(pages=4096):
+    """Host access cost to a managed range, in the configuration FBGEMM actually uses.
+
+    new_managed_tensor() does cudaMallocManaged followed by
+    SetPreferredLocation=host and SetAccessedBy=device, i.e. the data is
+    deliberately host-resident with the GPU mapping it directly ("no page faults
+    will be generated").  So the question is not fault-and-migrate cost, it is
+    what plain host reads/writes to that mapping cost under virtualization -
+    which is what test_uvm_slice's host-side loop does.
+
+    Both configurations are measured so the advises can be shown to matter or not.
+    """
+    print("-- H5  host access to managed memory " + "-" * 39)
+    PAGE = 4096
+    size = pages * PAGE
+
+    for label, advise in (("plain", False), ("fbgemm_advised", True)):
+        mptr = ctypes.c_void_p()
+        rc = hip.hipMallocManaged(ctypes.byref(mptr), size, 1)  # hipMemAttachGlobal
+        if rc != 0:
+            result(f"H5_{label}", status=f"hipMallocManaged failed rc={rc}")
+            continue
+        if advise:
+            hip.hipMemAdvise(mptr, size, hipMemAdviseSetPreferredLocation, hipCpuDeviceId)
+            hip.hipMemAdvise(mptr, size, hipMemAdviseSetAccessedBy, 0)
+
+        buf = (ctypes.c_ubyte * size).from_address(mptr.value)
+
+        writes = []
+        for p in range(pages):
+            off = p * PAGE
+            t0 = ns()
+            buf[off] = 1
+            writes.append(ns() - t0)
+        reads = []
+        for p in range(pages):
+            off = p * PAGE
+            t0 = ns()
+            _ = buf[off]
+            reads.append(ns() - t0)
+
+        wm, wmean, wp99 = stats(writes)
+        rm, rmean, rp99 = stats(reads)
+        result(f"H5_{label}", pages=pages,
+               write_median_us=f"{wm:.3f}", write_p99_us=f"{wp99:.3f}",
+               read_median_us=f"{rm:.3f}", read_p99_us=f"{rp99:.3f}",
+               total_ms=f"{(sum(writes)+sum(reads))/1e6:.1f}")
+        histogram(writes, f"H5 {label} per-page host write")
+        hip.hipFree(mptr)
+    print()
+
+
+# H6 (hipMemAdvise cost scales with range size) was dropped: it assumed the test
+# generates multi-TB ranges, which the bare-metal evidence contradicts.
+
+
+# --------------------------------------------------------------------------- #
+# H7 - allocation latency
+# --------------------------------------------------------------------------- #
+
+def h7_alloc(iters=200):
+    print("-- H7  allocation latency " + "-" * 50)
+    for label, fn, sz in (("hipMalloc_1MiB", "malloc", 1 << 20),
+                          ("hipMallocManaged_1MiB", "managed", 1 << 20)):
+        samples = []
+        for _ in range(iters):
+            p = ctypes.c_void_p()
+            t0 = ns()
+            if fn == "malloc":
+                rc = hip.hipMalloc(ctypes.byref(p), sz)
+            else:
+                rc = hip.hipMallocManaged(ctypes.byref(p), sz, 1)
+            samples.append(ns() - t0)
+            if rc == 0:
+                hip.hipFree(p)
+        med, mean, p99 = stats(samples)
+        result(f"H7_{label}", iters=iters, median_us=f"{med:.2f}",
+               mean_us=f"{mean:.2f}", p99_us=f"{p99:.2f}")
+    print()
+
+
+# --------------------------------------------------------------------------- #
+
+# Each test runs in its own process with a wall-clock budget, so one wedged HIP
+# call cannot take the suite down or discard the results already collected.
+TESTS = {
+    "fingerprint": (fingerprint, 120),
+    "c1": (c1_cpu_control, 180),
+    "c2": (c2_gpu_throughput, 240),
+    "h1": (h1_roundtrip, 240),
+    "h2": (h2_submit_vs_complete, 240),
+    "h3": (h3_interrupt_vs_polling, 360),
+    "h4": (h4_small_copy, 180),
+    "h5": (h5_managed_host_access, 300),
+    "h7": (h7_alloc, 240),
+}
+
+
+def run_child(name):
+    fn, _ = TESTS[name]
+    if name not in ("fingerprint", "c1", "h3"):
+        import torch
+        if not torch.cuda.is_available():
+            print("no GPU available", file=sys.stderr)
+            sys.exit(1)
+        torch.zeros(1, device="cuda")  # init context before timing anything
+    fn()
+
+
+def main():
+    # H3 re-invokes the script with interrupts disabled; it only wants H1.
+    if os.environ.get("VF_PROBE_CHILD"):
+        import torch  # noqa: F401
+        torch.zeros(1, device="cuda")
+        h1_roundtrip(show_hist=False)
+        return
+
+    if len(sys.argv) > 2 and sys.argv[1] == "--test":
+        run_child(sys.argv[2])
+        return
+
+    for name, (_, budget) in TESTS.items():
+        try:
+            p = subprocess.run(
+                [sys.executable, "-u", os.path.abspath(__file__), "--test", name],
+                timeout=budget, capture_output=True, text=True,
+            )
+            sys.stdout.write(p.stdout)
+            if p.returncode != 0:
+                print(f"!! {name} exited rc={p.returncode}")
+                tail = (p.stderr or "").strip().splitlines()[-5:]
+                for l in tail:
+                    print(f"   {l}")
+                print()
+        except subprocess.TimeoutExpired as e:
+            sys.stdout.write(e.stdout.decode() if e.stdout else "")
+            print(f"!! {name} EXCEEDED its {budget}s budget and was killed.")
+            print("   Note: a HIP call stuck in the kernel may defer SIGKILL; "
+                  "check for a lingering process before re-running.\n")
+        sys.stdout.flush()
+
+    print("=" * 78)
+    print("done")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/vf_latency_probe.py
+++ b/.github/scripts/vf_latency_probe.py
@@ -570,20 +570,43 @@ def h11_unique_consecutive_loop(iters=500, n=32, u=33):
     print()
 
 
+# --------------------------------------------------------------------------- #
+# H12 - is it FBGEMM's op, or gradcheck on this runner generally?
+#
+# test_index_select_dim0 is 51x slower on the VF and every primitive measured so
+# far comes back ~1x.  gradcheck over plain torch.index_select exercises the same
+# machinery - thousands of tiny forward/backward calls, autograd graph churn,
+# host-side comparison - with no FBGEMM code at all.  If this is also ~50x
+# slower, the problem is not index_select_dim0 and profiling it would mislead.
+# --------------------------------------------------------------------------- #
+
+def h12_gradcheck_torch():
+    print("-- H12  gradcheck over plain torch.index_select " + "-" * 28)
+    import torch
+    u, d, n = 33, 128, 32          # same scale as the FBGEMM test's shapes
+    x = torch.rand((u, d), dtype=torch.float32, device="cuda").requires_grad_(True)
+    idx = torch.randint(u, (n,), device="cuda")
+
+    t0 = ns()
+    ok = True
+    try:
+        torch.autograd.gradcheck(
+            lambda t: torch.index_select(t, 0, idx), (x,),
+            eps=1e-2, atol=1e-3, rtol=1e-3)
+    except Exception as e:
+        # Numerical failure is fine - we only care how long the machinery takes.
+        ok = f"{type(e).__name__}"
+    dt = (ns() - t0) / 1e9
+    result("H12_gradcheck_torch", shape=f"{u}x{d}", indices=n,
+           seconds=f"{dt:.2f}", passed=ok)
+    print()
+
+
 TESTS = {
     "fingerprint": (fingerprint, 120),
-    "c1": (c1_cpu_control, 180),
-    "c2": (c2_gpu_throughput, 240),
-    "h1": (h1_roundtrip, 240),
-    "h2": (h2_submit_vs_complete, 240),
-    "h3": (h3_interrupt_vs_polling, 360),
-    "h4": (h4_small_copy, 180),
-    "h5": (h5_managed_host_access, 300),
-    "h7": (h7_alloc, 240),
-    "h8": (h8_device_free, 240),
-    "h9": (h9_pinned, 240),
-    "h10": (h10_alloc_churn, 240),
-    "h11": (h11_unique_consecutive_loop, 300),
+    # H1-H11 all came back ~1x on the VF except managed and pinned memory, and
+    # have served their purpose; only the discriminator is kept.
+    "h12": (h12_gradcheck_torch, 600),
 }
 
 

--- a/.github/scripts/vf_uvm_repro.py
+++ b/.github/scripts/vf_uvm_repro.py
@@ -232,7 +232,7 @@ def run_both_regimes():
         env["VF_REPRO_CHILD"] = "1"
         try:
             p = subprocess.run([sys.executable, "-u", os.path.abspath(__file__)],
-                               env=env, timeout=1500, capture_output=True, text=True)
+                               env=env, timeout=900, capture_output=True, text=True)
             sys.stdout.write(p.stdout)
             if p.returncode != 0:
                 print(f"!! regime exited rc={p.returncode}")

--- a/.github/scripts/vf_uvm_repro.py
+++ b/.github/scripts/vf_uvm_repro.py
@@ -139,8 +139,18 @@ def main():
 
     try:
         import torch
-        torch.zeros(1, device="cuda")
+        # Do NOT allocate ordinary device memory here.  Under HSA_XNACK=1,
+        # torch.zeros(1, device="cuda") hangs in CUDA init on gfx950 - in a bare
+        # interpreter and under pytest alike.  The UVM tests never trip this
+        # because they only ever create zero-element tensors and managed memory.
+        torch.empty(0, device="cuda:0", dtype=torch.float)
+        arch = torch.cuda.get_device_properties(0).gcnArchName
         print(f"  device      : {torch.cuda.get_device_name(0)}")
+        # The decisive field: gcnArchName reports xnack+ only when XNACK is
+        # actually active, so this shows whether HSA_XNACK=1 took effect at all.
+        print(f"  gcnArchName : {arch}")
+        print(f"  HSA_XNACK   : {os.environ.get('HSA_XNACK', '(unset)')}"
+              f"   -> XNACK {'ACTIVE' if 'xnack+' in arch else 'INACTIVE'}")
     except Exception as e:
         print(f"  device      : torch init failed ({e})")
 
@@ -204,5 +214,38 @@ def main():
     return 0
 
 
+def run_both_regimes():
+    """Run the ladder twice in child processes: without XNACK and with it.
+
+    HSA_XNACK is read once at HSA runtime init, so it cannot be toggled inside a
+    single process.  Both arms in one job keeps them directly comparable, and
+    the same script run on bare metal gives the other half of the 2x2.
+    """
+    import subprocess
+    for label, extra in (("HSA_XNACK unset", {}), ("HSA_XNACK=1", {"HSA_XNACK": "1"})):
+        print("\n" + "#" * 78)
+        print(f"# REGIME: {label}")
+        print("#" * 78, flush=True)
+        env = dict(os.environ)
+        env.pop("HSA_XNACK", None)
+        env.update(extra)
+        env["VF_REPRO_CHILD"] = "1"
+        try:
+            p = subprocess.run([sys.executable, "-u", os.path.abspath(__file__)],
+                               env=env, timeout=1500, capture_output=True, text=True)
+            sys.stdout.write(p.stdout)
+            if p.returncode != 0:
+                print(f"!! regime exited rc={p.returncode}")
+                for l in (p.stderr or "").strip().splitlines()[-5:]:
+                    print("   ", l)
+        except subprocess.TimeoutExpired as e:
+            sys.stdout.write(e.stdout.decode() if e.stdout else "")
+            print(f"!! regime '{label}' exceeded its budget and was killed")
+        sys.stdout.flush()
+    return 0
+
+
 if __name__ == "__main__":
+    if not os.environ.get("VF_REPRO_CHILD"):
+        sys.exit(run_both_regimes())
     sys.exit(main())

--- a/.github/scripts/vf_uvm_repro.py
+++ b/.github/scripts/vf_uvm_repro.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Reproduce the conditions of the hanging UVM tests, without FBGEMM or pytest.
+
+test_uvm_slice hangs on the MI350 CI runner and passes in ~10s on bare metal.
+It never touches the allocated data - it allocates a managed tensor, slices it,
+and compares storage pointers - so the cost has to be in allocation, the two
+memory advises new_managed_tensor issues, or the free.
+
+The shapes below are the exact ones Hypothesis generated on the runner, read out
+of the CI log.  They are much larger than "a UVM test" suggests: 39 distinct
+shapes up to 786 GiB, 2.09 TiB requested in total.  That is the condition this
+script replicates, at the same sizes, through the same HIP calls, timing each
+step separately.
+
+It also reports the memory the environment actually has.  Nothing in the CI
+pipeline has ever printed that - print_system_info covers CPU, PCI and kernel but
+not memory - and the runner is a pod inside a KVM guest, so both guest RAM and a
+cgroup limit are plausible constraints that our 3 TiB bare-metal box does not
+have.
+
+Ascending order with a bail-out, so the first size that misbehaves is identified
+without wedging the machine on the one after it.
+"""
+
+import ctypes
+import os
+import sys
+import time
+
+# Exact shapes recorded on the MI350 VF runner, ascending by size.
+REAL_SHAPES = [
+    [1], [16], [1, 86], [107], [176], [463], [760], [946], [86, 86],
+    [163, 105], [18, 351, 4], [246, 246], [943, 133], [256, 624],
+    [96, 307, 23], [16, 270, 387], [61, 627, 234], [61, 627, 627],
+    [1023, 513, 823], [133, 133, 943, 133], [163, 105, 249, 575],
+    [300, 110, 320, 246], [255, 255, 939, 70], [943, 94, 377, 133],
+    [300, 246, 320, 246], [246, 246, 320, 320], [868, 76, 383, 282],
+    [300, 246, 320, 320], [320, 246, 320, 320], [943, 94, 943, 133],
+    [255, 709, 939, 70], [943, 133, 943, 133], [133, 133, 943, 943],
+    [255, 939, 939, 70], [939, 255, 939, 70], [939, 255, 939, 255],
+    [255, 939, 939, 255], [943, 133, 943, 943], [939, 939, 939, 255],
+]
+
+# Stop climbing once a single step takes longer than this.  The next shape is
+# often several times larger, so continuing past a slow one risks a wedge.
+BAIL_SECONDS = float(os.environ.get("VF_REPRO_BAIL_SECONDS", "60"))
+# Cap in GiB, so a cautious run can be done on a shared machine first.
+MAX_GIB = float(os.environ.get("VF_REPRO_MAX_GIB", "1024"))
+
+hipMemAdviseSetPreferredLocation = 3
+hipMemAdviseSetAccessedBy = 5
+hipCpuDeviceId = -1
+
+
+def load_hip():
+    cands = []
+    try:
+        import torch
+        cands.append(os.path.join(os.path.dirname(torch.__file__), "lib",
+                                  "libamdhip64.so"))
+    except Exception:
+        pass
+    cands += ["/opt/rocm/lib/libamdhip64.so", "libamdhip64.so",
+              "libamdhip64.so.7", "libamdhip64.so.6"]
+    for c in cands:
+        try:
+            return ctypes.CDLL(c), c
+        except OSError:
+            continue
+    return None, "NOT FOUND"
+
+
+def read_first(path, keys):
+    try:
+        with open(path) as f:
+            for line in f:
+                for k in keys:
+                    if line.startswith(k):
+                        return line.strip()
+    except Exception:
+        pass
+    return None
+
+
+def mem_available_gib():
+    """MemAvailable in GiB, to show whether an allocation actually commits."""
+    line = read_first("/proc/meminfo", ("MemAvailable",))
+    return int(line.split()[1]) / 1048576 if line else float("nan")
+
+
+def report_memory(label):
+    """Guest RAM and cgroup limits.  A pod limit is invisible to /proc/meminfo,
+    so both are reported."""
+    print(f"  [{label}]")
+    for k in ("MemTotal", "MemAvailable", "SwapTotal", "Committed_AS"):
+        line = read_first("/proc/meminfo", (k,))
+        if line:
+            val = int(line.split()[1]) / 1048576
+            print(f"    {k:14}: {val:10.1f} GiB")
+    for path in ("/sys/fs/cgroup/memory.max",
+                 "/sys/fs/cgroup/memory.current",
+                 "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+                 "/sys/fs/cgroup/memory/memory.usage_in_bytes"):
+        try:
+            with open(path) as f:
+                raw = f.read().strip()
+            if raw == "max":
+                print(f"    {os.path.basename(path):14}: max (unlimited)")
+            else:
+                print(f"    {os.path.basename(path):14}: {int(raw)/2**30:10.1f} GiB")
+        except Exception:
+            pass
+    for path in ("/proc/sys/vm/overcommit_memory", "/proc/sys/vm/overcommit_ratio"):
+        try:
+            with open(path) as f:
+                print(f"    {os.path.basename(path):14}: {f.read().strip()}")
+        except Exception:
+            pass
+
+
+def main():
+    hip, hip_path = load_hip()
+    print("=" * 78)
+    print("UVM ALLOCATION REPRODUCTION")
+    print("=" * 78)
+    print(f"  libamdhip64 : {hip_path}")
+    print(f"  bail after  : {BAIL_SECONDS}s per step")
+    print(f"  size cap    : {MAX_GIB} GiB")
+    if hip is None:
+        print("  libamdhip64 unavailable - cannot run")
+        return 1
+
+    hip.hipMallocManaged.argtypes = [ctypes.POINTER(ctypes.c_void_p),
+                                     ctypes.c_size_t, ctypes.c_uint]
+    hip.hipFree.argtypes = [ctypes.c_void_p]
+    hip.hipMemAdvise.argtypes = [ctypes.c_void_p, ctypes.c_size_t,
+                                 ctypes.c_int, ctypes.c_int]
+
+    try:
+        import torch
+        torch.zeros(1, device="cuda")
+        print(f"  device      : {torch.cuda.get_device_name(0)}")
+    except Exception as e:
+        print(f"  device      : torch init failed ({e})")
+
+    report_memory("memory at start")
+    print()
+    print(f"{'shape':32} {'GiB':>9} {'alloc_ms':>10} {'ms/GiB':>8} "
+          f"{'advise2_ms':>11} {'free_ms':>9} {'commit_GiB':>11}  rc")
+    print("-" * 100)
+
+    for shape in REAL_SHAPES:
+        nbytes = 4
+        for d in shape:
+            nbytes *= d
+        gib = nbytes / 2**30
+        if gib > MAX_GIB:
+            print(f"{str(shape):32} {gib:10.3f}  skipped, above cap")
+            continue
+
+        p = ctypes.c_void_p()
+        avail_before = mem_available_gib()
+        t0 = time.perf_counter()
+        rc = hip.hipMallocManaged(ctypes.byref(p), nbytes, 1)
+        t_alloc = time.perf_counter() - t0
+        if rc != 0:
+            print(f"{str(shape):32} {gib:10.3f} {t_alloc*1e3:10.1f}  "
+                  f"ALLOC FAILED rc={rc}", flush=True)
+            report_memory("memory after failed alloc")
+            break
+
+        # Exactly what new_managed_tensor does after the allocation.
+        t0 = time.perf_counter()
+        hip.hipMemAdvise(p, nbytes, hipMemAdviseSetPreferredLocation, hipCpuDeviceId)
+        t_adv1 = time.perf_counter() - t0
+        t0 = time.perf_counter()
+        hip.hipMemAdvise(p, nbytes, hipMemAdviseSetAccessedBy, 0)
+        t_adv2 = time.perf_counter() - t0
+
+        # How much memory the allocation actually consumed: distinguishes a
+        # lazy virtual reservation from an eager commit.
+        committed = avail_before - mem_available_gib()
+
+        t0 = time.perf_counter()
+        hip.hipFree(p)
+        t_free = time.perf_counter() - t0
+
+        rate = t_alloc * 1e3 / gib if gib > 0.001 else float('nan')
+        print(f"{str(shape):32} {gib:9.3f} {t_alloc*1e3:10.1f} {rate:8.2f} "
+              f"{t_adv2*1e3:11.1f} {t_free*1e3:9.1f} {committed:11.1f}  {rc}", flush=True)
+
+        worst = max(t_alloc, t_adv1, t_adv2, t_free)
+        if worst > BAIL_SECONDS:
+            print(f"\n  BAIL: a step took {worst:.1f}s at {gib:.1f} GiB; "
+                  f"not attempting larger shapes.")
+            report_memory("memory at bail")
+            break
+
+    print()
+    report_memory("memory at end")
+    print("=" * 78)
+    print("done")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -259,8 +259,14 @@ jobs:
     # the real shapes from the CI log, the same HIP call sequence, per-step
     # timing, plus the guest and cgroup memory limits that nothing in this
     # pipeline has ever reported.
+    # Runs the ladder twice, without HSA_XNACK and with HSA_XNACK=1, reporting
+    # gcnArchName in each.  The arch string is the decisive field: it reads
+    # xnack+ only when XNACK actually took effect, so this shows whether the
+    # runner can enter the fast path at all, and what allocation costs if it
+    # cannot.  test_all_fbgemm_gpu_modules sets HSA_XNACK=1 for ROCm, so the
+    # tests run in whichever regime the runner ends up in.
     - name: UVM Allocation Reproduction
-      timeout-minutes: 30
+      timeout-minutes: 55
       continue-on-error: true
       env:
         # Deliberately bounded.  Allocation cost is linear in size on bare metal

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -174,8 +174,10 @@ jobs:
         python-version: [ "3.14" ]
         rocm-version: [ "7.1" ]
         compiler: [ "gcc" ]
-    # DEBUG PR: no "needs: build_artifact".  The probe uses only torch and
-    # libamdhip64, so waiting on the build matrix would add hours for nothing.
+    # DEBUG PR: the build dependency is back - profiling the real test needs the
+    # FBGEMM wheel.  The matrix is trimmed to one combination, so this costs ~50
+    # minutes rather than the ~3 hours the full matrix would.
+    needs: build_artifact
 
     steps:
     - name: Setup Build Container
@@ -189,9 +191,7 @@ jobs:
       with:
         ref: ${{ (github.event_name == 'schedule' && 'nightly') || github.ref }}
 
-    # DEBUG PR: no wheel is built for this run, so there is nothing to download.
     - name: Download Wheel Artifact from GHA
-      if: false
       uses: actions/download-artifact@v7
       with:
         name: fbgemm_${{ matrix.build-target }}_${{ matrix.host-machine.arch }}_${{ matrix.compiler }}_py${{ matrix.python-version }}_rocm${{ matrix.rocm-version }}.whl
@@ -286,17 +286,54 @@ jobs:
           conda run --no-capture-output -n "$BUILD_ENV" python -u .github/scripts/vf_uvm_repro.py
         fi
 
-    # DEBUG PR: everything below is disabled.  No wheel exists to install, and the
-    # test suite is not what this run is measuring.
     - name: Prepare FBGEMM_GPU Build
-      if: false
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
     - name: Install FBGEMM_GPU Wheel
-      if: false
       run: . $PRELUDE; install_fbgemm_gpu_wheel $BUILD_ENV *.whl
 
-    - name: Test with PyTest
-      if: false
-      timeout-minutes: 90
-      run: . $PRELUDE; test_all_fbgemm_gpu_modules $BUILD_ENV
+    # DEBUG PR: profile the one test that is 51x slower on this runner and that
+    # no primitive measurement has explained.  Runs that nodeid only - the rest
+    # of the suite is not what this measures.
+    #
+    # The env below replicates what __configure_fbgemm_gpu_test_rocm sets, since
+    # we bypass test_all_fbgemm_gpu_modules: without CI=true Hypothesis picks a
+    # different example sequence, and without HIP_LAUNCH_BLOCKING the timing may
+    # not reproduce at all.
+    #
+    # cProfile, not py-spy.  py-spy was tried and rejected: --native has to
+    # symbolize through libtorch/libamdhip64/the FBGEMM .so and fell 221s behind
+    # at 50Hz, and even without --native it made an ~8s test exceed 60s.
+    # cProfile costs ~15% here (9.19s vs ~8s) and answers the first question -
+    # whether the time sits inside the op call or in gradcheck's Python
+    # machinery.  If it turns out to be inside one C++ call, a native profiler
+    # is the follow-up, not the starting point.
+    - name: Profile test_index_select_dim0
+      timeout-minutes: 45
+      continue-on-error: true
+      env:
+        CI: "true"
+        FBGEMM_TEST_WITH_ROCM: "1"
+        HIP_LAUNCH_BLOCKING: "1"
+        HSA_XNACK: "1"
+        FBGEMM_TBE_ROCM_INFERENCE_PACKED_BAGS: "1"
+      run: |
+        PY="${HOME}/miniconda/envs/${BUILD_ENV}/bin/python"
+        [ -x "$PY" ] || PY="$(command -v python)"
+        cd fbgemm_gpu/test
+        NODEID="./sparse/index_select_test.py::IndexSelectTest::test_index_select_dim0"
+
+        start=$(date +%s)
+        "$PY" -u -m cProfile -o /tmp/prof.out -m pytest -q -s \
+          -W ignore::pytest.PytestCollectionWarning --cache-clear "$NODEID" \
+          || echo "[PROFILE] pytest returned non-zero"
+        echo "[PROFILE] wall time: $(( $(date +%s) - start ))s"
+
+        "$PY" - <<'PYEOF'
+        import pstats
+        p = pstats.Stats("/tmp/prof.out")
+        print("\n=== top 40 by cumulative time ===")
+        p.sort_stats("cumulative").print_stats(40)
+        print("\n=== top 40 by total (self) time ===")
+        p.sort_stats("tottime").print_stats(40)
+        PYEOF

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -320,7 +320,15 @@ jobs:
       run: |
         PY="${HOME}/miniconda/envs/${BUILD_ENV}/bin/python"
         [ -x "$PY" ] || PY="$(command -v python)"
-        cd fbgemm_gpu/test
+        # test_all_fbgemm_gpu_modules installs the test dependencies as well as
+        # setting the environment; bypassing it means installing them here, or
+        # pytest is simply absent.
+        . $PRELUDE
+        cd fbgemm_gpu
+        install_fbgemm_gpu_deps "$BUILD_ENV"
+        "$PY" -m pip install --quiet pytest
+
+        cd test
         NODEID="./sparse/index_select_test.py::IndexSelectTest::test_index_select_dim0"
 
         start=$(date +%s)

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -255,6 +255,31 @@ jobs:
           conda run --no-capture-output -n "$BUILD_ENV" python -u .github/scripts/vf_latency_probe.py
         fi
 
+    # DEBUG PR: replicate the conditions of the hanging UVM tests directly -
+    # the real shapes from the CI log, the same HIP call sequence, per-step
+    # timing, plus the guest and cgroup memory limits that nothing in this
+    # pipeline has ever reported.
+    - name: UVM Allocation Reproduction
+      timeout-minutes: 30
+      continue-on-error: true
+      env:
+        # Deliberately bounded.  Allocation cost is linear in size on bare metal
+        # (55 ms/GiB from 8 to 58 GiB), so the slope measured at safe sizes
+        # extrapolates to the 786 GiB shapes the real test uses.  Running those
+        # directly would burn the step budget - a 415 GiB allocation blocked for
+        # over 12 minutes on bare metal - and tell us nothing extra.
+        VF_REPRO_BAIL_SECONDS: "30"
+        VF_REPRO_MAX_GIB: "32"
+      run: |
+        PY="${HOME}/miniconda/envs/${BUILD_ENV}/bin/python"
+        [ -x "$PY" ] || PY=""
+        if [ -n "$PY" ]; then
+          "$PY" -u .github/scripts/vf_uvm_repro.py
+        else
+          . $PRELUDE
+          conda run --no-capture-output -n "$BUILD_ENV" python -u .github/scripts/vf_uvm_repro.py
+        fi
+
     # DEBUG PR: everything below is disabled.  No wheel exists to install, and the
     # test suite is not what this run is measuring.
     - name: Prepare FBGEMM_GPU Build

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -320,15 +320,16 @@ jobs:
       run: |
         PY="${HOME}/miniconda/envs/${BUILD_ENV}/bin/python"
         [ -x "$PY" ] || PY="$(command -v python)"
-        # test_all_fbgemm_gpu_modules installs the test dependencies as well as
-        # setting the environment; bypassing it means installing them here, or
-        # pytest is simply absent.
+        # Bypassing test_all_fbgemm_gpu_modules skips the dependency install it
+        # performs as well as the environment it sets: pytest and expecttest are
+        # in neither requirements.txt nor install_build_tools, and are installed
+        # by fbgemm_gpu_testing_setup.  Call that directly rather than
+        # reimplementing it.  It pushd's into a scratch directory, so pop back.
         . $PRELUDE
-        cd fbgemm_gpu
-        install_fbgemm_gpu_deps "$BUILD_ENV"
-        "$PY" -m pip install --quiet pytest
+        fbgemm_gpu_testing_setup "$BUILD_ENV"
+        popd 2>/dev/null || true
 
-        cd test
+        cd fbgemm_gpu/test
         NODEID="./sparse/index_select_test.py::IndexSelectTest::test_index_select_dim0"
 
         start=$(date +%s)

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -237,7 +237,23 @@ jobs:
       timeout-minutes: 40
       continue-on-error: true
       run: |
-        "${HOME}/miniconda/envs/${BUILD_ENV}/bin/python" -u .github/scripts/vf_latency_probe.py
+        # Resolve the interpreter explicitly; conda is not reliably on PATH in a
+        # fresh step, and a wrong interpreter is the easiest way to waste a round.
+        PY="${HOME}/miniconda/envs/${BUILD_ENV}/bin/python"
+        if [ ! -x "$PY" ]; then
+          echo "[PROBE] $PY not found, falling back to conda run"
+          PY=""
+        fi
+        echo "[PROBE] interpreter: ${PY:-conda run -n $BUILD_ENV python}"
+        ls -la "$(dirname "$PY")" 2>/dev/null | head -5 || true
+        echo "[PROBE] candidate HIP libraries visible:"
+        ls -la /opt/rocm/lib/libamdhip64* 2>/dev/null || echo "  none under /opt/rocm/lib"
+        if [ -n "$PY" ]; then
+          "$PY" -u .github/scripts/vf_latency_probe.py
+        else
+          . $PRELUDE
+          conda run --no-capture-output -n "$BUILD_ENV" python -u .github/scripts/vf_latency_probe.py
+        fi
 
     # DEBUG PR: everything below is disabled.  No wheel exists to install, and the
     # test suite is not what this run is measuring.

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -75,13 +75,16 @@ jobs:
           { arch: x86, instance: "linux.24xlarge" },
         ]
         container-image: [ "ubuntu:22.04" ]
-        build-target: [ "default", "genai" ]
+        # DEBUG PR: trimmed from ["default","genai"] x ["7.0","7.1"] x ["gcc","clang"]
+        # to a single combination.  The probe needs no FBGEMM wheel at all, so
+        # building the full matrix would just occupy shared runners for hours.
+        build-target: [ "default" ]
         # NOTE: we test only a subset of Python versions to reduce CI expenses
         python-version: [ "3.14" ]
         # NOTE: PyTorch releases for ROCm include the ROCm patch version,
         # unlike releases for CUDA
-        rocm-version: [ "7.0", "7.1" ]
-        compiler: [ "gcc", "clang" ]
+        rocm-version: [ "7.1" ]
+        compiler: [ "gcc" ]
 
     steps:
     - name: Setup Build Container
@@ -161,14 +164,18 @@ jobs:
       fail-fast: false
       matrix:
         host-machine: [
-          { arch: x86, instance: "linux.rocm.gpu.gfx942.1" },
+          # DEBUG PR: the gfx942 label on main is unserved, so jobs using it queue
+          # and are cancelled without ever running.  The probe has to land on the
+          # MI350 runner, which is the environment under investigation.
+          { arch: x86, instance: "linux.rocm.gpu.ecosystem.mi350.1" },
         ]
-        build-target: [ "default", "genai" ]
+        build-target: [ "default" ]
         # ROCm machines are limited, so we only test a subset of Python versions
         python-version: [ "3.14" ]
         rocm-version: [ "7.1" ]
-        compiler: [ "gcc", "clang" ]
-    needs: build_artifact
+        compiler: [ "gcc" ]
+    # DEBUG PR: no "needs: build_artifact".  The probe uses only torch and
+    # libamdhip64, so waiting on the build matrix would add hours for nothing.
 
     steps:
     - name: Setup Build Container
@@ -182,7 +189,9 @@ jobs:
       with:
         ref: ${{ (github.event_name == 'schedule' && 'nightly') || github.ref }}
 
+    # DEBUG PR: no wheel is built for this run, so there is nothing to download.
     - name: Download Wheel Artifact from GHA
+      if: false
       uses: actions/download-artifact@v7
       with:
         name: fbgemm_${{ matrix.build-target }}_${{ matrix.host-machine.arch }}_${{ matrix.compiler }}_py${{ matrix.python-version }}_rocm${{ matrix.rocm-version }}.whl
@@ -220,12 +229,27 @@ jobs:
       if: ${{ success() || failure() }}
       run: if . $PRELUDE && which conda; then collect_pytorch_env_info $BUILD_ENV; fi
 
+    # DEBUG PR: the whole point of this run.  Placed before any FBGEMM step so it
+    # cannot be affected by the wheel, and so its output survives regardless of
+    # what happens later.  Deliberately does not fail the job: we want the numbers
+    # in the log, not a red/green verdict.
+    - name: GPU Virtualization Latency Probe
+      timeout-minutes: 40
+      continue-on-error: true
+      run: |
+        "${HOME}/miniconda/envs/${BUILD_ENV}/bin/python" -u .github/scripts/vf_latency_probe.py
+
+    # DEBUG PR: everything below is disabled.  No wheel exists to install, and the
+    # test suite is not what this run is measuring.
     - name: Prepare FBGEMM_GPU Build
+      if: false
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
     - name: Install FBGEMM_GPU Wheel
+      if: false
       run: . $PRELUDE; install_fbgemm_gpu_wheel $BUILD_ENV *.whl
 
     - name: Test with PyTest
+      if: false
       timeout-minutes: 90
       run: . $PRELUDE; test_all_fbgemm_gpu_modules $BUILD_ENV


### PR DESCRIPTION
**Do not merge.** This is a throwaway diagnostic PR. It deliberately disables most of the ROCm CI job so a single measurement can run on the MI350 runner. It will be closed once the numbers are collected.

### Why

The MI350 ROCm runner is a KVM guest with an SR-IOV virtual function (`torch.cuda.get_device_name()` returns `AMD Instinct MI350X VF`; `lscpu` reports `Hypervisor vendor: KVM`). A few tests are drastically slower there than on the previous bare-metal MI325X runner, while bulk compute is essentially unaffected:

| | MI325X bare metal | MI350X VF |
|---|---|---|
| `sparse/index_select_test.py` | 16 s | 816–1172 s |
| `tbe/cache/copy_test.py` | 9 s | 532–598 s |
| `tbe/cache/uvm_test.py` | 10 s | never returns (90 min timeout) |
| all other test files | — | median 1.1x |

The common factor looks like host↔device round trips rather than throughput. `test_index_select_dim0` alone accounts for ~1007 s, and it is `gradcheck` over tiny tensors — roughly 84k small launches, each followed by a synchronize. That works out to ~12 ms per round trip against 16.9 µs measured on bare metal.

### What this adds

`.github/scripts/vf_latency_probe.py`, a standalone probe with no FBGEMM, pytest or compiler dependency — just torch plus `libamdhip64` through `ctypes`:

- **C1** CPU control — is the guest CPU itself slow? (must be ruled out first)
- **C2** bulk GPU throughput — do we only get a slice of the GPU?
- **H1** launch + synchronize round trip, reported as a histogram, since a scheduling quantum quantises rather than shifting a mean
- **H2** submission vs completion
- **H3** H1 repeated with `HSA_ENABLE_INTERRUPT=0`
- **H4** 4-byte D2H copy latency
- **H5** host access to managed memory, in the configuration `new_managed_tensor` actually uses
- **H7** allocation latency

Bare-metal MI350X reference from the same script, for comparison against whatever CI reports:

```
C1 python_loop=158ms   C2 1005.6 TFLOP/s   H1 median 16.9us (p99 20.1us)
H2 submit 4.44us / idle-sync 1.97us        H3 16.9us (unchanged)
H4 14.65us   H5 0.070us per page   H7 malloc 0.81us / managed 84.03us
```

### Deliberate CI changes, all of which must be reverted

- Build and test matrices trimmed to one combination (default / gcc / 7.1)
- `needs: build_artifact` dropped — the probe needs no wheel
- Wheel download, build prep, wheel install and the pytest step set to `if: false`
- Runner label switched to `linux.rocm.gpu.ecosystem.mi350.1`, since the `gfx942` label on main is currently unserved and jobs using it queue and are cancelled without running

Together these take a round from several hours to roughly fifteen minutes, and avoid occupying the shared runner pool for a measurement that needs one GPU for about a minute.

The probe is `continue-on-error` and degrades rather than failing: if `libamdhip64` cannot be resolved it reports that and skips H4/H5/H7, while C1, C2, H1, H2 and H3 still produce numbers.
