### PR TITLE
Update OSS Composable Kernel SHA (#6223)

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/ck_utility.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/ck_utility.hip
@@ -32,6 +32,8 @@ namespace fbgemm_gpu {
 
 void flush_icache_ck()
 {
+    using namespace ck;
+
     hipDeviceProp_t deviceProps;
     hip_check_error(hipGetDeviceProperties(&deviceProps, 0));
     int32_t gpu_block3 = deviceProps.multiProcessorCount * 60;


### PR DESCRIPTION
Summary:

NOTE: No linked task. Please associate a task with this diff.

Update the fbcode and xplat FBGEMM OSS Composable Kernel pins from `7fe50dc3da2069d6645d9deb8c017a876472a977` to `fcc9372c009c8e0a23fece77b582da83b04a654f`, exactly matching the MSLK pin introduced by parent D117441615.

CK 1.2 places `hip_check_error` in namespace `ck`, while the existing internal CK dependency exposes it globally. Import `ck` locally in `flush_icache_ck` so the same source builds with both header layouts. Keep the existing FBGEMM BUCK dependencies unchanged because migrating every CK extension target would require unrelated CK API changes.

Differential Revision: D117467079
