### PR TITLE
Improve error for `info_B_num_bits` when B overflows

### DIFF
--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -812,7 +812,17 @@ class {{ autograd_func }} :
     // Constanting info_B_num_bits, info_B_mask for Dynamo for now.
     const auto info_B_num_bits = static_cast<int32_t>(aux_int[IDX_INFO_B_NUM_BITS]);
     const auto info_B_mask = static_cast<uint32_t>(aux_int[IDX_INFO_B_MASK]);
-    TORCH_SYM_CHECK(max_B_.sym_le(info_B_mask), "Not enough bits to accommodate B");
+    TORCH_SYM_CHECK(
+        max_B_.sym_le(info_B_mask),
+        "[{{ "VBE" if vbe else "const B" }}] Not enough bits to accommodate B: max_B = ",
+        max_B_,
+        " exceeds max allowed B = ",
+        info_B_mask,
+        " (info_B_num_bits = ",
+        info_B_num_bits,
+        ", derived from T = ",
+        T,
+        " features)");
     {%- if vbe %}
     static auto generate_vbe_metadata_op =
         torch::Dispatcher::singleton()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3108

# TLDR
The "Not enough bits to accommodate B" check gave no numbers, so hitting it told you nothing about how far over the limit you were or why the limit was what it was. Add the operands to the message.

`b_t_map` packs the feature index `t` and batch index `b` into one 32-bit word. `T` is fixed at TBE init, so its bit width is known up front and the remainder goes to `B` (see D69387123). When `max_B` exceeds that remainder, this is the check that fires.

# Changes
- `codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp`
  - `TORCH_SYM_CHECK` for `max_B_ <= info_B_mask` now reports:
    - `max_B_` — the offending value
    - `info_B_mask` — the actual maximum allowed
    - `info_B_num_bits` — the bits left for `B`
    - `T` — the feature count the bit split was derived from
    - a `[VBE]` / `[const B]` prefix via `{{ "VBE" if vbe else "const B" }}`

Example rendered message:

```
[VBE] Not enough bits to accommodate B: max_B = 40000000 exceeds max allowed B = 33554431 (info_B_num_bits = 25, derived from T = 101 features)
```

# Notes
- `TORCH_SYM_CHECK(cond, ...)` is variadic and forwards to `TORCH_CHECK` (`c10/core/SymBool.h:101`), so no `c10::str` wrapping is needed.
- `max_B_` and `T` are both `c10::SymInt`, which has an `operator<<` (`c10/core/SymInt.h:503`). Both are already streamed in the Kineto annotation a few lines above, so this adds no new requirement.
- `T` is labelled "features", not tables: it is `len(feature_table_map)` (`split_table_batched_embeddings_ops_training.py:951`), which is `>=` the table count when tables are shared across features.

Reviewed By: q10

Differential Revision: D117470122


