### PR TITLE
Mark GenerateEmbeddingSpMDM* is_bf16 params [[maybe_unused]]; use to_float/from_float in QuantUtils

### DIFF
--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -80,8 +80,8 @@ GenerateEmbeddingSpMDM(
     int prefetch = 16,
     bool is_weight_positional = false,
     bool use_offsets = true,
-    bool is_bf16_out = false,
-    bool is_bf16_in = false);
+    [[maybe_unused]] bool is_bf16_out = false,
+    [[maybe_unused]] bool is_bf16_in = false);
 
 /**
  * @param output_stride If -1, output_stride is same as block_size.
@@ -113,8 +113,8 @@ GenerateEmbeddingSpMDMWithStrides(
     std::int64_t input_stride = -1,
     bool scale_bias_last = true,
     bool no_bag = false,
-    bool is_bf16_out = false,
-    bool is_bf16_in = false);
+    [[maybe_unused]] bool is_bf16_out = false,
+    [[maybe_unused]] bool is_bf16_in = false);
 
 /**
  * @tparam IndexType can be int32_t or int64_t
@@ -174,7 +174,7 @@ GenerateEmbeddingSpMDMNBitWithStrides(
     std::int64_t output_stride = -1,
     std::int64_t input_stride = -1,
     bool scale_bias_last = true,
-    const bool is_bf16_out = false,
+    [[maybe_unused]] const bool is_bf16_out = false,
     const bool no_bag = false,
     int output_bit_rate = -1);
 
@@ -205,7 +205,7 @@ GenerateEmbeddingSpMDMFP8WithStrides(
     std::int64_t input_stride = -1,
     int exponent_bits = 4,
     int exponent_bias = 7,
-    bool is_bf16_out = false);
+    [[maybe_unused]] bool is_bf16_out = false);
 
 template <
     typename InType,

--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -565,7 +565,7 @@ void FloatOrHalfToFusedNBitRowwiseQuantizedSBHalfRef(
       if constexpr (std::is_same_v<InputType, float>) {
         input_row_float[col] = input_row[col];
       } else {
-        input_row_float[col] = cpu_half2float(input_row[col]);
+        input_row_float[col] = to_float(input_row[col]);
       }
     }
 
@@ -574,12 +574,12 @@ void FloatOrHalfToFusedNBitRowwiseQuantizedSBHalfRef(
     // Truncate since bias will be represented by fp16. Keep higher precision
     // max untouched.
     float16 minimum_element_fp16 = cpu_float2half_rn(minimum_element);
-    minimum_element = cpu_half2float(minimum_element_fp16);
+    minimum_element = to_float(minimum_element_fp16);
     const float range = maximum_element - minimum_element;
 
     float scale = range == 0 ? 1.0f : range / ((1 << bit_rate) - 1);
     float16 scale_fp16 = cpu_float2half_rn(scale);
-    scale = cpu_half2float(scale_fp16);
+    scale = to_float(scale_fp16);
     if (scale == 0) {
       // Corner case handling when maximum_element == minimum_element
       // Any scale would work because X - minimum_element will be 0 for all X
@@ -699,7 +699,7 @@ void FloatOrHalfToFused8BitRowwiseQuantizedSBFloatRef(
       if constexpr (std::is_same_v<InputType, float>) {
         input_row_float[col] = input_row[col];
       } else {
-        input_row_float[col] = cpu_half2float(input_row[col]);
+        input_row_float[col] = to_float(input_row[col]);
       }
     }
 
@@ -765,8 +765,8 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef(
         (scale_bias_last
              ? (output_columns + num_elem_per_byte - 1) / num_elem_per_byte
              : 0));
-    float scale = cpu_half2float(input_row_scale_bias[0]);
-    float bias = cpu_half2float(input_row_scale_bias[1]);
+    float scale = to_float(input_row_scale_bias[0]);
+    float bias = to_float(input_row_scale_bias[1]);
     const std::uint8_t* nums =
         (scale_bias_last) ? input_row : input_row + 2 * sizeof(float16);
     OutputType* output_row = output + row * output_columns;
@@ -780,7 +780,7 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef(
       if constexpr (std::is_same_v<OutputType, float>) {
         output_row[col] = output_value;
       } else if constexpr (std::is_same_v<OutputType, bfloat16>) {
-        output_row[col] = cpu_float2bfloat16(output_value);
+        output_row[col] = from_float<OutputType>(output_value);
       } else {
         output_row[col] = cpu_float2half_rn(output_value);
       }
@@ -883,7 +883,7 @@ void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfRef(
       if constexpr (std::is_same_v<OutputType, float>) {
         output_row[col] = output_value;
       } else if constexpr (std::is_same_v<OutputType, bfloat16>) {
-        output_row[col] = cpu_float2bfloat16(output_value);
+        output_row[col] = from_float<OutputType>(output_value);
       } else {
         output_row[col] = cpu_float2half_rn(output_value);
       }


### PR DESCRIPTION
Prerequisite for #6194 ("Use distinct float16 and bfloat16 CPU template types").

## Summary

This PR originally also added a `FbgemmHalfType` concept and generic `to_float<T>`/`from_float<T>` helpers, but that part has since landed on `main` via #6049 ("Make float16/bfloat16 distinct types"), so it's been dropped from this branch as redundant. It now contains two small, independent, backward-compatible pieces:

- `include/fbgemm/FbgemmEmbedding.h`: mark the `is_bf16_out`/`is_bf16_in` parameters on `GenerateEmbeddingSpMDM*` as `[[maybe_unused]]`, in preparation for callers moving to compile-time dispatch on the distinct types instead of these runtime flags. No signature change.
- `src/QuantUtils.cc`: use the `to_float`/`from_float<T>` helpers (from #6049) instead of the equivalent direct `cpu_half2float`/`cpu_bf162float`/`cpu_float2bfloat16` calls in `FloatOrHalfToFusedNBitRowwiseQuantizedSBHalfRef`, `FloatOrHalfToFused8BitRowwiseQuantizedSBFloatRef`, `FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef`, and `Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfRef`. Purely a call-site rename to the same underlying function in each case — no behavior change. The `float16` quantize (write) branches intentionally keep the explicit `cpu_float2half_rn` call rather than `from_float<float16>` (which resolves to the hardware-accelerated `cpu_float2half` when available) to avoid changing rounding behavior, and the `cpu_half2float_ref` call in the Ref-suffixed `Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfRef` scale/bias read is left untouched since it's deliberately the portable, non-hardware-accelerated reference path.

#6194 currently carries the first of these two pieces on its branch and will rebase to drop it once this lands.

## Test plan

- [x] Verified existing (pre-#6194) `src/EmbeddingSpMDM.cc`, `EmbeddingSpMDMAutovec.cc`, `EmbeddingSpMDMNBit.cc` still compile unchanged against these headers (`clang++ -fsyntax-only`) — confirms this is non-breaking for current callers.
- [x] `src/QuantUtils.cc` compiles clean with `clang++ -fsyntax-only`.
- [ ] CI green