### PR TITLE
Drain the marked rows into row ids

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -154,8 +154,14 @@ class RESParams:
         default_factory=list
     )  # table names that are enabled for RES (empty means all enabled)
     # Streams DEVICE-placed tables named in `res_enabled_tables`, which the
-    # cache lane cannot reach. Costs a byte per row of the shard, so it is opt-in.
+    # cache lane cannot reach. Holds device memory scaled to the row count of
+    # this TBE, whether or not those rows are streamed, so it is opt-in.
     enable_hbm_streaming: bool = False
+    # Drain period in iterations. Marks accumulate in between, and marking a
+    # row again does nothing, so a row touched every iteration still ships once
+    # per interval. That is what it is for: it stops a hot row flooding the
+    # downstream, which has to absorb everything a drain sends.
+    res_hbm_drain_interval: int = 1
 
 
 class PrefetchedInfo:
@@ -179,6 +185,10 @@ class PrefetchedInfo:
         self.linear_unique_indices_length = linear_unique_indices_length
         self.hash_zch_identities = hash_zch_identities
         self.hash_zch_runtime_meta = hash_zch_runtime_meta
+        # Row ids from an HBM drain one or more iterations back, None when none
+        # was pending. The drain assigns it after construction, so the
+        # annotation is what keeps the attribute's type from narrowing to None.
+        self.res_hbm_indices: torch.Tensor | None = None
 
 
 def construct_split_state(
@@ -674,6 +684,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
     # pyre-fixme[13]: Attribute `last_uvm_cache_print_state` is never initialized.
     last_uvm_cache_print_state: torch.Tensor
     _vbe_B_offsets: torch.Tensor | None
+    _res_compacted_rows: torch.Tensor | None
     _vbe_max_B: int
 
     def __init__(  # noqa C901
@@ -766,6 +777,9 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             enable_raw_embedding_streaming
             and (res_params or RESParams()).enable_hbm_streaming
         )
+        self._res_hbm_drain_interval: int = (
+            res_params or RESParams()
+        ).res_hbm_drain_interval
         self.pooling_mode = pooling_mode
         self.is_nobag: bool = self.pooling_mode == PoolingMode.NONE
 
@@ -1923,16 +1937,18 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
     @torch.jit.ignore
     def _register_res_hbm_buffers(self) -> None:
-        """Allocate the map of rows touched since the last drain.
+        """Allocate the HBM lane's per-TBE state.
 
-        Written during prefetch from the unfiltered `linearize_cache_indices`
-        output, so every looked-up row lands here whatever its placement or
-        allowlist status. Narrowing that down is the drain's job.
+        The touched-row map is written during prefetch from the unfiltered
+        `linearize_cache_indices` output, so every looked-up row lands there
+        whatever its placement or allowlist status. Narrowing that down is the
+        drain's job.
         """
         assert (
             self.enable_raw_embedding_streaming
         ), "Should not register res hbm buffers when raw embedding streaming is not enabled"
 
+        self._validate_res_hbm_params()
         # +1: the kernel dumps indices it cannot place -- pruned rows among
         # them -- on total_hash_size, so that slot gets written and has to exist.
         linear_size = self.total_hash_size + 1
@@ -1941,6 +1957,68 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             torch.zeros(linear_size, device=self.current_device, dtype=torch.bool),
             persistent=False,  # RES buffer is not checkpointed
         )
+        self.register_buffer(
+            "_res_hbm_linear_mask",
+            self._build_res_hbm_linear_mask(linear_size),
+            persistent=False,
+        )
+        self._res_drain_counter: int = 0
+
+        # A compact runs an iteration before its rows go out; these three carry
+        # it across that gap.
+        self._res_compacted_rows = None
+        self._res_drain_event: torch.cuda.Event = torch.cuda.Event()
+        self._res_drain_count_cpu: Tensor = torch.zeros(
+            1, dtype=torch.int64, pin_memory=True
+        )
+
+    @torch.jit.ignore
+    def _validate_res_hbm_params(self) -> None:
+        """Reject HBM lane settings that would otherwise fail silently or late."""
+        table_names = self.res_params.table_names
+        if len(table_names) != len(self.embedding_specs):
+            raise ValueError(
+                f"RES table_names must name every table in this TBE, one per "
+                f"embedding_spec: got {len(table_names)} names for "
+                f"{len(self.embedding_specs)} tables"
+            )
+        if self.res_params.res_hbm_drain_interval < 1:
+            raise ValueError(
+                "res_hbm_drain_interval must be >= 1, got "
+                f"{self.res_params.res_hbm_drain_interval}"
+            )
+
+    @torch.jit.ignore
+    def _build_res_hbm_linear_mask(self, linear_size: int) -> Tensor:
+        """A mask over the rows of every table RES streams.
+
+        Streamed means DEVICE-placed AND allowlisted.
+        """
+        table_offsets = self.res_params.table_sizes
+        table_names = self.res_params.table_names
+        configured = self.res_params.res_enabled_tables
+        # Empty means all tables, as it does for the UVM-cached lane.
+        allowlist = set(configured) or set(table_names)
+        linear_mask = torch.zeros(
+            linear_size, device=self.current_device, dtype=torch.bool
+        )
+        streamed_tables, streamed_rows = 0, 0
+        for table_idx, spec in enumerate(self.embedding_specs):
+            name = table_names[table_idx]
+            if spec[2] != EmbeddingLocation.DEVICE or name not in allowlist:
+                continue
+            first_row = table_offsets[table_idx]
+            num_rows = table_offsets[table_idx + 1] - first_row
+            linear_mask.narrow(0, first_row, num_rows).fill_(True)
+            streamed_tables += 1
+            streamed_rows += num_rows
+        self.log(
+            f"[RES] HBM lane streams {streamed_tables} of "
+            f"{len(table_names)} tables, {streamed_rows} rows; "
+            f"res_enabled_tables={sorted(configured) if configured else 'ALL (empty)'}; "
+            f"tables={table_names}"
+        )
+        return linear_mask
 
     @torch.jit.ignore
     def _mark_res_hbm_rows(
@@ -4944,6 +5022,81 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         )
 
     @torch.jit.ignore
+    def _res_compact_due(self) -> bool:
+        """Whether to compact now, so that the next iteration is the one that
+        streams.
+
+        The caller has already ticked the counter for this iteration, so
+        `counter + 1` is the NEXT call: compact when that next call is the one
+        landing on the interval.
+
+        The counter is its own rather than `self.timestep`: what is controlled
+        is the interval between drains of THIS TBE, not alignment to any global
+        step.
+        """
+        return (self._res_drain_counter + 1) % self._res_hbm_drain_interval == 0
+
+    @torch.jit.ignore
+    def _drain_hbm_rows(self, prefetched_info: PrefetchedInfo) -> None:
+        """Advance the drain, which spans two iterations: it compacts and clears
+        the accumulated marks one call before the interval, and hands those rows
+        to `prefetched_info` on the next call, which is where the interval lands.
+
+        Runs once per prefetch. The pickup comes first so the count it reads was
+        queued at least an iteration ago and costs nothing to read.
+        """
+        prefetched_info.res_hbm_indices = self._pickup_drained_rows()
+        self._res_drain_counter += 1
+        if self._res_compact_due():
+            self._compact_marked_rows()
+
+    @torch.jit.ignore
+    def _compact_marked_rows(self) -> None:
+        """Compact the marked rows into row ids and clear them, without waiting.
+
+        Leaves the result pending for `_pickup_drained_rows` to slice next
+        iteration; nothing here blocks the host.
+        """
+        with record_function(f"## res_drain {self.timestep} {self.uuid} ##"):
+            # Which rows this drain may ship: marked, and streamed by RES.
+            drain_mask = self._res_rows_seen & self._res_hbm_linear_mask
+            rows, count = res_bitmap_compact(drain_mask)
+            self._res_rows_seen.masked_fill_(drain_mask, False)
+            # Hand the count to the host without waiting on it. `rows` stays
+            # unsliced until the pickup, which is what the deferral costs: the
+            # compaction buffer is held for one iteration per drain.
+            self._res_drain_count_cpu.copy_(count, non_blocking=True)
+            self._res_drain_event.record()
+            self._res_compacted_rows = rows
+
+    @torch.jit.ignore
+    def _pickup_drained_rows(self) -> Tensor | None:
+        """Slice the pending drain with a count queued an iteration ago.
+
+        None when no drain is pending or it selected nothing. A drain still
+        pending at shutdown is lost: the compact cleared its bits eagerly, so
+        nothing will select those rows again.
+        """
+        rows = self._res_compacted_rows
+        if rows is None:
+            return None
+        self._res_compacted_rows = None
+        # Queued an iteration ago, so it has almost certainly landed and this
+        # costs nothing -- that is what deferring buys. If it has not, we block
+        # here: the block moved by an iteration, it did not disappear.
+        if not self._res_drain_event.query():
+            self._res_drain_event.synchronize()
+        drain_count = int(self._res_drain_count_cpu.item())
+        if drain_count == 0:
+            return None
+        # `rows[:n]` is a view into the compaction buffer, which is one int64
+        # per row of EVERY table in this TBE plus the sentinel -- sized by the
+        # bitmap, not by how few rows drained. `clone()` frees it here instead
+        # of holding it for the iteration or two the slice spends in
+        # prefetched_info_list.
+        return rows[:drain_count].clone()
+
+    @torch.jit.ignore
     def _store_prefetched_tensors(
         self,
         indices: torch.Tensor,
@@ -5003,6 +5156,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 hash_zch_runtime_meta,
                 self.lxu_cache_weights.size(0),
             )
+            if self._res_hbm_streaming:
+                self._drain_hbm_rows(prefetched_info)
 
             self.prefetched_info_list.append(prefetched_info)
 

--- a/fbgemm_gpu/test/tbe/training/res_enabled_tables_test.py
+++ b/fbgemm_gpu/test/tbe/training/res_enabled_tables_test.py
@@ -27,6 +27,10 @@ if open_source:
 else:
     from fbgemm_gpu.test.test_utils import gpu_unavailable
 
+# Table height the fixtures build and the tests do their linear-index
+# arithmetic against. One name because the two have to agree.
+ROWS = 64
+
 
 class ResEnabledTablesTest(unittest.TestCase):
     """
@@ -41,8 +45,6 @@ class ResEnabledTablesTest(unittest.TestCase):
         self,
         table_names: list[str],
         res_enabled_tables: list[str],
-        rows: int = 64,
-        dim: int = 16,
         location: EmbeddingLocation = EmbeddingLocation.DEVICE,
         uvm_host_mapped: bool = False,
     ) -> SplitTableBatchedEmbeddingBagsCodegen:
@@ -51,13 +53,13 @@ class ResEnabledTablesTest(unittest.TestCase):
         res_params = RESParams(
             res_store_shards=1,
             table_names=list(table_names),
-            table_offsets=[i * rows for i in range(n)],
-            table_sizes=[rows] * n,
+            table_offsets=[i * ROWS for i in range(n)],
+            table_sizes=[ROWS] * n,
             res_enabled_tables=list(res_enabled_tables),
         )
         return SplitTableBatchedEmbeddingBagsCodegen(
             embedding_specs=[
-                (rows, dim, location, ComputeDevice.CUDA) for _ in range(n)
+                (ROWS, 16, location, ComputeDevice.CUDA) for _ in range(n)
             ],
             enable_raw_embedding_streaming=True,
             res_params=res_params,
@@ -114,13 +116,13 @@ class ResEnabledTablesTest(unittest.TestCase):
         enable_hbm_streaming: bool = True,
         heights: list[int] | None = None,
         feature_table_map: list[int] | None = None,
-        dim: int = 16,
         dims: list[int] | None = None,
+        res_hbm_drain_interval: int = 1,
     ) -> SplitTableBatchedEmbeddingBagsCodegen:
         """One table per name, each with its own placement, row count and dim."""
         n = len(table_names)
-        rows = heights if heights is not None else [64] * n
-        widths = dims if dims is not None else [dim] * n
+        rows = heights if heights is not None else [ROWS] * n
+        widths = dims if dims is not None else [16] * n
         offsets = []
         running = 0
         for h in rows:
@@ -133,8 +135,11 @@ class ResEnabledTablesTest(unittest.TestCase):
             table_sizes=list(rows),
             res_enabled_tables=list(res_enabled_tables),
             enable_hbm_streaming=enable_hbm_streaming,
+            # Drain every prefetch: these tests assert on what a drain ships,
+            # not on when one fires. The cadence tests set their own.
+            res_hbm_drain_interval=res_hbm_drain_interval,
         )
-        return SplitTableBatchedEmbeddingBagsCodegen(
+        tbe = SplitTableBatchedEmbeddingBagsCodegen(
             embedding_specs=[
                 (h, w, loc, ComputeDevice.CUDA)
                 for h, w, loc in zip(rows, widths, locations)
@@ -143,6 +148,123 @@ class ResEnabledTablesTest(unittest.TestCase):
             res_params=res_params,
             feature_table_map=feature_table_map,
         )
+        return tbe
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_linear_mask_covers_disjoint_device_tables(self) -> None:
+        # DEVICE tables need not be contiguous, so the mask cannot be a range.
+        # t1 is MANAGED and must be excluded even though it is allowlisted.
+        rows = ROWS
+        tbe = self._build_mixed_tbe(
+            ["t0", "t1", "t2"],
+            [
+                EmbeddingLocation.DEVICE,
+                EmbeddingLocation.MANAGED,
+                EmbeddingLocation.DEVICE,
+            ],
+            res_enabled_tables=["t0", "t1", "t2"],
+        )
+        mask = tbe.get_buffer("_res_hbm_linear_mask").tolist()
+        self.assertEqual(len(mask), 3 * rows + 1)
+        self.assertTrue(all(mask[0:rows]))
+        self.assertFalse(any(mask[rows : 2 * rows]))
+        self.assertTrue(all(mask[2 * rows : 3 * rows]))
+        # The pruning sentinel slot is never in the enabled set.
+        self.assertFalse(mask[3 * rows])
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_linear_mask_uses_table_not_feature_offsets(self) -> None:
+        # Non-uniform heights and a non-identity feature_table_map: a mask built
+        # from the per-feature cumsum, or from a fixed stride, lands on the
+        # wrong rows here even though it would pass a uniform-height test.
+        tbe = self._build_mixed_tbe(
+            ["t0", "t1", "t2"],
+            [
+                EmbeddingLocation.DEVICE,
+                EmbeddingLocation.MANAGED,
+                EmbeddingLocation.DEVICE,
+            ],
+            res_enabled_tables=["t2"],
+            heights=[10, 20, 30],
+            feature_table_map=[0, 0, 1, 2],
+        )
+        mask = tbe.get_buffer("_res_hbm_linear_mask").tolist()
+        self.assertEqual(len(mask), 61)
+        # t2 occupies rows [30, 60) -- offsets are 0, 10, 30.
+        self.assertFalse(any(mask[0:30]))
+        self.assertTrue(all(mask[30:60]))
+        self.assertFalse(mask[60])
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_empty_allowlist_enables_all_tables(self) -> None:
+        # Empty means all tables, the same as it does for the UVM-cached lane.
+        # Mixed placement on purpose -- with both tables DEVICE an all-True
+        # mask would also pass if the placement filter were gone.
+        rows = ROWS
+        tbe = self._build_mixed_tbe(
+            ["t0", "t1"],
+            [EmbeddingLocation.DEVICE, EmbeddingLocation.MANAGED],
+            res_enabled_tables=[],
+        )
+        mask = tbe.get_buffer("_res_hbm_linear_mask").tolist()
+        self.assertTrue(all(mask[0:rows]))
+        self.assertFalse(any(mask[rows:]))
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_table_names_must_cover_every_table(self) -> None:
+        # Surplus names, not a deficit: with fewer names than tables and a
+        # non-empty allowlist `_register_res_enabled_feature_mask` hits
+        # IndexError first and the validator never runs.
+        with self.assertRaisesRegex(ValueError, "must name every table"):
+            self._build_mixed_tbe(
+                ["t0", "t1", "t2"],
+                [EmbeddingLocation.DEVICE] * 2,
+                res_enabled_tables=["t0"],
+                heights=[64, 64],
+            )
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_linear_mask_excludes_allowlisted_non_device_table(self) -> None:
+        # Allowlisting a table the lane cannot serve enables nothing
+        # rather than streaming it. This is the state a config produces when it
+        # names a UVM table for the HBM lane. t2 is the positive control: the
+        # zero over t0 and t1 says nothing without a one in the same mask.
+        rows = ROWS
+        tbe = self._build_mixed_tbe(
+            ["t0", "t1", "t2"],
+            [
+                EmbeddingLocation.MANAGED,
+                EmbeddingLocation.MANAGED_CACHING,
+                EmbeddingLocation.DEVICE,
+            ],
+            res_enabled_tables=["t0", "t1", "t2"],
+        )
+        mask = tbe.get_buffer("_res_hbm_linear_mask").tolist()
+        self.assertFalse(any(mask[: 2 * rows]))
+        self.assertTrue(all(mask[2 * rows : 3 * rows]))
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hbm_linear_mask_intersects_allowlist(self) -> None:
+        # DEVICE-placed is not sufficient: t2 is DEVICE but not allowlisted.
+        rows = ROWS
+        tbe = self._build_mixed_tbe(
+            ["t0", "t1", "t2"],
+            [
+                EmbeddingLocation.DEVICE,
+                EmbeddingLocation.MANAGED,
+                EmbeddingLocation.DEVICE,
+            ],
+            res_enabled_tables=["t0"],
+        )
+        mask = tbe.get_buffer("_res_hbm_linear_mask").tolist()
+        self.assertTrue(all(mask[0:rows]))
+        self.assertFalse(any(mask[rows:]))
 
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
@@ -155,18 +277,23 @@ class ResEnabledTablesTest(unittest.TestCase):
             res_enabled_tables=[],
             enable_hbm_streaming=False,
         )
-        # hasattr, not just named_buffers: registering it as a plain attribute
-        # would keep the buffer assertion green while still paying the whole
-        # allocation this test exists to prevent.
-        self.assertNotIn("_res_rows_seen", dict(tbe.named_buffers()))
+        # hasattr, not named_buffers: registering one as a plain attribute
+        # instead would keep a named_buffers assertion green while still paying
+        # the whole allocation this test exists to prevent.
         self.assertFalse(hasattr(tbe, "_res_rows_seen"))
+        self.assertFalse(hasattr(tbe, "_res_hbm_linear_mask"))
+        self.assertFalse(hasattr(tbe, "_res_drain_count_cpu"))
 
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_hbm_mark_records_every_touched_row(self) -> None:
         # The mark is unconditional on cache state: t1 is DEVICE-placed and so
-        # never hits the cache, and its row must still be recorded.
-        rows = 64
+        # never hits the cache, and its row must still be recorded. At
+        # res_hbm_drain_interval=1 the drain consumes in-mask marks in the same
+        # call, so the t1 row is observed in what the next iteration ships while
+        # the out-of-mask t0 row is observed in the residue the drain never
+        # clears.
+        rows = ROWS
         tbe = self._build_mixed_tbe(
             ["t0", "t1"],
             [EmbeddingLocation.MANAGED_CACHING, EmbeddingLocation.DEVICE],
@@ -178,9 +305,10 @@ class ResEnabledTablesTest(unittest.TestCase):
             torch.tensor([3, 5], device=device, dtype=torch.int64),
             torch.tensor([0, 1, 2], device=device, dtype=torch.int64),
         )
+        self.assertEqual(self._idle_iteration(tbe), [rows + 5])
         present = tbe.get_buffer("_res_rows_seen").tolist()
         self.assertEqual(len(present), 2 * rows + 1)
-        self.assertEqual([i for i, p in enumerate(present) if p], [3, rows + 5])
+        self.assertEqual([i for i, p in enumerate(present) if p], [3])
 
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
@@ -190,7 +318,7 @@ class ResEnabledTablesTest(unittest.TestCase):
         # on every RES model that leaves the lane off. Drives _prefetch, which
         # is where the mark lives; calling _store_prefetched_tensors here would
         # exercise a method the mark is no longer in.
-        rows = 64
+        rows = ROWS
         tbe = self._build_mixed_tbe(
             ["t0", "t1"],
             [EmbeddingLocation.MANAGED_CACHING, EmbeddingLocation.DEVICE],
@@ -203,7 +331,7 @@ class ResEnabledTablesTest(unittest.TestCase):
             torch.tensor([3, 5], device=device, dtype=torch.int64),
             torch.tensor([0, 1, 2], device=device, dtype=torch.int64),
         )
-        self.assertNotIn("_res_rows_seen", dict(tbe.named_buffers()))
+        self.assertFalse(hasattr(tbe, "_res_rows_seen"))
 
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
@@ -213,7 +341,7 @@ class ResEnabledTablesTest(unittest.TestCase):
         # that invokes the inner method directly cannot see that guard at all.
         # The DEVICE-only TBE is the shape TorchRec actually builds for a
         # DEVICE table, and the only shape this lane exists to serve.
-        rows = 64
+        rows = ROWS
         device = torch.cuda.current_device()
         indices = torch.tensor([3], device=device, dtype=torch.int64)
         offsets = torch.tensor([0, 1], device=device, dtype=torch.int64)
@@ -236,6 +364,85 @@ class ResEnabledTablesTest(unittest.TestCase):
                     [3],
                 )
 
+    def _drain_tbe(
+        self,
+        drain_interval: int = 1,
+    ) -> SplitTableBatchedEmbeddingBagsCodegen:
+        """t0 MANAGED_CACHING (out of the lane), t1 DEVICE and allowlisted.
+
+        The cached table is what gives the cache lane a non-empty
+        ``total_cache_hash_size``; only t1's rows are in the HBM lane's mask.
+        """
+        return self._build_mixed_tbe(
+            ["t0", "t1"],
+            [EmbeddingLocation.MANAGED_CACHING, EmbeddingLocation.DEVICE],
+            res_enabled_tables=["t1"],
+            heights=[ROWS, ROWS],
+            res_hbm_drain_interval=drain_interval,
+        )
+
+    def _mark_and_store_one_row(
+        self,
+        tbe: SplitTableBatchedEmbeddingBagsCodegen,
+        t1_row: int,
+        rows: int = 64,
+    ) -> list[int] | None:
+        """One iteration's mark + store for a single t1 row, bypassing
+        `_prefetch`; returns drained ids or None.
+        """
+        device = torch.cuda.current_device()
+        tbe._mark_res_hbm_rows(
+            torch.tensor([t1_row], device=device, dtype=torch.int64),
+            torch.tensor([0, 0, 1], device=device, dtype=torch.int64),
+            None,
+        )
+        tbe._store_prefetched_tensors(
+            # Empty bag for feature 0, one index for feature 1.
+            indices=torch.tensor([t1_row], device=device, dtype=torch.int64),
+            offsets=torch.tensor([0, 0, 1], device=device, dtype=torch.int64),
+            vbe_metadata=None,
+            linear_cache_indices_merged=torch.tensor(
+                [rows], device=device, dtype=torch.int64
+            ),
+            final_lxu_cache_locations=torch.tensor(
+                [-1], device=device, dtype=torch.int32
+            ),
+            hash_zch_identities=None,
+            hash_zch_runtime_meta=None,
+        )
+        drained = tbe.prefetched_info_list[-1].res_hbm_indices
+        return None if drained is None else drained.tolist()
+
+    def _idle_iteration(
+        self,
+        tbe: SplitTableBatchedEmbeddingBagsCodegen,
+    ) -> list[int] | None:
+        """Advance one iteration without a lookup, to collect the pending drain.
+
+        The drain queues its row count to the host asynchronously, so what it
+        compacted ships on the iteration after it ran, not its own.
+
+        Both this and `_mark_and_store_one_row` mark before storing, mirroring
+        `_prefetch`: the mark sits above the cache guard, and
+        `_store_prefetched_tensors` does not mark.
+        """
+        device = torch.cuda.current_device()
+        empty = torch.zeros(0, device=device, dtype=torch.int64)
+        # Every fixture this serves has two features, and offsets is one longer.
+        offsets = torch.zeros(3, device=device, dtype=torch.int64)
+        tbe._mark_res_hbm_rows(empty, offsets, None)
+        tbe._store_prefetched_tensors(
+            indices=empty,
+            offsets=offsets,
+            vbe_metadata=None,
+            linear_cache_indices_merged=empty,
+            final_lxu_cache_locations=torch.zeros(0, device=device, dtype=torch.int32),
+            hash_zch_identities=None,
+            hash_zch_runtime_meta=None,
+        )
+        drained = tbe.prefetched_info_list[-1].res_hbm_indices
+        return None if drained is None else drained.tolist()
+
     def _device_tbe(
         self, heights: list[int], dims: list[int]
     ) -> SplitTableBatchedEmbeddingBagsCodegen:
@@ -251,6 +458,183 @@ class ResEnabledTablesTest(unittest.TestCase):
         flat = tbe.get_buffer("weights_dev")
         flat.copy_(torch.arange(flat.numel(), device=flat.device, dtype=flat.dtype))
         return tbe
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_drain_ships_only_rows_marked_since_the_last_drain(self) -> None:
+        # Four drains over disjoint row sets, at interval 1 so each prefetch
+        # drains. A single drain cannot see the bug: a drain that fails to clear
+        # still returns the right rows the first time and only ratchets on the
+        # second, so the shape of this test is load-bearing.
+        rows = ROWS
+        tbe = self._drain_tbe()
+        drains = [self._mark_and_store_one_row(tbe, i, rows) for i in range(4)]
+        drains.append(self._idle_iteration(tbe))
+
+        # 1. Every iteration drains, and each one ships only its own row, one
+        #    iteration after the drain that compacted it. Pinned as one literal
+        #    because that is also where "no row ships twice and none is lost"
+        #    is enforced: a ratchet lands here as a duplicate, a failure to
+        #    clear as a short list.
+        self.assertEqual(drains, [None, [rows + 0], [rows + 1], [rows + 2], [rows + 3]])
+        # 2. Nothing in the lane's mask is still set after the last drain.
+        present = tbe.get_buffer("_res_rows_seen")
+        mask = tbe.get_buffer("_res_hbm_linear_mask")
+        self.assertFalse(bool((present & mask).any()))
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_drain_ships_only_rows_the_mask_allows(self) -> None:
+        # The mark is over-broad on placement, allowlist and the pruning
+        # sentinel; the intersect is the only thing that removes them. t0 is
+        # cached and not allowlisted, so its row must not ship even though the
+        # bitmap records it.
+        rows = ROWS
+        tbe = self._drain_tbe()
+        device = torch.cuda.current_device()
+        tbe._mark_res_hbm_rows(
+            torch.tensor([5, 7, -1], device=device, dtype=torch.int64),
+            torch.tensor([0, 1, 3], device=device, dtype=torch.int64),
+            None,
+        )
+        tbe._store_prefetched_tensors(
+            # t0 row 5 (cached, out of the lane), t1 row 7 (in the lane),
+            # and a pruned -1 that linearizes to the sentinel.
+            indices=torch.tensor([5, 7, -1], device=device, dtype=torch.int64),
+            offsets=torch.tensor([0, 1, 3], device=device, dtype=torch.int64),
+            vbe_metadata=None,
+            linear_cache_indices_merged=torch.tensor(
+                [5, rows, rows], device=device, dtype=torch.int64
+            ),
+            final_lxu_cache_locations=torch.tensor(
+                [0, -1, -1], device=device, dtype=torch.int32
+            ),
+            hash_zch_identities=None,
+            hash_zch_runtime_meta=None,
+        )
+        present = tbe.get_buffer("_res_rows_seen")
+        # All three really were marked, including the sentinel -- otherwise this
+        # test would pass for the wrong reason.
+        self.assertTrue(bool(present[2 * rows]))
+        self.assertEqual(self._idle_iteration(tbe), [rows + 7])
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_drain_ships_no_more_rows_than_res_streams(self) -> None:
+        # A drain carries at most one row per row RES streams, however many
+        # iterations of marks it covers: the window here is nearly two full
+        # passes over the 64 streamed rows. The t0 and sentinel marks are what
+        # make the bound binding -- without the mask intersect this drain would
+        # carry 129 rows.
+        rows = ROWS
+        tbe = self._drain_tbe(drain_interval=rows * 2)
+        device = torch.cuda.current_device()
+        last = rows * 2 - 1
+        drained: list[int] = []
+        for i in range(rows * 2):
+            tbe._mark_res_hbm_rows(
+                torch.tensor(
+                    [i % rows, i % rows, -1], device=device, dtype=torch.int64
+                ),
+                torch.tensor([0, 1, 3], device=device, dtype=torch.int64),
+                None,
+            )
+            shipped = self._idle_iteration(tbe)
+            if i < last:
+                # Nothing ships until the interval is up.
+                self.assertIsNone(shipped)
+            else:
+                assert shipped is not None
+                drained = shipped
+        self.assertEqual(sorted(drained), [rows + i for i in range(rows)])
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_drain_fires_only_on_the_interval(self) -> None:
+        # The interval must stay > 1: at 1 every drain fires on every call
+        # whatever the counter does, so this is where the off-by-one is pinned.
+        rows = ROWS
+        tbe = self._drain_tbe(drain_interval=3)
+        drains = [self._mark_and_store_one_row(tbe, i, rows) for i in range(6)]
+        drains.append(self._idle_iteration(tbe))
+        # Marks keep landing every prefetch. The compact fires one call BEFORE
+        # the interval -- calls 2 and 5 -- so the rows go out on calls 3 and 6,
+        # which is where the interval lands.
+        self.assertEqual([drains[i] for i in (0, 1, 3, 4, 6)], [None] * 5)
+        # A drain carries its whole window, not just one iteration. The first
+        # window is a call short, since the phase puts the first compact on
+        # call K-1.
+        self.assertEqual(drains[2], [rows + 0, rows + 1])
+        self.assertEqual(drains[5], [rows + 2, rows + 3, rows + 4])
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hot_row_ships_once_per_interval(self) -> None:
+        # The reason to queue in the trainer at all. Setting a bit is
+        # idempotent, so a row touched every iteration costs one shipped row per
+        # interval, not one per iteration -- that is what bounds how much delta
+        # the downstream absorbs. A drain that shipped per-mark would return
+        # four copies here. The trailing idle call is what shows the row does
+        # not ship again once the interval has passed.
+        rows = ROWS
+        tbe = self._drain_tbe(drain_interval=4)
+        drains = [self._mark_and_store_one_row(tbe, 7, rows) for _ in range(4)]
+        drains.append(self._idle_iteration(tbe))
+        self.assertEqual(drains, [None, None, None, [rows + 7], None])
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_hot_row_ships_every_drain_when_remarked(self) -> None:
+        # The complement of the interval bound above: a row that keeps changing
+        # keeps shipping, once per drain. Clearing at pickup instead of at
+        # compact would wipe the re-mark with the previous drain's mask, so the
+        # second update would be dropped and iteration 3 would return None.
+        rows = ROWS
+        tbe = self._drain_tbe()
+        drains = [self._mark_and_store_one_row(tbe, 7, rows) for _ in range(4)]
+        self.assertEqual(drains, [None, [rows + 7], [rows + 7], [rows + 7]])
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_drain_leaves_its_count_pending(self) -> None:
+        # The drain must not read the count. Asserting on the pending buffer is
+        # the only way to see that from the outside: a drain that resolved the
+        # count itself would ship on its own iteration and leave nothing here,
+        # which is the host block the deferral exists to remove.
+        rows = ROWS
+        tbe = self._drain_tbe()
+        self._mark_and_store_one_row(tbe, 3, rows)
+
+        pending = tbe._res_compacted_rows
+        assert pending is not None
+        # Sized by the whole linear index space, because the count that would
+        # narrow it has not landed.
+        linear_size = tbe.get_buffer("_res_hbm_linear_mask").numel()
+        self.assertEqual(pending.numel(), linear_size + 1)
+        # Pinned, or the count copy could not be async.
+        self.assertTrue(tbe._res_drain_count_cpu.is_pinned())
+
+        self.assertEqual(self._idle_iteration(tbe), [rows + 3])
+        # What ships is a clone, not a view: a view would hold the whole
+        # compaction buffer alive for as long as the slice sits in
+        # prefetched_info_list, which is one int64 per row of every table.
+        drained = tbe.prefetched_info_list[-1].res_hbm_indices
+        assert drained is not None
+        self.assertEqual(drained.untyped_storage().nbytes(), drained.numel() * 8)
+
+    # pyrefly: ignore [bad-argument-type]
+    @unittest.skipIf(*gpu_unavailable)
+    def test_drain_interval_must_be_positive(self) -> None:
+        # interval 0 raises ZeroDivisionError deep in prefetch rather than at
+        # construction; a negative interval silently behaves as its absolute
+        # value, so -3 would drain every third iteration while looking rejected.
+        # Anchored past the knob name rather than matching it loosely: any
+        # future knob prefixed `res_hbm_drain_interval` would otherwise satisfy
+        # this regex from its own raise.
+        with self.assertRaisesRegex(ValueError, r"res_hbm_drain_interval must be"):
+            self._drain_tbe(drain_interval=0)
+        with self.assertRaisesRegex(ValueError, r"res_hbm_drain_interval must be"):
+            self._drain_tbe(drain_interval=-3)
 
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
@@ -387,7 +771,7 @@ class ResEnabledTablesTest(unittest.TestCase):
         # _prefetch sits below prepare_inputs, so bounds_check_indices has not
         # run and index 999 into 64 rows reaches the clamp raw. Without the
         # clamp this is a device-side assert, not a wrong row.
-        rows = 64
+        rows = ROWS
         device = torch.cuda.current_device()
         tbe = self._build_mixed_tbe(
             ["t0"],
@@ -407,11 +791,11 @@ class ResEnabledTablesTest(unittest.TestCase):
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_hbm_mark_negative_index_never_reaches_the_clamp(self) -> None:
-        # Why the clamp is upper-bound only: linearize_cache_indices guards both
-        # its write sites on `indices[index] >= 0`
-        # (linearize_cache_indices.cu:57 and :165) and routes anything negative
-        # to the sentinel, so a negative input arrives here already in range.
-        rows = 64
+        # Why the clamp is upper-bound only: linearize_cache_indices.cu guards
+        # both its write sites on `indices[index] >= 0` and routes anything
+        # negative to the sentinel, so a negative input arrives here already in
+        # range.
+        rows = ROWS
         device = torch.cuda.current_device()
         tbe = self._build_mixed_tbe(
             ["t0"],
@@ -450,8 +834,8 @@ class ResEnabledTablesTest(unittest.TestCase):
     # pyrefly: ignore [bad-argument-type]
     @unittest.skipIf(*gpu_unavailable)
     def test_get_enabled_feature_mask_and_indices(self) -> None:
-        rows = 64
-        tbe = self._build_tbe(["t0", "t1", "t2"], res_enabled_tables=["t1"], rows=rows)
+        rows = ROWS
+        tbe = self._build_tbe(["t0", "t1", "t2"], res_enabled_tables=["t1"])
         device = torch.cuda.current_device()
         # linear indices: t0 row 5, t1 row 0 (boundary), t2 row 10, t1 row 63
         linear = torch.tensor(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3113

Selects the marked rows for hbm, compacts them into row ids, and clears them.

A drain spans two iterations. The compact runs one call before the interval, which is what lets the row count reach the host for free it goes to pinned memory and is read an iteration later.

      ```
      res_hbm_drain_interval = 3
        call 1   mark
        call 2   mark, compact + clear, queue count
        call 3   mark, rows out
      ```

Reviewed By: chouxi

Differential Revision: D116863069


