### PR TITLE
Add -Wshorten-64-to-32, without errors (#6230)

### DIFF
--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -229,7 +229,18 @@ function(fbgemm_get_warning_flags)
     # `_hipcc_suppressions`), which keeps the diagnostic VISIBLE so 02c.3's
     # census can count it, without breaking the build if some CK header is
     # still reached via `-I`.
-    -Wheader-hygiene)
+    -Wheader-hygiene
+    # ---- Phase B4: 64-to-32 narrowing -------------------------------------
+    # clang-only: g++ 11.5 rejects the flag outright (probed).
+    # Enabled DEMOTED -- see -Wno-error=shorten-64-to-32 in the clang
+    # suppressions, which must ALSO be clang-guarded (see there).
+    #
+    # B0 measured 711 first-party diagnostics across 76 files, 55% in the top
+    # five. Subplan 09 calls this the hardest chunk in the project: the fixups
+    # are casts in index arithmetic, where a wrong cast is a silent numerical
+    # or OOB bug rather than a compile error. Enabling it demoted makes the
+    # backlog visible without forcing rushed casts.
+    -Wshorten-64-to-32)
 
   # Clang-only flags that also need a RECENT clang. An older clang does not
   # know these flags, and an unknown `-W` option stops the build when `-Werror`
@@ -298,7 +309,17 @@ function(fbgemm_get_warning_flags)
     # Note that this is stricter than a bare unknown `-Wno-<name>`, which g++
     # accepts silently. The leniency does not extend to the `=` form.
     # TODO(T169200065): drop once the toolchain stops surfacing this header.
-    -Wno-error=deprecated-dynamic-exception-spec)
+    -Wno-error=deprecated-dynamic-exception-spec
+    # Phase B4, landing demoted; see -Wshorten-64-to-32 in _cc_clang_only.
+    #
+    # This escape MUST stay clang-guarded. g++ hard-errors on
+    # -Wno-error=<warning it does not know>, even without -Werror:
+    #   cc1plus: error: '-Wno-error=shorten-64-to-32': no option
+    #                   '-Wshorten-64-to-32'
+    # Same landmine as the A2.1 escape. Putting it in _cc_suppressions_common
+    # would break every gcc leg of the OSS matrix.
+    # TODO(T169200065): delete once the count reaches zero.
+    -Wno-error=shorten-64-to-32)
 
   set(_cc_suppressions_clang_gt13
     -Wno-error=unused-but-set-parameter

--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -108,7 +108,17 @@ function(fbgemm_get_warning_flags)
     # of the three with ZERO third-party exposure, so unlike
     # -Wshorten-64-to-32 and -Wzero-as-null-pointer-constant it is not blocked
     # on giving PyTorch/ATen/c10 headers -isystem treatment.
-    -Wshadow)
+    -Wshadow
+    # ---- Phase B3: zero as null pointer -----------------------------------
+    # Portable: probed accepted AND diagnosing on g++ 11.5 and clang 22.
+    # Enabled DEMOTED -- see -Wno-error=zero-as-null-pointer-constant.
+    #
+    # B0 measured 449 first-party diagnostics across 130 files. That is the
+    # LARGEST job of the three B flags despite having ~260 fewer diagnostics
+    # than -Wshorten-64-to-32, because it is diffuse: only 19% sit in the top
+    # five files, versus 79% for -Wshadow. Rank by file count and
+    # concentration, not by raw count.
+    -Wzero-as-null-pointer-constant)
 
   # Clang-only warning flags. These are appended to `_cc` ONLY when the host
   # compiler is clang (see the guarded append below), because the OSS CI matrix
@@ -253,7 +263,18 @@ function(fbgemm_get_warning_flags)
     # hard-errors on and which therefore had to be clang-guarded.
     # TODO(T169200065): delete once the -Wshadow count reaches zero. This is
     # the whole point of enabling it demoted rather than silently.
-    -Wno-error=shadow)
+    -Wno-error=shadow
+    # Phase B3, landing demoted while its 449 diagnostics across 130 files
+    # are fixed; see -Wzero-as-null-pointer-constant in _cc_common. Portable
+    # escape -- probed demoting to a warning on both g++ and clang.
+    #
+    # This escape also covers the 48 diagnostics coming from PyTorch / ATen /
+    # c10 / folly / thrift headers, which are NOT FBGEMM's to fix. Those need
+    # -isystem treatment (unowned work that B0 newly identified) before this
+    # flag can go to hard error, independently of the first-party backlog.
+    # TODO(T169200065): delete once the count reaches zero AND the external
+    # headers are -isystem.
+    -Wno-error=zero-as-null-pointer-constant)
 
   # Clang suppressions, split by the clang version that made them necessary.
   # The CXX path applies these conditionally on the HOST clang version (below);


### PR DESCRIPTION
Summary:
NOTE: No linked task. Please associate a task with this diff.


Adds `-Wshorten-64-to-32` with the matching `-Wno-error=` form. The
warning becomes visible, but it does not stop the build.

Clang knows the flag. GCC does not know it. A compiler test shows this. The
flag and the `-Wno-error=` form both go in the clang-only list.

Keep the `-Wno-error=` form in the clang-only list. GCC stops with an error
if it gets `-Wno-error=shorten-64-to-32`, because GCC does not know the
warning. GCC gives this message:

  error: '-Wno-error=shorten-64-to-32': no option '-Wshorten-64-to-32'

The warning finds a 64-bit value that the code puts into a 32-bit variable.

Reviewed By: cthi

Differential Revision: D117101707


