### PR TITLE
Gather the drained rows' weights (#6220)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -1635,6 +1635,9 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         )
         self.register_buffer(
             "res_count",
+            # new_unified_tensor mallocs and ignores the input tensor's
+            # contents, so torch.zeros below does NOT zero the result -- it
+            # only supplies dtype and device. C++ reads this as a row count.
             torch.ops.fbgemm.new_unified_tensor(
                 torch.zeros(
                     1,
@@ -1643,11 +1646,15 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 ),
                 (1,),
                 is_host_mapped=self.uvm_host_mapped,
-            ),
+            ).zero_(),
             persistent=False,  # RES buffer is not checkpointed since it is used as intermediate buffer for copying
         )
         self.register_buffer(
             "res_copy_done",
+            # Unzeroed for the same reason as res_count above. The C++ poll
+            # reads any nonzero as "the GPU is done writing the RES buffers"
+            # and then resets it, so garbage here desyncs the handshake by one
+            # iteration for the rest of the run, not just the first drain.
             torch.ops.fbgemm.new_unified_tensor(
                 torch.zeros(
                     1,
@@ -1656,7 +1663,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 ),
                 (1,),
                 is_host_mapped=self.uvm_host_mapped,
-            ),
+            ).zero_(),
             persistent=False,  # RES buffer is not checkpointed since it is used as intermediate buffer for copying
         )
 

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -1575,6 +1575,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             )
             self._register_res_enabled_feature_mask()
             if self.res_params.enable_hbm_streaming:
+                self._precompute_res_gather_layout()
                 self._register_res_hbm_buffers()
             logging.info(
                 f"{self.uuid} raw embedding streaming enabled with {self.res_params=}, {self._res_require_copy=}, {self._res_sync_copy=}"
@@ -1762,6 +1763,129 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self._res_all_features_enabled: bool = bool(enabled_feature_mask.all())
 
     @torch.jit.ignore
+    def _precompute_res_gather_layout(self) -> None:
+        """Decide the gather path once, at construction."""
+        pool_dims = {
+            spec[1]
+            for spec in self.embedding_specs
+            if spec[2] == EmbeddingLocation.DEVICE
+        }
+        # Empty and one-width both count as uniform.
+        self._res_hbm_dims_equal: bool = len(pool_dims) <= 1
+        self._res_hbm_dim: int = next(iter(pool_dims)) if len(pool_dims) == 1 else 0
+        self._res_device_features: set[int] = {
+            f
+            for f, t in enumerate(self.feature_table_map)
+            if self.embedding_specs[t][2] == EmbeddingLocation.DEVICE
+        }
+        n_features = len(self.feature_table_map)
+        self._res_all_features_device_placed: bool = (
+            len(self._res_device_features) == n_features
+        )
+        # Differing widths are handled a table at a time, and that loop needs
+        # each feature's width, offset and row count as plain numbers. Reading
+        # them off the device there would sync three times per feature per
+        # drain, and they are table layout, so read them once. One entry per
+        # FEATURE, not per table.
+        self._res_weights_offsets_cpu: torch.Tensor = self.weights_offsets.cpu()
+        self._res_rows_per_table_cpu: torch.Tensor = self.rows_per_table.cpu()
+        self._res_D_offsets_cpu: torch.Tensor = self.D_offsets.cpu()
+
+    @torch.jit.ignore
+    def _gather_res_rows(
+        self,
+        res_indices: torch.Tensor,
+        res_weights: torch.Tensor,
+        weights: torch.Tensor,
+    ) -> None:
+        """Gather the rows named by `res_indices` out of `weights` into `res_weights`.
+
+        `res_indices` are in the TBE's linear index space and must exclude the
+        pruning sentinel: clamped to the last feature it becomes a row one past
+        that table's end, which device-asserts.
+
+        Zero-padding covers COLUMNS, not rows. Rows past `len(res_indices)` keep
+        the previous drain's values -- the staging buffers are grow-and-keep, so
+        callers must slice to the count.
+        """
+        if weights.numel() == 0:
+            return
+        num_indices = res_indices.size(0)
+        if num_indices == 0:
+            return
+
+        max_D = res_weights.shape[1]
+
+        uniform_device = (
+            self._res_hbm_dims_equal and self._res_all_features_device_placed
+        )
+        self.log(
+            f"[RES] gather: path={'uniform_device' if uniform_device else 'per_feature'} "
+            f"rows={num_indices}"
+        )
+
+        # Shortcut, and it needs both: one width across the pool, and every
+        # feature DEVICE-placed. Together they make a linear row id already BE
+        # the pool row, so the index goes in unmodified. Relaxing either half
+        # silently breaks that.
+        if uniform_device:
+            dim = self._res_hbm_dim
+            torch.index_select(
+                weights.view(-1, dim),
+                0,
+                res_indices.long(),
+                out=res_weights[:num_indices, :dim],
+            )
+            if dim < max_D:
+                res_weights[:num_indices, dim:].zero_()
+            return
+
+        # Flat because the loop slices by ELEMENT offset; on a 2-D weights_dev
+        # (dev_reshape, OptimType.NONE) a slice would take rows instead.
+        weights_flat = weights.flatten() if weights.dim() == 2 else weights
+        feature_indices = self._res_feature_of(res_indices)
+        # One index_select per run rather than per row. `unique_consecutive`,
+        # not `unique`: it collapses only ADJACENT equals and keeps input order,
+        # which is what lets `pos` below walk input and output together.
+        unique_features, counts = torch.unique_consecutive(
+            feature_indices, return_counts=True
+        )
+        local_indices_all = (
+            res_indices - self.hash_size_cumsum[feature_indices]
+        ).long()
+        # The syncs are here, not in the loop: the body reads host values only.
+        features: list[int] = unique_features.tolist()
+        # Free: `features` is already on the host.
+        non_device_features: list[int] = [
+            f for f in features if f not in self._res_device_features
+        ]
+        if non_device_features:
+            logging.error(
+                f"[TBE={self.uuid}] [RES] gather: SHOULD NOT HAPPEN -- features "
+                f"{non_device_features} are not DEVICE-placed, so their rows read "
+                f"from the wrong offset. _res_hbm_linear_mask marks only allowlisted "
+                f"DEVICE rows, so a drain cannot select them."
+            )
+        pos = 0
+        for feature_idx, cnt in zip(features, counts.tolist()):
+            dim = int(
+                self._res_D_offsets_cpu[feature_idx + 1]
+                - self._res_D_offsets_cpu[feature_idx]
+            )
+            w_start = int(self._res_weights_offsets_cpu[feature_idx])
+            nrows = int(self._res_rows_per_table_cpu[feature_idx])
+            table_view = weights_flat[w_start : w_start + nrows * dim].view(-1, dim)
+            torch.index_select(
+                table_view,
+                0,
+                local_indices_all[pos : pos + cnt],
+                out=res_weights[pos : pos + cnt, :dim],
+            )
+            if dim < max_D:
+                res_weights[pos : pos + cnt, dim:].zero_()
+            pos += cnt
+
+    @torch.jit.ignore
     def _register_res_hbm_buffers(self) -> None:
         """Allocate the map of rows touched since the last drain.
 
@@ -1839,6 +1963,19 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         # Tensor | Module); tensor indexing is valid at runtime.
         enabled_mask = self.res_enabled_feature_mask[valid_feature_indices]
         return enabled_mask, feature_indices
+
+    @torch.jit.ignore
+    def _res_feature_of(self, linear_indices: torch.Tensor) -> torch.Tensor:
+        """Feature id owning each linear row id, clamped to a real feature.
+
+        `right=True` so a table's first row resolves to that table, not the one
+        before. The clamp catches the pruning sentinel, which owns no feature.
+        Assumes `feature_table_map` is non-decreasing, as TorchRec emits.
+        """
+        last_feature = self._res_num_features - 1
+        return torch.searchsorted(
+            self.hash_size_cumsum[1:], linear_indices, right=True
+        ).clamp(0, last_feature)
 
     @torch.jit.ignore
     def log(self, msg: str) -> None:

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -147,6 +147,9 @@ class RESParams:
     res_enabled_tables: list[str] = field(
         default_factory=list
     )  # table names that are enabled for RES (empty means all enabled)
+    # Streams DEVICE-placed tables named in `res_enabled_tables`, which the
+    # cache lane cannot reach. Costs a byte per row of the shard, so it is opt-in.
+    enable_hbm_streaming: bool = False
 
 
 class PrefetchedInfo:
@@ -725,6 +728,12 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.table_names: list[str] | None = table_names
         self.logging_table_name: str = self.get_table_name_for_logging(table_names)
         self.enable_raw_embedding_streaming: bool = enable_raw_embedding_streaming
+        # Precomputed: `_prefetch` is not `@torch.jit.ignore`, and TorchScript
+        # cannot resolve `res_params` there, so we read it here instead.
+        self._res_hbm_streaming: bool = bool(
+            enable_raw_embedding_streaming
+            and (res_params or RESParams()).enable_hbm_streaming
+        )
         self.pooling_mode = pooling_mode
         self.is_nobag: bool = self.pooling_mode == PoolingMode.NONE
 
@@ -1565,6 +1574,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 self.res_params.table_sizes,
             )
             self._register_res_enabled_feature_mask()
+            if self.res_params.enable_hbm_streaming:
+                self._register_res_hbm_buffers()
             logging.info(
                 f"{self.uuid} raw embedding streaming enabled with {self.res_params=}, {self._res_require_copy=}, {self._res_sync_copy=}"
             )
@@ -1749,6 +1760,64 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             "res_enabled_feature_mask", enabled_feature_mask, persistent=False
         )
         self._res_all_features_enabled: bool = bool(enabled_feature_mask.all())
+
+    @torch.jit.ignore
+    def _register_res_hbm_buffers(self) -> None:
+        """Allocate the map of rows touched since the last drain.
+
+        Written during prefetch from the unfiltered `linearize_cache_indices`
+        output, so every looked-up row lands here whatever its placement or
+        allowlist status. Narrowing that down is the drain's job.
+        """
+        assert (
+            self.enable_raw_embedding_streaming
+        ), "Should not register res hbm buffers when raw embedding streaming is not enabled"
+
+        # +1: the kernel dumps indices it cannot place -- pruned rows among
+        # them -- on total_hash_size, so that slot gets written and has to exist.
+        linear_size = self.total_hash_size + 1
+        self.register_buffer(
+            "_res_rows_seen",
+            torch.zeros(linear_size, device=self.current_device, dtype=torch.bool),
+            persistent=False,  # RES buffer is not checkpointed
+        )
+
+    @torch.jit.ignore
+    def _mark_res_hbm_rows(
+        self,
+        indices: Tensor,
+        offsets: Tensor,
+        vbe_metadata: invokers.lookup_args.VBEMetadata | None,
+    ) -> None:
+        """Record every row this lookup touched, whatever its placement.
+
+        Must run before `_prefetch`'s `lxu_cache_weights.numel()` guard: a TBE
+        holding only DEVICE tables has an empty `lxu_cache_weights`, so nothing
+        past that guard runs for DEVICE-placed tables.
+        """
+        if not self._res_hbm_streaming:
+            return
+        # hash_size_cumsum, not cache_hash_size_cumsum: the latter is a
+        # 1-element stub on a cacheless TBE and holds -1 for every non-cached
+        # feature, which the kernel routes to the sentinel -- a whole DEVICE
+        # table collapsing onto one slot. It is also the index space
+        # `_res_rows_seen` is sized against.
+        linearize_indices = torch.ops.fbgemm.linearize_cache_indices(
+            self.hash_size_cumsum,
+            indices,
+            offsets,
+            vbe_metadata.B_offsets if vbe_metadata is not None else None,
+            vbe_metadata.max_B if vbe_metadata is not None else -1,
+        )
+        # index_fill_ asserts on out-of-range indices in release builds, so an
+        # unclamped index kills the rank instead of writing a wrong row.
+        # Reachable only under bounds_check_mode=NONE. Upper bound only: the
+        # kernel already routes negatives to the sentinel. In place -- the
+        # tensor is local and feeds nothing but the fill.
+        linearize_indices.clamp_(max=self.total_hash_size)
+        # index_fill_ rather than setitem: assigning a Python scalar into a
+        # CUDA tensor forces a host sync.
+        self._res_rows_seen.index_fill_(0, linearize_indices, True)
 
     @torch.jit.ignore
     def _get_enabled_feature_mask_and_indices(
@@ -3123,6 +3192,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             # Mutations of nn.Module attr forces dynamo restart of Analysis which increases compilation time
             self.timestep += 1
             self.timesteps_prefetched.append(self.timestep)
+
+        self._mark_res_hbm_rows(indices, offsets, vbe_metadata)
 
         # pyre-fixme[29]: `(self: TensorBase) -> int | Module | Tensor` is not
         #  a function.

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/raw_embedding_streamer.h
@@ -97,6 +97,9 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
   /// not interfere with cache-hit streaming at the dispatch or copy level. Only
   /// the ship path (consumer_executor_) stays shared. Defaults false (main
   /// path) -- inert until an out-of-scope caller opts in.
+  /// @param expected_flag_value when set, wait for copy_done_flag to equal
+  /// exactly this value and do not reset it, instead of waiting for any
+  /// nonzero and resetting. Must be in [1, 2^31-1]. See poll_copy_done_flag.
   ///
   /// @return None
   void stream(
@@ -108,7 +111,8 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
       bool require_tensor_copy,
       bool blocking_tensor_copy = true,
       std::optional<at::Tensor> copy_done_flag = std::nullopt,
-      bool use_hbm = false);
+      bool use_hbm = false,
+      std::optional<int64_t> expected_flag_value = std::nullopt);
 
   /*
    * Join the pending dispatch future (which resolves only after all copies for
@@ -228,9 +232,19 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
       int64_t end);
 
   // Waits (spinning) for copy_done_flag to signal the source tensors are safe
-  // to read, resetting it. Returns false on timeout. Shared by the blocking
-  // stream() path and dispatch_copy_task.
-  bool poll_copy_done_flag(const std::optional<at::Tensor>& copy_done_flag);
+  // to read. Returns false on timeout. Shared by the blocking stream() path and
+  // dispatch_copy_task.
+  //
+  // By default the flag is a boolean: the producer writes any nonzero and this
+  // resets it to 0. Passing expected_flag_value instead waits for the flag to
+  // equal exactly that value and leaves it in place. Prefer that where
+  // possible -- a boolean poll that times out leaves the flag set, so the next
+  // drain reads it as already signalled and copies the source tensors while
+  // they are still being written. The boolean form is kept for backward
+  // compatibility.
+  bool poll_copy_done_flag(
+      const std::optional<at::Tensor>& copy_done_flag,
+      std::optional<int64_t> expected_flag_value);
 
   // Coroutine form of the non-blocking dispatch (poll_copy_done_flag +
   // chunked_copy_and_enqueue). Args are taken by value so nothing dangles once
@@ -244,7 +258,8 @@ class RawEmbeddingStreamer : public torch::jit::CustomClassHolder {
       std::optional<at::Tensor> runtime_meta,
       at::Tensor count,
       std::optional<at::Tensor> copy_done_flag,
-      bool use_hbm);
+      bool use_hbm,
+      std::optional<int64_t> expected_flag_value);
 #endif
 };
 

--- a/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/raw_embedding_streamer.cpp
@@ -133,6 +133,41 @@ inline int64_t get_maybe_uvm_scalar(const at::Tensor& tensor) {
       : *(tensor.const_data_ptr<int32_t>());
 }
 
+/// Called from stream(), not poll_copy_done_flag: the non-blocking path polls
+/// from a coroutine that swallows exceptions.
+void validate_copy_done_flag(
+    const std::optional<at::Tensor>& copy_done_flag,
+    std::optional<int64_t> expected_flag_value) {
+  // 0 is the boolean reset value and the state of an untouched buffer; past
+  // int32 max the comparison narrows.
+  constexpr int64_t kMaxFlagValue = 2147483647;
+  if (expected_flag_value.has_value()) {
+    TORCH_CHECK(
+        *expected_flag_value >= 1 && *expected_flag_value <= kMaxFlagValue,
+        "expected_flag_value must be in [1, ",
+        kMaxFlagValue,
+        "], got ",
+        *expected_flag_value);
+    // Without a flag there is nothing to wait on: poll_copy_done_flag returns
+    // true immediately, so a caller that set only this would get no
+    // synchronisation and no log.
+    TORCH_CHECK(
+        copy_done_flag.has_value(),
+        "expected_flag_value requires copy_done_flag");
+  }
+  // No device check: the production flag is host-mapped and need not report
+  // device CPU.
+  if (copy_done_flag.has_value()) {
+    TORCH_CHECK(
+        copy_done_flag->scalar_type() == at::kInt &&
+            copy_done_flag->numel() == 1,
+        "copy_done_flag must be a 1-element int32 tensor, got ",
+        copy_done_flag->numel(),
+        " element(s) of ",
+        copy_done_flag->scalar_type());
+  }
+}
+
 #endif
 
 } // namespace
@@ -388,7 +423,8 @@ void RawEmbeddingStreamer::stream(
     bool require_tensor_copy [[maybe_unused]],
     bool blocking_tensor_copy [[maybe_unused]],
     std::optional<at::Tensor> copy_done_flag [[maybe_unused]],
-    bool use_hbm [[maybe_unused]]) {
+    bool use_hbm [[maybe_unused]],
+    std::optional<int64_t> expected_flag_value [[maybe_unused]]) {
   if (!enable_raw_embedding_streaming_) {
     return;
   }
@@ -404,8 +440,10 @@ void RawEmbeddingStreamer::stream(
         count));
     return;
   }
-  auto poll_flag = [this, copy_done_flag]() {
-    return poll_copy_done_flag(copy_done_flag);
+  validate_copy_done_flag(copy_done_flag, expected_flag_value);
+
+  auto poll_flag = [this, copy_done_flag, expected_flag_value]() {
+    return poll_copy_done_flag(copy_done_flag, expected_flag_value);
   };
 
   // Select the lane's executors once: the HBM path runs on its own dispatch +
@@ -468,7 +506,8 @@ void RawEmbeddingStreamer::stream(
                             std::move(runtime_meta),
                             count,
                             std::move(copy_done_flag),
-                            use_hbm))
+                            use_hbm,
+                            expected_flag_value))
                         .start();
   rec->record.end();
 #endif
@@ -627,24 +666,41 @@ folly::coro::Task<void> RawEmbeddingStreamer::chunked_copy_and_enqueue(
 }
 
 bool RawEmbeddingStreamer::poll_copy_done_flag(
-    const std::optional<at::Tensor>& copy_done_flag) {
-  if (copy_done_flag.has_value()) {
-    auto* ptr = static_cast<volatile int32_t*>(copy_done_flag->data_ptr());
-    folly::stop_watch<std::chrono::microseconds> poll_watch;
-    while (*ptr == 0) {
-      std::this_thread::yield();
-      // At shutdown the producing GPU work is abandoned, so the flag may never
-      // be set.
-      if (stop_.load(std::memory_order_relaxed)) {
-        return false;
-      }
-      if (poll_watch.elapsed().count() > kCopyDonePollTimeoutUs) {
-        LOG(ERROR) << "[TBE_ID" << unique_id_
-                   << "] copy_done_flag poll timed out after "
-                   << kCopyDonePollTimeoutUs / 1'000'000 << "s";
-        return false;
-      }
+    const std::optional<at::Tensor>& copy_done_flag,
+    std::optional<int64_t> expected_flag_value) {
+  if (!copy_done_flag.has_value()) {
+    return true;
+  }
+  auto* ptr = static_cast<volatile int32_t*>(copy_done_flag->data_ptr());
+  // Sequence protocol waits for one exact value; boolean protocol waits for any
+  // nonzero.
+  const auto signalled = [ptr, expected_flag_value]() {
+    return expected_flag_value.has_value()
+        ? *ptr == static_cast<int32_t>(*expected_flag_value)
+        : *ptr != 0;
+  };
+  folly::stop_watch<std::chrono::microseconds> poll_watch;
+  while (!signalled()) {
+    std::this_thread::yield();
+    // At shutdown the producing GPU work is abandoned, so the flag may never
+    // be set.
+    if (stop_.load(std::memory_order_relaxed)) {
+      return false;
     }
+    if (poll_watch.elapsed().count() > kCopyDonePollTimeoutUs) {
+      LOG(ERROR) << "[TBE_ID" << unique_id_
+                 << "] copy_done_flag poll timed out after "
+                 << kCopyDonePollTimeoutUs / 1'000'000 << "s, expected "
+                 << (expected_flag_value.has_value()
+                         ? std::to_string(*expected_flag_value)
+                         : "nonzero")
+                 << ", observed " << *ptr;
+      return false;
+    }
+  }
+  // Only the boolean protocol consumes the signal; resetting a sequence value
+  // would reopen the stale-flag window the sequence exists to close.
+  if (!expected_flag_value.has_value()) {
     *ptr = 0;
   }
   return true;
@@ -657,8 +713,9 @@ folly::coro::Task<void> RawEmbeddingStreamer::dispatch_copy_task(
     std::optional<at::Tensor> runtime_meta,
     at::Tensor count,
     std::optional<at::Tensor> copy_done_flag,
-    bool use_hbm) {
-  if (!poll_copy_done_flag(copy_done_flag)) {
+    bool use_hbm,
+    std::optional<int64_t> expected_flag_value) {
+  if (!poll_copy_done_flag(copy_done_flag, expected_flag_value)) {
     co_return;
   }
   // Log at failure time instead of letting the exception ride dispatch_future_

--- a/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
@@ -125,6 +125,7 @@ auto raw_embedding_streamer =
                 torch::arg("blocking_tensor_copy"),
                 torch::arg("copy_done_flag") = std::nullopt,
                 torch::arg("use_hbm") = false,
+                torch::arg("expected_flag_value") = std::nullopt,
             })
         // The exposed name is kept as-is for backward compatibility: frozen
         // fbgemm clones bundled with published models (pyper_models/.../

--- a/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/tests/raw_embedding_streamer_test.cpp
@@ -996,6 +996,313 @@ TEST(RawEmbeddingStreamerTest, TestStreamWithCopyDoneFlagNonBlockingCopy) {
   EXPECT_EQ(copy_done_flag.item<int32_t>(), 0);
 }
 
+TEST(RawEmbeddingStreamerTest, TestExpectedFlagValueSequenceIsNotReset) {
+  // Sequence protocol: the producer writes a monotonically increasing value and
+  // the poll waits for that exact value, leaving it in place. A reset here
+  // would reopen the stale-flag window the sequence protocol closes.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_flag_sequence", true, table_names, table_offsets, table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2, 1, 150, 170, 230, 280},
+      at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  // A sequence value that is neither 0 nor 1, so a legacy "wait nonzero, then
+  // reset" poll would be visibly wrong.
+  constexpr int32_t kSeq = 7;
+  auto copy_done_flag =
+      at::full({1}, kSeq, at::TensorOptions().device(at::kCPU).dtype(at::kInt));
+
+  // Stop the dequeue thread to get an accurate, stable queue size.
+  streamer->join_weights_stream_thread();
+
+  streamer->stream(
+      indices,
+      weights,
+      std::nullopt,
+      std::nullopt,
+      count,
+      /*require_tensor_copy=*/true,
+      /*blocking_tensor_copy=*/false,
+      copy_done_flag,
+      /*use_hbm=*/false,
+      /*expected_flag_value=*/kSeq);
+
+  streamer->join_dispatch_and_workers();
+  EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 1);
+  EXPECT_EQ(copy_done_flag.item<int32_t>(), kSeq);
+}
+
+TEST(RawEmbeddingStreamerTest, TestExpectedFlagValueSequenceOnBlockingPath) {
+  // The blocking path polls the flag inline rather than on the dispatch
+  // coroutine, so it needs its own coverage that the sequence value is matched
+  // and left in place.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_flag_sequence_block",
+      true,
+      table_names,
+      table_offsets,
+      table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2, 1, 150, 170, 230, 280},
+      at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  constexpr int32_t kSeq = 42;
+  auto copy_done_flag =
+      at::full({1}, kSeq, at::TensorOptions().device(at::kCPU).dtype(at::kInt));
+
+  streamer->join_weights_stream_thread();
+
+  streamer->stream(
+      indices,
+      weights,
+      std::nullopt,
+      std::nullopt,
+      count,
+      /*require_tensor_copy=*/true,
+      /*blocking_tensor_copy=*/true,
+      copy_done_flag,
+      /*use_hbm=*/false,
+      /*expected_flag_value=*/kSeq);
+
+  EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 1);
+  EXPECT_EQ(copy_done_flag.item<int32_t>(), kSeq);
+}
+
+TEST(RawEmbeddingStreamerTest, TestExpectedFlagValueWaitsForWrongNonzero) {
+  // The other sequence tests pre-arm the flag with the awaited value, so they
+  // pass even against a poll that only tests "nonzero". Start at a nonzero
+  // value that is NOT the awaited one -- the only state where the two differ.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_flag_sequence_wait", true, table_names, table_offsets, table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2, 1, 150, 170, 230, 280},
+      at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  constexpr int32_t kSeq = 7;
+  auto copy_done_flag = at::full(
+      {1}, kSeq - 1, at::TensorOptions().device(at::kCPU).dtype(at::kInt));
+
+  streamer->join_weights_stream_thread();
+
+  streamer->stream(
+      indices,
+      weights,
+      std::nullopt,
+      std::nullopt,
+      count,
+      /*require_tensor_copy=*/true,
+      /*blocking_tensor_copy=*/false,
+      copy_done_flag,
+      /*use_hbm=*/false,
+      /*expected_flag_value=*/kSeq);
+
+  // Fixed wait rather than a poll loop: the assertion is a negative, so there
+  // is nothing to poll for. Failing to wait long enough can only make this
+  // test pass spuriously, never fail spuriously.
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 0);
+
+  // Release the poll before joining -- join_dispatch_and_workers() waits on
+  // the dispatch coroutine, which is still spinning until the flag matches.
+  copy_done_flag.fill_(kSeq);
+  streamer->join_dispatch_and_workers();
+  EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 1);
+  EXPECT_EQ(copy_done_flag.item<int32_t>(), kSeq);
+}
+
+TEST(RawEmbeddingStreamerTest, TestExpectedFlagValueRejectsOutOfRange) {
+  // Both bounds of stream()'s [1, int32 max] guard.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_flag_range", true, table_names, table_offsets, table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto copy_done_flag =
+      at::full({1}, 1, at::TensorOptions().device(at::kCPU).dtype(at::kInt));
+
+  const auto stream_with = [&](int64_t expected_flag_value,
+                               bool blocking_tensor_copy = true) {
+    streamer->stream(
+        indices,
+        weights,
+        std::nullopt,
+        std::nullopt,
+        count,
+        /*require_tensor_copy=*/true,
+        blocking_tensor_copy,
+        copy_done_flag,
+        /*use_hbm=*/false,
+        expected_flag_value);
+  };
+
+  EXPECT_THROW(stream_with(0), c10::Error);
+  // Narrows to 5, which is in range: rejecting it is what pins the check
+  // ahead of the cast rather than after it.
+  EXPECT_THROW(stream_with((int64_t{1} << 32) + 5), c10::Error);
+  // Non-blocking too, so the check cannot be moved into poll_copy_done_flag --
+  // there it would be swallowed by the dispatch coroutine.
+  EXPECT_THROW(stream_with(0, /*blocking_tensor_copy=*/false), c10::Error);
+}
+
+TEST(RawEmbeddingStreamerTest, TestExpectedFlagValueRequiresCopyDoneFlag) {
+  // An expected value with no flag to read it from polls nothing: the caller
+  // believes it is synchronised and is not.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_flag_required", true, table_names, table_offsets, table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  EXPECT_THROW(
+      streamer->stream(
+          indices,
+          weights,
+          std::nullopt,
+          std::nullopt,
+          count,
+          /*require_tensor_copy=*/true,
+          /*blocking_tensor_copy=*/true,
+          /*copy_done_flag=*/std::nullopt,
+          /*use_hbm=*/false,
+          /*expected_flag_value=*/1),
+      c10::Error);
+}
+
+TEST(RawEmbeddingStreamerTest, TestCopyDoneFlagRejectsWrongShapeOrDtype) {
+  // The poll reinterprets the buffer as int32 and reads one element, so a flag
+  // of another dtype or width is read as garbage. Checked for both protocols;
+  // this drives the boolean one, which is the live path.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_flag_dtype", true, table_names, table_offsets, table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  const auto stream_with_flag = [&](const at::Tensor& copy_done_flag) {
+    streamer->stream(
+        indices,
+        weights,
+        std::nullopt,
+        std::nullopt,
+        count,
+        /*require_tensor_copy=*/true,
+        /*blocking_tensor_copy=*/true,
+        copy_done_flag,
+        /*use_hbm=*/false,
+        /*expected_flag_value=*/std::nullopt);
+  };
+
+  EXPECT_THROW(
+      stream_with_flag(
+          at::full(
+              {1}, 1, at::TensorOptions().device(at::kCPU).dtype(at::kLong))),
+      c10::Error);
+  EXPECT_THROW(
+      stream_with_flag(
+          at::full(
+              {2}, 1, at::TensorOptions().device(at::kCPU).dtype(at::kInt))),
+      c10::Error);
+}
+
+TEST(RawEmbeddingStreamerTest, TestExpectedFlagValueAcceptsLowerBound) {
+  // 1 is in range and must be accepted: a sequence counter starts there, so a
+  // guard that rejected it would throw on the first drain of every process.
+  // The other sequence tests all use larger values and miss that.
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+
+  auto streamer = getRawEmbeddingStreamer(
+      "test_flag_lower_bound", true, table_names, table_offsets, table_sizes);
+
+  auto indices = at::tensor(
+      {10, 2, 1, 150, 170, 230, 280},
+      at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {indices.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {indices.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+
+  constexpr int32_t kSeq = 1;
+  auto copy_done_flag =
+      at::full({1}, kSeq, at::TensorOptions().device(at::kCPU).dtype(at::kInt));
+
+  streamer->join_weights_stream_thread();
+
+  EXPECT_NO_THROW(streamer->stream(
+      indices,
+      weights,
+      std::nullopt,
+      std::nullopt,
+      count,
+      /*require_tensor_copy=*/true,
+      /*blocking_tensor_copy=*/true,
+      copy_done_flag,
+      /*use_hbm=*/false,
+      /*expected_flag_value=*/kSeq));
+
+  EXPECT_EQ(streamer->get_weights_to_stream_queue_size(), 1);
+  EXPECT_EQ(copy_done_flag.item<int32_t>(), kSeq);
+}
+
 TEST(RawEmbeddingStreamerTest, TestStreamHbmLaneE2E) {
   // The blocking copy path is lane-agnostic: passing use_hbm=true
   // still ships through the SAME consumer_executor_ as the main path (blocking

--- a/fbgemm_gpu/test/tbe/training/res_enabled_tables_test.py
+++ b/fbgemm_gpu/test/tbe/training/res_enabled_tables_test.py
@@ -115,10 +115,12 @@ class ResEnabledTablesTest(unittest.TestCase):
         heights: list[int] | None = None,
         feature_table_map: list[int] | None = None,
         dim: int = 16,
+        dims: list[int] | None = None,
     ) -> SplitTableBatchedEmbeddingBagsCodegen:
-        """One table per name, each with its own placement and row count."""
+        """One table per name, each with its own placement, row count and dim."""
         n = len(table_names)
         rows = heights if heights is not None else [64] * n
+        widths = dims if dims is not None else [dim] * n
         offsets = []
         running = 0
         for h in rows:
@@ -134,7 +136,8 @@ class ResEnabledTablesTest(unittest.TestCase):
         )
         return SplitTableBatchedEmbeddingBagsCodegen(
             embedding_specs=[
-                (h, dim, loc, ComputeDevice.CUDA) for h, loc in zip(rows, locations)
+                (h, w, loc, ComputeDevice.CUDA)
+                for h, w, loc in zip(rows, widths, locations)
             ],
             enable_raw_embedding_streaming=True,
             res_params=res_params,
@@ -232,6 +235,151 @@ class ResEnabledTablesTest(unittest.TestCase):
                     ],
                     [3],
                 )
+
+    def _device_tbe(
+        self, heights: list[int], dims: list[int]
+    ) -> SplitTableBatchedEmbeddingBagsCodegen:
+        """All-DEVICE TBE whose flat weights are filled with arange."""
+        names = [f"t{i}" for i in range(len(heights))]
+        tbe = self._build_mixed_tbe(
+            names,
+            [EmbeddingLocation.DEVICE] * len(heights),
+            res_enabled_tables=names,
+            heights=heights,
+            dims=dims,
+        )
+        flat = tbe.get_buffer("weights_dev")
+        flat.copy_(torch.arange(flat.numel(), device=flat.device, dtype=flat.dtype))
+        return tbe
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_dim_uniformity_records_per_feature_layout(self) -> None:
+        # feature_table_map duplicates t0, so the cached layout tensors are 3
+        # long (per feature), not 2 (per table) -- rows_per_table included.
+        tbe = self._build_mixed_tbe(
+            ["t0", "t1"],
+            [EmbeddingLocation.DEVICE, EmbeddingLocation.DEVICE],
+            res_enabled_tables=["t0", "t1"],
+            heights=[4, 3],
+            dims=[8, 4],
+            feature_table_map=[0, 0, 1],
+        )
+        self.assertFalse(tbe._res_hbm_dims_equal)
+        self.assertEqual(tbe._res_hbm_dim, 0)
+        self.assertEqual(tbe._res_rows_per_table_cpu.tolist(), [4, 4, 3])
+        self.assertEqual(tbe._res_D_offsets_cpu.tolist(), [0, 8, 16, 20])
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_copy_weights_uniform_dim(self) -> None:
+        tbe = self._device_tbe(heights=[4, 3], dims=[8, 8])
+        self.assertTrue(tbe._res_hbm_dims_equal)
+        device = torch.cuda.current_device()
+        res_indices = torch.tensor([1, 5], device=device, dtype=torch.int64)
+        out = torch.full((2, 8), -1.0, device=device)
+        tbe._gather_res_rows(res_indices, out, tbe.get_buffer("weights_dev"))
+        self.assertEqual(out[0].tolist(), list(range(8, 16)))
+        self.assertEqual(out[1].tolist(), list(range(40, 48)))
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_copy_weights_mixed_dim_zero_pads_narrow_table(self) -> None:
+        # Without the zero pad the receiver would ship whatever `out` held.
+        tbe = self._device_tbe(heights=[4, 3], dims=[8, 4])
+        self.assertFalse(tbe._res_hbm_dims_equal)
+        device = torch.cuda.current_device()
+        # t0 row 1, then t1 row 1 (linear 5) -- ascending, as the gather requires.
+        res_indices = torch.tensor([1, 5], device=device, dtype=torch.int64)
+        out = torch.full((2, 8), -1.0, device=device)
+        tbe._gather_res_rows(res_indices, out, tbe.get_buffer("weights_dev"))
+        self.assertEqual(out[0].tolist(), list(range(8, 16)))
+        # t1's region starts at element 4*8=32; its row 1 is elements 36..39.
+        self.assertEqual(out[1].tolist(), [36.0, 37.0, 38.0, 39.0, 0.0, 0.0, 0.0, 0.0])
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_gather_uniformity_counts_non_allowlisted_pool_tables(self) -> None:
+        # `pad0`/`pad1` are DEVICE and share `weights_dev` with the allowlisted
+        # table, but are not themselves allowlisted. Their widths still decide
+        # whether `view(-1, dim)` is a legal reinterpretation of the pool, and
+        # their elements still push `t1` off a `dim` boundary.
+        #
+        # Sized so the pool DIVIDES: 4 + 64 + 4 = 72 elements and 72 % 8 == 0,
+        # so a uniform path here would not raise -- it would return wrong rows.
+        # The non-dividing case is the safe one, since `view` catches it.
+        tbe = self._build_mixed_tbe(
+            ["pad0", "t1", "pad1"],
+            [EmbeddingLocation.DEVICE] * 3,
+            res_enabled_tables=["t1"],
+            heights=[1, 8, 1],
+            dims=[4, 8, 4],
+        )
+        flat = tbe.get_buffer("weights_dev")
+        self.assertEqual(flat.numel(), 72)
+        flat.copy_(torch.arange(flat.numel(), device=flat.device, dtype=flat.dtype))
+
+        device = torch.cuda.current_device()
+        # t1 row 0 is linear 1, since pad0 holds linear 0. Its elements start at
+        # 1*4 = 4, but a uniform path would read row 1 of an 8-wide grid --
+        # elements 8..15 -- because pad0's 4 elements shifted the grid.
+        # Asserted before the mechanism below so that a regression fails on the
+        # WRONG VALUES, which is the bug, rather than on the flag that causes it.
+        res_indices = torch.tensor([1], device=device, dtype=torch.int64)
+        out = torch.full((1, 8), -1.0, device=device)
+        tbe._gather_res_rows(res_indices, out, flat)
+        self.assertEqual(out[0].tolist(), [float(v) for v in range(4, 12)])
+
+        # Uniformity is a property of the pool, not of the allowlist.
+        self.assertFalse(tbe._res_hbm_dims_equal)
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_gather_logs_cached_feature_ids(self) -> None:
+        # weights_offsets restarts at zero per placement pool, so a cached id
+        # resolves to an offset INSIDE weights_dev and returns a DEVICE row
+        # under a cached row's name -- in range, no error. t0 and t1 are the
+        # same shape so the aliasing is exact.
+        #
+        # The drain cannot produce this: _res_hbm_linear_mask marks only
+        # allowlisted DEVICE rows. So it is logged rather than raised, and the
+        # aliased row is asserted here because that is what the log is warning
+        # about -- a silent wrong row, not a crash.
+        rows = 4
+        tbe = self._build_mixed_tbe(
+            ["t0", "t1"],
+            [EmbeddingLocation.DEVICE, EmbeddingLocation.MANAGED_CACHING],
+            res_enabled_tables=["t0", "t1"],
+            heights=[rows, rows],
+            dims=[8, 8],
+        )
+        flat = tbe.get_buffer("weights_dev")
+        flat.copy_(torch.arange(flat.numel(), device=flat.device, dtype=flat.dtype))
+        device = torch.cuda.current_device()
+        out = torch.full((1, 8), -1.0, device=device)
+        # Linear id `rows` is t1 row 0 -- a cached feature.
+        cached_id = torch.tensor([rows], device=device, dtype=torch.int64)
+        with self.assertLogs(level="ERROR") as logs:
+            tbe._gather_res_rows(cached_id, out, flat)
+        self.assertIn("not DEVICE-placed", "\n".join(logs.output))
+        # t1 row 0 aliased onto t0 row 0, which is elements 0..7.
+        self.assertEqual(out[0].tolist(), list(range(8)))
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_gather_empty_indices_is_a_noop(self) -> None:
+        # An empty drain is the normal condition, not an edge case: on a real
+        # model most TBEs mark nothing most iterations.
+        tbe = self._device_tbe(heights=[4], dims=[8])
+        device = torch.cuda.current_device()
+        out = torch.full((2, 8), -1.0, device=device)
+        tbe._gather_res_rows(
+            torch.empty(0, device=device, dtype=torch.int64),
+            out,
+            tbe.get_buffer("weights_dev"),
+        )
+        # Untouched, not zeroed: callers slice to the count.
+        self.assertEqual(out.unique().tolist(), [-1.0])
 
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)

--- a/fbgemm_gpu/test/tbe/training/res_enabled_tables_test.py
+++ b/fbgemm_gpu/test/tbe/training/res_enabled_tables_test.py
@@ -106,6 +106,180 @@ class ResEnabledTablesTest(unittest.TestCase):
         mask = tbe.get_buffer("res_enabled_feature_mask")
         self.assertEqual(mask.tolist(), [True, True, True])
 
+    def _build_mixed_tbe(
+        self,
+        table_names: list[str],
+        locations: list[EmbeddingLocation],
+        res_enabled_tables: list[str],
+        enable_hbm_streaming: bool = True,
+        heights: list[int] | None = None,
+        feature_table_map: list[int] | None = None,
+        dim: int = 16,
+    ) -> SplitTableBatchedEmbeddingBagsCodegen:
+        """One table per name, each with its own placement and row count."""
+        n = len(table_names)
+        rows = heights if heights is not None else [64] * n
+        offsets = []
+        running = 0
+        for h in rows:
+            offsets.append(running)
+            running += h
+        res_params = RESParams(
+            res_store_shards=1,
+            table_names=list(table_names),
+            table_offsets=offsets,
+            table_sizes=list(rows),
+            res_enabled_tables=list(res_enabled_tables),
+            enable_hbm_streaming=enable_hbm_streaming,
+        )
+        return SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (h, dim, loc, ComputeDevice.CUDA) for h, loc in zip(rows, locations)
+            ],
+            enable_raw_embedding_streaming=True,
+            res_params=res_params,
+            feature_table_map=feature_table_map,
+        )
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_buffers_not_allocated_when_lane_disabled(self) -> None:
+        # The buffers span the whole linear index space, so a RES model that leaves
+        # the lane off must not pay for them.
+        tbe = self._build_mixed_tbe(
+            ["t0"],
+            [EmbeddingLocation.DEVICE],
+            res_enabled_tables=[],
+            enable_hbm_streaming=False,
+        )
+        # hasattr, not just named_buffers: registering it as a plain attribute
+        # would keep the buffer assertion green while still paying the whole
+        # allocation this test exists to prevent.
+        self.assertNotIn("_res_rows_seen", dict(tbe.named_buffers()))
+        self.assertFalse(hasattr(tbe, "_res_rows_seen"))
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_mark_records_every_touched_row(self) -> None:
+        # The mark is unconditional on cache state: t1 is DEVICE-placed and so
+        # never hits the cache, and its row must still be recorded.
+        rows = 64
+        tbe = self._build_mixed_tbe(
+            ["t0", "t1"],
+            [EmbeddingLocation.MANAGED_CACHING, EmbeddingLocation.DEVICE],
+            res_enabled_tables=["t1"],
+            heights=[rows, rows],
+        )
+        device = torch.cuda.current_device()
+        tbe._prefetch(
+            torch.tensor([3, 5], device=device, dtype=torch.int64),
+            torch.tensor([0, 1, 2], device=device, dtype=torch.int64),
+        )
+        present = tbe.get_buffer("_res_rows_seen").tolist()
+        self.assertEqual(len(present), 2 * rows + 1)
+        self.assertEqual([i for i, p in enumerate(present) if p], [3, rows + 5])
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_prefetch_with_lane_off(self) -> None:
+        # The buffer does not exist when the lane is off, so the mark must be
+        # gated rather than guarded -- an ungated index_fill_ is AttributeError
+        # on every RES model that leaves the lane off. Drives _prefetch, which
+        # is where the mark lives; calling _store_prefetched_tensors here would
+        # exercise a method the mark is no longer in.
+        rows = 64
+        tbe = self._build_mixed_tbe(
+            ["t0", "t1"],
+            [EmbeddingLocation.MANAGED_CACHING, EmbeddingLocation.DEVICE],
+            res_enabled_tables=["t1"],
+            enable_hbm_streaming=False,
+            heights=[rows, rows],
+        )
+        device = torch.cuda.current_device()
+        tbe._prefetch(
+            torch.tensor([3, 5], device=device, dtype=torch.int64),
+            torch.tensor([0, 1, 2], device=device, dtype=torch.int64),
+        )
+        self.assertNotIn("_res_rows_seen", dict(tbe.named_buffers()))
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_mark_fires_through_prefetch(self) -> None:
+        # Drives _prefetch rather than calling _store_prefetched_tensors by
+        # hand: the mark has to survive the cacheless early-return, and a test
+        # that invokes the inner method directly cannot see that guard at all.
+        # The DEVICE-only TBE is the shape TorchRec actually builds for a
+        # DEVICE table, and the only shape this lane exists to serve.
+        rows = 64
+        device = torch.cuda.current_device()
+        indices = torch.tensor([3], device=device, dtype=torch.int64)
+        offsets = torch.tensor([0, 1], device=device, dtype=torch.int64)
+
+        for location in (
+            EmbeddingLocation.MANAGED_CACHING,  # positive control: has a cache
+            EmbeddingLocation.DEVICE,  # no cache, so no _prefetch tail
+        ):
+            with self.subTest(location=location):
+                tbe = self._build_mixed_tbe(
+                    ["t0"], [location], res_enabled_tables=["t0"], heights=[rows]
+                )
+                tbe._prefetch(indices, offsets)
+                self.assertEqual(
+                    [
+                        i
+                        for i, p in enumerate(tbe.get_buffer("_res_rows_seen").tolist())
+                        if p
+                    ],
+                    [3],
+                )
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_mark_clamps_out_of_range_into_the_sentinel(self) -> None:
+        # _prefetch sits below prepare_inputs, so bounds_check_indices has not
+        # run and index 999 into 64 rows reaches the clamp raw. Without the
+        # clamp this is a device-side assert, not a wrong row.
+        rows = 64
+        device = torch.cuda.current_device()
+        tbe = self._build_mixed_tbe(
+            ["t0"],
+            [EmbeddingLocation.DEVICE],
+            res_enabled_tables=["t0"],
+            heights=[rows],
+        )
+        tbe._prefetch(
+            torch.tensor([999], device=device, dtype=torch.int64),
+            torch.tensor([0, 1], device=device, dtype=torch.int64),
+        )
+        present = [
+            i for i, p in enumerate(tbe.get_buffer("_res_rows_seen").tolist()) if p
+        ]
+        self.assertEqual(present, [rows])
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_mark_negative_index_never_reaches_the_clamp(self) -> None:
+        # Why the clamp is upper-bound only: linearize_cache_indices guards both
+        # its write sites on `indices[index] >= 0`
+        # (linearize_cache_indices.cu:57 and :165) and routes anything negative
+        # to the sentinel, so a negative input arrives here already in range.
+        rows = 64
+        device = torch.cuda.current_device()
+        tbe = self._build_mixed_tbe(
+            ["t0"],
+            [EmbeddingLocation.DEVICE],
+            res_enabled_tables=["t0"],
+            heights=[rows],
+        )
+        tbe._prefetch(
+            torch.tensor([-1], device=device, dtype=torch.int64),
+            torch.tensor([0, 1], device=device, dtype=torch.int64),
+        )
+        present = [
+            i for i, p in enumerate(tbe.get_buffer("_res_rows_seen").tolist()) if p
+        ]
+        self.assertEqual(present, [rows])
+
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_subset_allowlist_builds_feature_mask(self) -> None:

--- a/fbgemm_gpu/test/tbe/training/res_enabled_tables_test.py
+++ b/fbgemm_gpu/test/tbe/training/res_enabled_tables_test.py
@@ -43,8 +43,10 @@ class ResEnabledTablesTest(unittest.TestCase):
         res_enabled_tables: list[str],
         rows: int = 64,
         dim: int = 16,
+        location: EmbeddingLocation = EmbeddingLocation.DEVICE,
+        uvm_host_mapped: bool = False,
     ) -> SplitTableBatchedEmbeddingBagsCodegen:
-        """One DEVICE table per name (one feature per table), RES enabled."""
+        """One table per name (one feature per table), RES enabled."""
         n = len(table_names)
         res_params = RESParams(
             res_store_shards=1,
@@ -55,12 +57,36 @@ class ResEnabledTablesTest(unittest.TestCase):
         )
         return SplitTableBatchedEmbeddingBagsCodegen(
             embedding_specs=[
-                (rows, dim, EmbeddingLocation.DEVICE, ComputeDevice.CUDA)
-                for _ in range(n)
+                (rows, dim, location, ComputeDevice.CUDA) for _ in range(n)
             ],
             enable_raw_embedding_streaming=True,
             res_params=res_params,
+            uvm_host_mapped=uvm_host_mapped,
         )
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_res_count_and_copy_done_start_zero(self) -> None:
+        # new_unified_tensor hands back an unzeroed allocation. res_count is
+        # read as a row count by a std::copy that does not bound check, and any
+        # nonzero copy_done reads as "the GPU is done writing" -- so an unzeroed
+        # pair makes the first drain over-read and ship mid-write.
+        # Both arguments are load-bearing, and the test is vacuous without
+        # either. MANAGED_CACHING, not DEVICE: a DEVICE table has no UVM cache,
+        # so cache_size is 0 and _register_res_buffers takes the empty branch,
+        # which allocates with plain torch.zeros. uvm_host_mapped, because only
+        # that branch of new_unified_tensor allocates with malloc; the default
+        # cudaMallocManaged branch hands back fresh zeroed pages, so the
+        # unzeroed value is never observed there.
+        tbe = self._build_tbe(
+            ["t0"],
+            ["t0"],
+            location=EmbeddingLocation.MANAGED_CACHING,
+            uvm_host_mapped=True,
+        )
+        self.assertGreater(tbe.get_buffer("lxu_cache_weights").size(0), 0)
+        self.assertEqual(tbe.get_buffer("res_count").tolist(), [0])
+        self.assertEqual(tbe.get_buffer("res_copy_done").tolist(), [0])
 
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3104

 `_gather_res_rows` copies the rows a drain selected out of `weights` into the host-mapped staging buffers. Nothing but its own tests calls it yet.

One width across the DEVICE pool and every feature DEVICE-placed means a linear row id already IS the pool row, so the copy is one `index_select`. Otherwise it walks the tables. Uniformity is a property of the POOL, not the allowlist: a non-allowlisted table of another width shifts the rest off the grid, silently whenever the pool's element count still divides.

Reviewed By: chouxi

Differential Revision: D117047316


