### PR TITLE
TBE backward: consume precomputed index-preproc tensors

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_grad_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_grad_template.cu
@@ -10,6 +10,11 @@
 #include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
+#include "fbgemm_gpu/config/feature_gates.h"
+#include "fbgemm_gpu/utils/kernel_launcher.cuh"
+#include "fbgemm_gpu/utils/ops_utils.h"
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/library.h>
 
 using Tensor = at::Tensor;
 
@@ -248,5 +253,180 @@ void grad_mean{{ vdesc }}_kernel
 {% endfor %} // for vbe in [True, False]
 
 }
+
+{% if not is_index_select %}
+// ===========================================================================
+// tbe_bwd_indices_preproc: combined index-preprocessing op for the TBE
+// backward. Folded into this single, non-optimizer-templated TU so it shares
+// the split_embedding_backward_codegen_find_long_segments __global__ defined
+// above (embedding_ops namespace) -- no forward-decl, compiled once, NO
+// separate build target/file. Wraps the two grad-independent steps
+//   1) transpose_embedding_input  (linearize -> radix-sort -> RLE + cumsum)
+//   2) find_long_segments         (segment partition)
+// so they can be hoisted OFF the backward critical path. CUDA, common path
+// (bagged, non-index-select). max_segment_length_per_cta +
+// use_deterministic_algorithms are derived internally, mirroring the driver.
+// The 12-tensor output order matches the driver's preproc_tensors[0..11]
+// unpack contract in embedding_backward_split_template.cu.
+// Design doc:
+// docs.google.com/document/d/1Z8_1zI_4WSF-gsaHKVLY3wUNPyAZSYRJLDSbDZfRE2o
+// ===========================================================================
+namespace fbgemm_gpu {
+
+std::tuple<
+    Tensor, // linear_indices
+    Tensor, // linear_indices_sorted
+    Tensor, // sorted_linear_indices_run
+    Tensor, // sorted_linear_indices_run_lengths
+    Tensor, // sorted_linear_indices_num_runs
+    Tensor, // sorted_linear_indices_cumulative_run_lengths
+    Tensor, // infos_sorted
+    Tensor, // long_run_ids
+    Tensor, // num_long_run_ids
+    Tensor, // long_run_id_to_really_long_run_ids
+    Tensor, // num_really_long_run_ids
+    Tensor> // grad_accum_counter
+tbe_bwd_indices_preproc_cuda(
+    const Tensor& hash_size_cumsum,
+    const int64_t total_hash_size_bits,
+    const Tensor& indices,
+    const Tensor& offsets,
+    const int64_t info_B_num_bits,
+    const int64_t info_B_mask,
+    const int64_t total_unique_indices,
+    const std::optional<Tensor>& vbe_b_t_map,
+    const bool nobag,
+    const bool is_index_select) {
+  CUDA_DEVICE_GUARD(indices);
+
+  // ---- Part A: transpose_embedding_input ----------------------------------
+  auto
+      [linear_indices,
+       linear_indices_sorted,
+       infos_sorted,
+       sorted_linear_indices_run,
+       sorted_linear_indices_run_lengths,
+       sorted_linear_indices_num_runs,
+       sorted_linear_indices_cumulative_run_lengths] =
+          transpose_embedding_input(
+              hash_size_cumsum,
+              total_hash_size_bits,
+              indices,
+              offsets,
+              nobag,
+              vbe_b_t_map,
+              info_B_num_bits,
+              info_B_mask,
+              total_unique_indices,
+              is_index_select);
+
+  // ---- Part B: find_long_segments -----------------------------------------
+  // Grid bound: when total_unique_indices is unknown at call time (-1, e.g.
+  // hoisted into the forward before the run count is available), fall back to
+  // indices.numel() -- a safe upper bound on the number of runs. The kernel
+  // bounds its real work by the device-side run count, so extra blocks are
+  // no-ops; this only over-launches, it does not affect correctness.
+  const auto num_unique =
+      total_unique_indices >= 0 ? total_unique_indices : indices.numel();
+
+  auto long_run_ids =
+      at::empty({indices.numel()}, sorted_linear_indices_run_lengths.options());
+  auto num_long_run_ids = at::zeros({1}, indices.options().dtype(at::kInt));
+
+  const bool use_deterministic_algorithms =
+      at::globalContext().deterministicAlgorithms();
+
+  // max_segment_length_per_warp is a fixed policy constant (warp/CTA routing
+  // threshold), not a runtime input -- derived internally to mirror the driver.
+#ifdef USE_ROCM
+  constexpr int32_t max_segment_length_per_warp = 16384;
+  const int max_segment_length_per_cta =
+      use_deterministic_algorithms ? INT_MAX : 4096;
+#else
+  constexpr int32_t max_segment_length_per_warp = 32;
+  const auto device_properties = at::cuda::getCurrentDeviceProperties();
+  int default_segment_length = 1024;
+  const bool b200_feature_enabled =
+      (device_properties->major >= 10) &&
+      fbgemm_gpu::config::is_feature_enabled(
+          fbgemm_gpu::config::FeatureGateName::
+              TBE_USE_TUNED_SEGMENT_LENGTHS_CTA_B200);
+  if (b200_feature_enabled) {
+    default_segment_length = 4096;
+  }
+  const int max_segment_length_per_cta =
+      use_deterministic_algorithms ? INT_MAX : default_segment_length;
+#endif
+
+  Tensor long_run_id_to_really_long_run_ids;
+  if (use_deterministic_algorithms) {
+    long_run_id_to_really_long_run_ids =
+        at::empty(0, sorted_linear_indices_run_lengths.options());
+  } else {
+    long_run_id_to_really_long_run_ids = at::empty(
+        {indices.numel()}, sorted_linear_indices_run_lengths.options());
+  }
+
+  auto num_really_long_run_ids =
+      at::zeros({1}, indices.options().dtype(at::kInt));
+  auto grad_accum_counter = at::empty(
+      use_deterministic_algorithms
+          ? 0
+          : (indices.numel() / max_segment_length_per_cta),
+      indices.options().dtype(at::kInt));
+
+  constexpr auto fls_ctx = "find_long_segments";
+  FBGEMM_LAUNCH_KERNEL(
+      embedding_ops::split_embedding_backward_codegen_find_long_segments,
+      div_round_up(num_unique, kMaxThreads),
+      kMaxThreads,
+      0,
+      at::cuda::getCurrentCUDAStream(),
+      PTA_B(sorted_linear_indices_num_runs, int32_t, 1, 32).build(fls_ctx),
+      PTA_B(sorted_linear_indices_run_lengths, int32_t, 1, 32).build(fls_ctx),
+      PTA_B(long_run_ids, int32_t, 1, 32).build(fls_ctx),
+      PTA_B(num_long_run_ids, int32_t, 1, 32).build(fls_ctx),
+      PTA_B(long_run_id_to_really_long_run_ids, int32_t, 1, 32).build(fls_ctx),
+      PTA_B(num_really_long_run_ids, int32_t, 1, 32).build(fls_ctx),
+      PTA_B(grad_accum_counter, int32_t, 1, 32).build(fls_ctx),
+      max_segment_length_per_warp,
+      max_segment_length_per_cta,
+      use_deterministic_algorithms);
+
+  return {
+      linear_indices,
+      linear_indices_sorted,
+      sorted_linear_indices_run,
+      sorted_linear_indices_run_lengths,
+      sorted_linear_indices_num_runs,
+      sorted_linear_indices_cumulative_run_lengths,
+      infos_sorted,
+      long_run_ids,
+      num_long_run_ids,
+      long_run_id_to_really_long_run_ids,
+      num_really_long_run_ids,
+      grad_accum_counter};
+}
+
+} // namespace fbgemm_gpu
+
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  m.def(
+      "tbe_bwd_indices_preproc("
+      "    Tensor hash_size_cumsum, "
+      "    int total_hash_size_bits, "
+      "    Tensor indices, "
+      "    Tensor offsets, "
+      "    int info_B_num_bits=26, "
+      "    int info_B_mask=0x2FFFFFF, "
+      "    int total_unique_indices=-1, "
+      "    Tensor? vbe_b_t_map=None, "
+      "    bool nobag=False, "
+      "    bool is_index_select=False"
+      ") -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, "
+      "Tensor, Tensor, Tensor, Tensor)");
+  DISPATCH_TO_CUDA("tbe_bwd_indices_preproc", tbe_bwd_indices_preproc_cuda);
+}
+{% endif %}
 
 // clang-format on

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -209,6 +209,7 @@ enum SSDTensor {
           {%- else %}
           /*unused=*/0
           {%- endif %}
+          , std::nullopt
     );
 
     if (is_annotate_trace_enabled) {
@@ -549,7 +550,8 @@ Tensor
     {%- endif %}
     const double gwd_lower_bound,
     {%- endif %}
-    {{ args.split_function_args | join(", ") }});
+    {{ args.split_function_args | join(", ") }}
+    , std::optional<std::vector<Tensor>> preproc_tensors = std::nullopt);
 {%- endfor %} {#-/* for weighted*/#}
 
 {%- if args.split_function_args_v1 is not none %}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_meta_template.cpp
@@ -134,6 +134,9 @@ Tensor {{ mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ desc
     int64_t total_hash_size,
     c10::SymInt total_unique_indices
     {%- endif %}
+    {%- if not is_index_select %}
+    , std::optional<std::vector<Tensor>> preproc_tensors [[maybe_unused]]
+    {%- endif %}
 ) {
 
     // NB: Should we have something for aligning memory like we do on the tensor kernels?

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -681,6 +681,9 @@ Tensor {{ embedding_cuda_op }}(
     int64_t total_hash_size,
     c10::SymInt total_unique_indices_
     {%- endif %}
+    {%- if not is_index_select %}
+    , std::optional<std::vector<Tensor>> preproc_tensors
+    {%- endif %}
 ) {
     {%- if not nobag or is_index_select %}
     const int64_t max_D = max_D_.guard_int(__FILE__, __LINE__);
@@ -841,6 +844,28 @@ Tensor {{ embedding_cuda_op }}(
         sorted_linear_indices_run, sorted_linear_indices_run_lengths,
         sorted_linear_indices_num_runs,
         sorted_linear_indices_cumulative_run_lengths;
+    // When preproc tensors are provided, the grad-independent index preproc has
+    // already been computed off the backward critical path, so skip recomputing it.
+    std::vector<Tensor> _preproc_tensors;
+    {%- if not is_index_select %}
+    const bool skip_preproc = preproc_tensors.has_value() &&
+        preproc_tensors->size() == 12;
+    {%- else %}
+    const std::optional<std::vector<Tensor>> preproc_tensors = std::nullopt;
+    const bool skip_preproc = false;
+    {%- endif %}
+
+    if (skip_preproc) {
+        _preproc_tensors = preproc_tensors.value();
+        linear_indices=_preproc_tensors[0];
+        linear_indices_sorted=_preproc_tensors[1];
+        sorted_linear_indices_run=_preproc_tensors[2];
+        sorted_linear_indices_run_lengths=_preproc_tensors[3];
+        sorted_linear_indices_num_runs=_preproc_tensors[4];
+        sorted_linear_indices_cumulative_run_lengths=_preproc_tensors[5];
+        infos_sorted=_preproc_tensors[6];
+    }
+    else {
     std::tie(
         linear_indices,
         linear_indices_sorted,
@@ -868,7 +893,7 @@ Tensor {{ embedding_cuda_op }}(
             false // is_index_select
             {%- endif %}
         );
-
+    }
     {%- if not dense %}
     Tensor {{ locs_or_addrs_tensor }}_sorted = {{ locs_or_addrs_tensor }};
     Tensor table_unique_indices_offsets;
@@ -1078,31 +1103,37 @@ Tensor {{ embedding_cuda_op }}(
             } }
             {%- endif %}
 
-            DISPATCH_OPTIMAL_KERNEL(max_D, [&] {
-                auto long_run_ids = at::empty({indices.numel()}, sorted_linear_indices_run_lengths.options());
-                auto num_long_run_ids = at::zeros({1}, indices.options().dtype(at::kInt));
+            const bool use_deterministic_algorithms = at::globalContext().deterministicAlgorithms();
 
-                const bool use_deterministic_algorithms = at::globalContext().deterministicAlgorithms();
+            {% if is_rocm %}
+                const int max_segment_length_per_cta = use_deterministic_algorithms ? INT_MAX : 4096;
+            {% else %}
+                //optimize for B200
+                const auto device_properties = at::cuda::getCurrentDeviceProperties();
+                int default_segment_length = 1024;
+                const bool b200_feature_enabled = (device_properties->major >= 10) && fbgemm_gpu::config::is_feature_enabled(fbgemm_gpu::config::FeatureGateName::TBE_USE_TUNED_SEGMENT_LENGTHS_CTA_B200);
+                if (b200_feature_enabled) {
+                default_segment_length = 4096;
+                }
+                // Debug logging - remove after verification
+                TORCH_WARN_ONCE("TBE B200 optimization: device_major=", device_properties->major,
+                                ", feature_enabled=", b200_feature_enabled,
+                                ", segment_length=", default_segment_length);
+                const int max_segment_length_per_cta = use_deterministic_algorithms ? INT_MAX : default_segment_length;
 
-                {% if is_rocm %}
-                    const int max_segment_length_per_cta = use_deterministic_algorithms ? INT_MAX : 4096;
-                {% else %}
-                    //optimize for B200
-                    const auto device_properties = at::cuda::getCurrentDeviceProperties();
-                    int default_segment_length = 1024;
-                    const bool b200_feature_enabled = (device_properties->major >= 10) && fbgemm_gpu::config::is_feature_enabled(fbgemm_gpu::config::FeatureGateName::TBE_USE_TUNED_SEGMENT_LENGTHS_CTA_B200);
-                    if (b200_feature_enabled) {
-                      default_segment_length = 4096;
-                    }
-                    // Debug logging - remove after verification
-                    TORCH_WARN_ONCE("TBE B200 optimization: device_major=", device_properties->major,
-                                    ", feature_enabled=", b200_feature_enabled,
-                                    ", segment_length=", default_segment_length);
-                    const int max_segment_length_per_cta = use_deterministic_algorithms ? INT_MAX : default_segment_length;
+            {%- endif %}
 
-                {%- endif %}
-
-                Tensor long_run_id_to_really_long_run_ids;
+            Tensor long_run_ids, num_long_run_ids, long_run_id_to_really_long_run_ids, num_really_long_run_ids, grad_accum_counter;
+            if (skip_preproc) {
+                long_run_ids = _preproc_tensors[7];
+                num_long_run_ids = _preproc_tensors[8];
+                long_run_id_to_really_long_run_ids = _preproc_tensors[9];
+                num_really_long_run_ids = _preproc_tensors[10];
+                grad_accum_counter = _preproc_tensors[11];
+            }
+            else {
+                long_run_ids = at::empty({indices.numel()}, sorted_linear_indices_run_lengths.options());
+                num_long_run_ids = at::zeros({1}, indices.options().dtype(at::kInt));
                 if (use_deterministic_algorithms) {
                     long_run_id_to_really_long_run_ids =
                         at::empty(0, sorted_linear_indices_run_lengths.options());
@@ -1111,14 +1142,14 @@ Tensor {{ embedding_cuda_op }}(
                         at::empty({indices.numel()}, sorted_linear_indices_run_lengths.options());
                 }
 
-                auto num_really_long_run_ids = at::zeros({1}, indices.options().dtype(at::kInt));
-                auto grad_accum_counter = at::empty(
+                num_really_long_run_ids = at::zeros({1}, indices.options().dtype(at::kInt));
+                grad_accum_counter = at::empty(
                     use_deterministic_algorithms ? 0 : (indices.numel() / max_segment_length_per_cta),
                     indices.options().dtype(at::kInt));
 
                 constexpr auto fls_ctx = "find_long_segments";
                 FBGEMM_LAUNCH_KERNEL(
-                    split_embedding_backward_codegen_find_long_segments,
+                    {{ "index_select" if is_index_select else "embedding_ops" }}::split_embedding_backward_codegen_find_long_segments,
                     utils::cuda::cap_grid_dim_x_from_workload(
                         total_unique_indices, kMaxThreads, at::cuda::getCurrentCUDAStream()),
                     kMaxThreads,
@@ -1135,6 +1166,9 @@ Tensor {{ embedding_cuda_op }}(
                     max_segment_length_per_cta,
                     use_deterministic_algorithms
                 );
+            }
+
+            DISPATCH_OPTIMAL_KERNEL(max_D, [&] {
 
                 // A temp buffer to accumulate gradients with atomics.
                 auto temp_grad_accum = at::zeros(
@@ -1669,7 +1703,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
           {%- endif %}
           "    float gwd_lower_bound, "
           {%- endif %}
-          "    {{ args.split_function_schemas | join(", ") }}"
+          "    {{ args.split_function_schemas | join(", ") }}, "
+          "    Tensor[]? preproc_tensors=None"
           ") -> Tensor");
     DISPATCH_TO_CUDA(
         "{{ embedding_codegen_backward_op }}",

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -290,6 +290,7 @@ enum SSDTensor {
                 {%- if not nobag %}
                 , const int64_t /*output_dtype*/
                 {%- endif %}
+                , std::optional<std::vector<Tensor>> /*preproc_tensors*/
             )>();
 
     {%- if not dense %}
@@ -380,6 +381,7 @@ enum SSDTensor {
           {%- if not nobag %}
           , output_dtype
           {%- endif %}
+          , preproc_tensors
     );
 
     if (is_annotate_trace_enabled) {
@@ -1133,7 +1135,19 @@ static torch::autograd::variable_list backward(
           "{{ bwd_mdesc }}_tbe_bwd" + op_annotation);
     }
 
-    TORCH_CHECK_EQ(grad_outputs.size(), 1);
+    // grad_outputs[0] is the embedding grad. Either that alone, or it plus the
+    // 12 index-preproc grads (grad_outputs[1..12]) when the forward emits the
+    // dummy outputs.
+    constexpr int kNumPreprocTensors = 12;
+    TORCH_CHECK(
+        grad_outputs.size() == 1 ||
+        grad_outputs.size() == 1 + kNumPreprocTensors);
+
+    std::optional<std::vector<Tensor>> preproc_tensors = std::nullopt;
+    if (grad_outputs.size() == 1 + kNumPreprocTensors) {
+      preproc_tensors =
+          std::vector<Tensor>(grad_outputs.begin() + 1, grad_outputs.end());
+    }
 
     // BT_block_size and max_segment_length_per_warp are GPU kernel
     // launch parameters that the dispatched backward op consumes only

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
@@ -286,7 +286,8 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{
     {{ args_pt2.split_function_args | join(", ") }}
     {%- if not nobag %}
     , const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)
-    {%- endif %})
+    {%- endif %}
+    , std::optional<std::vector<Tensor>> /*preproc_tensors*/ = std::nullopt)
     {
         // Accept the MTIA CPU-fallback 5-slot device layout too. Slots 3/4 are
         // unused here; assert they are empty so device state isn't silently dropped.
@@ -503,6 +504,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         {%- if not nobag %}
         "    , int output_dtype=0 "
         {%- endif %}
+        "    , Tensor[]? preproc_tensors=None "
         ") -> Tensor");
     }
     DISPATCH_TO_CPU("{{ embedding_codegen_backward_op }}_wrapper", {{ embedding_codegen_backward_op }}_cpu_wrapper);

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
@@ -277,7 +277,8 @@ Tensor {{ bwd_mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ 
     {{ args_pt2.split_function_args | join(", ") }}
     {%- if not nobag %}
     , const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)
-    {%- endif %}){
+    {%- endif %}
+    , std::optional<std::vector<Tensor>> preproc_tensors = std::nullopt){
         TORCH_CHECK(
             weights.size() == 5,
             "CUDA weights must contain dev, placements, offsets, uvm, lxu_cache");
@@ -364,8 +365,9 @@ Tensor {{ bwd_mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ 
                         const double /*gwd_lower_bound*/,
                         {%- endif %}
                         {%- for arg_type in args.split_function_args %}
-                        {{ arg_type.split(' ')[0]}}{%- if not loop.last %}{{ "," }}{%- endif %}
+                        {{ arg_type.split(' ')[0]}}{{ "," }}
                         {%- endfor %}
+                        std::optional<std::vector<Tensor>>
                 )>();
 
         return op.call(
@@ -424,6 +426,7 @@ Tensor {{ bwd_mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ 
             gwd_lower_bound,
             {%- endif %}
             {{ args.split_function_arg_names | join(", ") }}
+            , preproc_tensors
         );
     }
 
@@ -675,6 +678,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         {%- if not nobag %}
         "    , int output_dtype=0 "
         {%- endif %}
+        "    , Tensor[]? preproc_tensors=None "
         ") -> Tensor");
     }
     {%- endif %}

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
@@ -43,6 +43,49 @@ transpose_embedding_input(
     const int64_t fixed_L_per_warp = 0,
     const int64_t num_warps_per_feature = 0);
 
+std::tuple<
+    at::Tensor, // long_run_ids
+    at::Tensor, // num_long_run_ids
+    at::Tensor, // long_run_id_to_really_long_run_ids
+    at::Tensor, // num_really_long_run_ids
+    at::Tensor> // grad_accum_counter
+split_embedding_backward_codegen_find_long_segments(
+    at::Tensor sorted_linear_indices_num_runs,
+    at::Tensor sorted_linear_indices_run_lengths,
+    at::Tensor long_run_ids,
+    at::Tensor num_long_run_ids,
+    at::Tensor long_run_id_to_really_long_run_ids,
+    at::Tensor num_really_long_run_ids,
+    at::Tensor grad_accum_counter,
+    const int32_t max_segment_length_per_warp,
+    const int32_t max_segment_length_per_cta,
+    const bool use_deterministic_algorithms);
+
+// std::tuple<
+//     at::Tensor, // linear_indices
+//     at::Tensor, // linear_indices_sorted
+//     at::Tensor, // sorted_linear_indices_run
+//     at::Tensor, // sorted_linear_indices_run_lengths
+//     at::Tensor, // sorted_linear_indices_num_runs
+//     at::Tensor, // sorted_linear_indices_cumulative_run_lengths
+//     at::Tensor, // infos_sorted
+//     at::Tensor, // long_run_ids
+//     at::Tensor, // num_long_run_ids
+//     at::Tensor, // long_run_id_to_really_long_run_ids
+//     at::Tensor, // num_really_long_run_ids
+//     at::Tensor> // grad_accum_counter
+// tbe_bwd_indices_preproc_cuda(
+//     const at::Tensor& hash_size_cumsum,
+//     const int64_t total_hash_size_bits,
+//     const at::Tensor& indices,
+//     const at::Tensor& offsets,
+//     const int64_t info_B_num_bits,
+//     const int64_t info_B_mask,
+//     const int64_t total_unique_indices,
+//     const std::optional<at::Tensor>& vbe_b_t_map,
+//     const bool nobag,
+//     const bool is_index_select);
+
 // Use these functions instead of directly calling cub functions
 // to reduce code size and compilation time.
 // Arguments are the same as cub::DeviceRadixSort::SortPairs

--- a/fbgemm_gpu/src/split_embeddings_utils/split_embeddings_utils.cpp
+++ b/fbgemm_gpu/src/split_embeddings_utils/split_embeddings_utils.cpp
@@ -15,6 +15,21 @@ using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  // m.def(
+  //     "tbe_bwd_indices_preproc("
+  //     "    Tensor hash_size_cumsum, "
+  //     "    int total_hash_size_bits, "
+  //     "    Tensor indices, "
+  //     "    Tensor offsets, "
+  //     "    int info_B_num_bits=26, "
+  //     "    int info_B_mask=0x2FFFFFF, "
+  //     "    int total_unique_indices=-1, "
+  //     "    Tensor? vbe_b_t_map=None, "
+  //     "    bool nobag=False, "
+  //     "    bool is_index_select=False"
+  //     ") -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor,
+  //     " "Tensor, Tensor, Tensor, Tensor)");
+  // DISPATCH_TO_CUDA("tbe_bwd_indices_preproc", tbe_bwd_indices_preproc_cuda);
   DISPATCH_TO_CUDA("transpose_embedding_input", transpose_embedding_input);
   DISPATCH_TO_CUDA("get_infos_metadata", get_infos_metadata);
   DISPATCH_TO_CUDA("generate_vbe_metadata", generate_vbe_metadata);

--- a/fbgemm_gpu/test/tbe/training/backward_sgd_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_sgd_test.py
@@ -85,7 +85,21 @@ class BackwardSGDTest(unittest.TestCase):
         use_writeback_bwd_prehook: bool = False,
         enable_writeback_bwd_prehook_first_feature_only: bool = False,
         use_api_v1: bool = False,
+        use_preproc_bwd: bool = False,
     ) -> None:
+        # The preproc-consume backward is only wired for the common path (bagged/SUM,
+        # non-VBE, CUDA, FP32, no cache/writeback). Skip other combos so the arm is
+        # only exercised where it is valid -- same early-return style as below.
+        if use_preproc_bwd and (
+            use_cpu
+            or use_cache
+            or mixed_B
+            or pooling_mode != PoolingMode.SUM
+            or use_writeback_bwd_prehook
+            or weights_precision != SparseType.FP32
+            or output_dtype != SparseType.FP32
+        ):
+            return
         # NOTE: cache is not applicable to CPU version.
         if use_cpu and use_cache:
             return
@@ -327,6 +341,11 @@ class BackwardSGDTest(unittest.TestCase):
             x, L, sum(Bs), use_cpu=use_cpu
         )
 
+        # The preproc op's find_long_segments kernel cannot launch a 0-width grid, so
+        # the preproc arm needs at least one index. The normal backward handles empty.
+        if use_preproc_bwd and indices.numel() == 0:
+            return
+
         batch_size_per_feature_per_rank = Bs_rank_feature if mixed_B else None
 
         # Run TBE's forward
@@ -359,7 +378,23 @@ class BackwardSGDTest(unittest.TestCase):
             goc = torch.cat(gos, dim=0)
 
         # Run TBE's backward
-        fc2.backward(goc)
+        if use_preproc_bwd:
+            # Drive the fused SGD backward through the backend-dispatched
+            # *_pt2_wrapper op with a hoisted index-preproc bundle instead of the
+            # normal autograd backward. The in-place weight update must match the
+            # baseline all the same -- see _run_preproc_backward.
+            self._run_preproc_backward(
+                cc,
+                indices,
+                offsets,
+                goc,
+                B,
+                num_features,
+                weighted,
+                per_sample_weights,
+            )
+        else:
+            fc2.backward(goc)
 
         if use_cache:
             cc.flush()
@@ -382,6 +417,98 @@ class BackwardSGDTest(unittest.TestCase):
                     else (2.0e-2 if weights_precision == SparseType.FP16 else 1.0e-5)
                 ),
             )
+
+    def _run_preproc_backward(
+        self,
+        cc: SplitTableBatchedEmbeddingBagsCodegen,
+        indices: torch.Tensor,
+        offsets: torch.Tensor,
+        grad_output: torch.Tensor,
+        B: int,
+        num_features: int,
+        weighted: bool,
+        per_sample_weights: torch.Tensor | None,
+    ) -> None:
+        """Feed a hoisted index-preproc bundle into the fused SGD backward op.
+
+        Instead of driving the normal autograd backward, compute the index-preproc
+        (``tbe_bwd_indices_preproc``) up front and hand it to the backward driver via
+        the trailing ``preproc_tensors`` arg. The op skips the inline
+        ``transpose_embedding_input`` + ``find_long_segments`` and consumes the bundle
+        instead; the in-place fused SGD weight update is identical, so the caller's
+        existing weight assertion validates numerical correctness.
+
+        The call goes through the backend-dispatched ``*_pt2_wrapper`` op (NOT the
+        CUDA-only ``*_exact_cuda`` op), so the path stays portable across backends
+        (CPU / Meta / MTIA), which is the whole point of routing preproc through the
+        wrapper.
+        """
+        ind, off, _, _ = cc.prepare_inputs(
+            indices, offsets, None, None, force_cast_input_types=True
+        )
+        info_B_num_bits, info_B_mask = torch.ops.fbgemm.get_infos_metadata(
+            cc.hash_size_cumsum, B, num_features
+        )
+        preproc = list(
+            torch.ops.fbgemm.tbe_bwd_indices_preproc(
+                cc.hash_size_cumsum,
+                cc.total_hash_size_bits,
+                ind,
+                off,
+                nobag=False,
+                vbe_b_t_map=None,
+                info_B_num_bits=info_B_num_bits,
+                info_B_mask=info_B_mask,
+                total_unique_indices=-1,
+            )
+        )
+        wdesc = "weighted" if weighted else "unweighted"
+        backward_op = getattr(
+            torch.ops.fbgemm,
+            f"split_embedding_backward_codegen_sgd_{wdesc}_pt2_wrapper",
+        )
+        # Bagged ops always take an indice_weights arg; unweighted passes an empty one.
+        indice_weights = (
+            per_sample_weights
+            if weighted
+            else torch.empty(0, dtype=torch.float, device=cc.weights_dev.device)
+        )
+        # Post-D113869217 the *_pt2_wrapper op takes a packed `weights` TensorList
+        # and a packed `aux_tensor_bwd` TensorList instead of loose tensors. GPU
+        # (non-VBE) layout: weights = [dev, placements, offsets, uvm, lxu_cache];
+        # aux_tensor_bwd = [lxu_cache_locations] (slot 0 only, size 1).
+        weights = [
+            cc.weights_dev,
+            cc.weights_placements,
+            cc.weights_offsets,
+            cc.weights_uvm,
+            cc.lxu_cache_weights,
+        ]
+        aux_tensor_bwd = [cc.lxu_cache_locations_empty]
+        backward_op(
+            grad_output.contiguous(),
+            weights,
+            cc.D_offsets,
+            cc.max_D,
+            cc.mixed_D,
+            cc.hash_size_cumsum,
+            cc.total_hash_size_bits,
+            ind,
+            off,
+            cc.pooling_mode,
+            indice_weights,
+            aux_tensor_bwd,
+            0,  # BT_block_size (unused)
+            32,  # max_segment_length_per_warp
+            cc.stochastic_rounding,
+            info_B_num_bits,
+            info_B_mask,
+            False,  # use_uniq_cache_locations
+            False,  # use_homogeneous_placements
+            cc.learning_rate_tensor,
+            cc.output_dtype,
+            preproc,
+        )
 
     @given(
         T=st.integers(min_value=1, max_value=5),
@@ -443,6 +570,57 @@ class BackwardSGDTest(unittest.TestCase):
             pooling_mode,
             use_cpu,
             SparseType.FP32,  # output_dtype
+        )
+
+    @unittest.skipIf(*gpu_unavailable)
+    @given(
+        T=st.integers(min_value=1, max_value=5),
+        D=st.integers(min_value=2, max_value=256),
+        B=st.integers(min_value=1, max_value=128),
+        log_E=st.integers(min_value=3, max_value=5),
+        L=st.integers(min_value=1, max_value=20),
+        weighted=st.booleans(),
+        mixed=st.booleans(),
+        long_segments=st.booleans(),
+    )
+    @settings(
+        verbosity=VERBOSITY,
+        max_examples=MAX_EXAMPLES,
+        deadline=None,
+    )
+    def test_backward_sgd_preproc(
+        self,
+        T: int,
+        D: int,
+        B: int,
+        log_E: int,
+        L: int,
+        weighted: bool,
+        mixed: bool,
+        long_segments: bool,
+    ) -> None:
+        """Same fused SGD backward as ``test_backward_sgd``, but the backward is driven
+        through the ``*_pt2_wrapper`` op fed a hoisted index-preproc bundle
+        (``use_preproc_bwd=True``). Consuming the preproc must produce the identical
+        weight update, so this reuses the harness assertion. Constrained to the common
+        path the preproc consume is wired for: bagged/SUM, CUDA, FP32, no cache."""
+        self.execute_backward_sgd_(
+            T,
+            D,
+            B,
+            log_E,
+            L,
+            weights_precision=SparseType.FP32,
+            weighted=weighted,
+            mixed=mixed,
+            mixed_B=False,
+            use_cache=False,
+            cache_algorithm=CacheAlgorithm.LRU,
+            long_segments=long_segments,
+            pooling_mode=PoolingMode.SUM,
+            use_cpu=False,
+            output_dtype=SparseType.FP32,
+            use_preproc_bwd=True,
         )
 
     @given(


### PR DESCRIPTION
Summary:
Everything except the forward for moving grad-independent index preprocessing
off the TBE backward critical path. Two halves, folded into one diff:

- Backend driver (consume): adds an optional `preproc_tensors` (Tensor[]?)
  argument to the TBE backward driver so it can accept precomputed
  index-preprocessing outputs (transpose_embedding_input + find_long_segments)
  and skip recomputing them inline. When the arg is None (the default / common
  path), the driver runs the inline preprocessing exactly as before -- no
  behavior change. Applied across the backward host/meta/cu templates, the PT2
  CPU/CUDA wrappers, and split_embeddings_utils.

- PT2 autograd (route): threads the optional preproc_tensors bundle through the
  PT2 training autograd backward into the backend backward op. When the forward
  emits the 12 index-preproc grad slots (grad_outputs[1..12]), backward packs
  them into preproc_tensors and forwards them to the driver's consume path;
  otherwise preproc_tensors stays nullopt and the driver recomputes the preproc
  inline exactly as before.

Non-breaking on its own: no forward output is emitted yet, so grad_outputs stays
size 1 until the forward-emit diff (top of stack) is applied. The backward
simply gains the ability to accept and route the extra grads when they later
appear. Builds on the add-op base (D114645411, below in stack).

Differential Revision: D113624507


