### PR TITLE
Use fbgemm::bfloat16 in QuantUtils dequant helpers

### DIFF
--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -80,8 +80,8 @@ GenerateEmbeddingSpMDM(
     int prefetch = 16,
     bool is_weight_positional = false,
     bool use_offsets = true,
-    bool is_bf16_out = false,
-    bool is_bf16_in = false);
+    [[maybe_unused]] bool is_bf16_out = false,
+    [[maybe_unused]] bool is_bf16_in = false);
 
 /**
  * @param output_stride If -1, output_stride is same as block_size
@@ -113,8 +113,8 @@ GenerateEmbeddingSpMDMWithStrides(
     std::int64_t input_stride = -1,
     bool scale_bias_last = true,
     bool no_bag = false,
-    bool is_bf16_out = false,
-    bool is_bf16_in = false);
+    [[maybe_unused]] bool is_bf16_out = false,
+    [[maybe_unused]] bool is_bf16_in = false);
 
 /**
  * @tparam IndexType can be int32_t or int64_t
@@ -169,7 +169,7 @@ GenerateEmbeddingSpMDMNBitWithStrides(
     std::int64_t output_stride = -1,
     std::int64_t input_stride = -1,
     bool scale_bias_last = true,
-    const bool is_bf16_out = false,
+    [[maybe_unused]] const bool is_bf16_out = false,
     const bool no_bag = false,
     int output_bit_rate = -1);
 
@@ -200,7 +200,7 @@ GenerateEmbeddingSpMDMFP8WithStrides(
     std::int64_t input_stride = -1,
     int exponent_bits = 4,
     int exponent_bias = 7,
-    bool is_bf16_out = false);
+    [[maybe_unused]] bool is_bf16_out = false);
 
 template <
     typename InType,

--- a/include/fbgemm/FloatConversion.h
+++ b/include/fbgemm/FloatConversion.h
@@ -314,4 +314,18 @@ inline bfloat16 cpu_float2bfloat16(float src) {
   return {static_cast<uint16_t>((temp + (1u << 15)) >> 16)};
 }
 
+template <typename T>
+inline float to_float(T src) {
+  if constexpr (std::is_same_v<T, bfloat16>) return cpu_bf162float(src);
+  else if constexpr (std::is_same_v<T, float16>) return cpu_half2float(src);
+  else return static_cast<float>(src);
+}
+
+template <typename T>
+inline T from_float(float f) {
+  if constexpr (std::is_same_v<T, bfloat16>) return cpu_float2bfloat16(f);
+  else if constexpr (std::is_same_v<T, float16>) return cpu_float2half_rn(f);
+  else return static_cast<T>(f);
+}
+
 } // namespace fbgemm

--- a/include/fbgemm/Types.h
+++ b/include/fbgemm/Types.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <cstdint>
 #include <type_traits>
 
@@ -34,6 +35,10 @@ static_assert(alignof(float16) == alignof(uint16_t));
 static_assert(std::is_standard_layout_v<bfloat16>);
 static_assert(std::is_trivially_copyable_v<bfloat16>);
 static_assert(alignof(bfloat16) == alignof(uint16_t));
+
+// Half-precision float concept
+template <typename T>
+concept FbgemmHalfType = std::same_as<T, float16> || std::same_as<T, bfloat16>;
 
 constexpr int64_t round_up(int64_t val, int64_t unit) {
   return (val + unit - 1) / unit * unit;

--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -749,9 +749,8 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef(
     OutputType* output,
     bool scale_bias_last) {
   static_assert(
-      std::is_same_v<OutputType, float> ||
-          std::is_same_v<OutputType, float16> ||
-          std::is_same_v<OutputType, bfloat16>,
+      std::is_same_v<OutputType, float> || std::is_same_v<OutputType, float16>
+          || std::is_same_v<OutputType, bfloat16>,
       "Only float, float16 or bfloat16 types are allowed.");
   int num_elem_per_byte = 8 / bit_rate;
   const int64_t output_columns =
@@ -796,11 +795,6 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf(
     int input_columns,
     OutputType* output,
     bool scale_bias_last [[maybe_unused]]) {
-  auto ref_fallback = [&]() {
-    FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef<OutputType>(
-        bit_rate, input, input_rows, input_columns, output);
-  };
-
 #if HAVE_SVE
   switch (bit_rate) {
     case 2:
@@ -816,9 +810,11 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf(
           input, input_rows, input_columns, output);
       break;
     default:
-      ref_fallback();
+      FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef<OutputType>(
+          bit_rate, input, input_rows, input_columns, output);
   }
 #else
+
   if (cpuinfo_initialize() && fbgemmHasAvx2Support()) {
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
     switch (bit_rate) {
@@ -835,12 +831,14 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf(
             input, input_rows, input_columns, output);
         break;
       default:
-        ref_fallback();
+        FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef<OutputType>(
+            bit_rate, input, input_rows, input_columns, output);
     }
-    return;
 #endif
+  } else {
+    FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef<OutputType>(
+        bit_rate, input, input_rows, input_columns, output);
   }
-  ref_fallback();
 #endif
 }
 

--- a/test/TestUtils.cc
+++ b/test/TestUtils.cc
@@ -145,7 +145,7 @@ template <>
     const float atol,
     const float rtol) {
   std::vector<float> b_float(b.size());
-  const auto transform = [](float16 input) { return cpu_half2float(input); };
+  const auto transform = [](float16 input) { return to_float(input); };
   std::ranges::transform(b, b_float.begin(), transform);
   return floatCloseAll(a, b_float, atol, rtol);
 }
@@ -158,7 +158,7 @@ template <>
     const float rtol) {
   std::vector<float> a_float(a.size());
   std::vector<float> b_float(b.size());
-  const auto transform = [](float16 input) { return cpu_half2float(input); };
+  const auto transform = [](float16 input) { return to_float(input); };
   std::ranges::transform(a, a_float.begin(), transform);
   std::ranges::transform(b, b_float.begin(), transform);
   return floatCloseAll(a_float, b_float, atol, rtol);


### PR DESCRIPTION
Stacked on #6237 — only the last commit ("Use fbgemm::bfloat16 in QuantUtils dequant helpers") is new here; the rest of the diff is #6237, included because this branch is built on top of it and hasn't merged yet. Compare just the new commit: https://github.com/cyyever/FBGEMM/compare/add-float16-bfloat16-type-helpers...bf16-quant-utils

## Summary

Split out of #6194 ("Make float16/bfloat16 distinct types, eliminate is_bf16 runtime flags"). Switches `QuantUtils.cc`'s 8-bit and N-bit rowwise dequantization paths from a formatting-agnostic `uint16_t` buffer to the distinct `fbgemm::bfloat16` type where the output is bf16, matching how the float16 case is already handled. Also de-duplicates a repeated ref-fallback call into a single lambda.

This file is independent of the embedding SpMDM kernel work in #6194: `QuantUtils.cc` has no calls into `RefImplementations.h`'s `convert_to_float_ref`/`is_16bit_storage_v` helpers (unlike the SpMDM kernel files), and nothing in the SpMDM kernel files calls into `QuantUtils.cc`. Verified the existing (pre-#6194) `EmbeddingSpMDM.cc`/`EmbeddingSpMDMAutovec.cc`/`EmbeddingSpMDMNBit.cc`/`EmbeddingSpMDMAvx2.cc`/`RefImplementations.cc` still compile unchanged against this file.

#6194 will rebase to drop this diff once this (and #6237) land.

## Test plan

- [x] Verified this file's changes compile standalone (`clang++ -fsyntax-only`) alongside the still-unmodified SpMDM kernel files and `RefImplementations.cc`, confirming no coupling.
- [ ] CI green