### PR TITLE
Add three warnings for unused variables (#6240)

### DIFF
--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -118,7 +118,18 @@ function(fbgemm_get_warning_flags)
     # than -Wshorten-64-to-32, because it is diffuse: only 19% sit in the top
     # five files, versus 79% for -Wshadow. Rank by file count and
     # concentration, not by raw count.
-    -Wzero-as-null-pointer-constant)
+    -Wzero-as-null-pointer-constant
+    # ---- Parity gap G1: unused-family flags fbcode enables globally ---------
+    # Probed accepted on g++ 11.5 AND clang 22, so portable.
+    # -Wunused-variable and -Wunused-but-set-variable are already [enabled] by
+    # -Wall/-Wextra (verified with `g++ -Wall -Wextra -Q --help=warning`), so
+    # naming them explicitly is parity, not a behaviour change. It also makes
+    # the pre-existing -Wno-error=unused-but-set-variable escapes meaningful:
+    # an escape without its positive flag is inert.
+    # -Wunused-const-variable IS a real addition (gcc maps it to level =2).
+    -Wunused-variable
+    -Wunused-const-variable
+    -Wunused-but-set-variable)
 
   # Clang-only warning flags. These are appended to `_cc` ONLY when the host
   # compiler is clang (see the guarded append below), because the OSS CI matrix

--- a/cmake/modules/GpuCppLibrary.cmake
+++ b/cmake/modules/GpuCppLibrary.cmake
@@ -168,6 +168,7 @@ function(gpu_cpp_library)
         CC_FLAGS            # General compilation flags applicable to all build variants
         NVCC_FLAGS          # Compilation flags specific to NVCC
         HIPCC_FLAGS         # Compilation flags specific to HIPCC
+        EXCLUDED_WARNING_FLAGS # Shared warning flags not applied to this target
         INCLUDE_DIRS        # First-party include directories for compilation
         SYSTEM_INCLUDE_DIRS # Third-party include directories, passed as SYSTEM to suppress their warnings
         DEPS                # Target dependencies, i.e. built STATIC targets
@@ -240,6 +241,12 @@ function(gpu_cpp_library)
         HIPCC_FLAGS_VAR _hipcc_warning_flags
         EXTRA_MSVC_FLAGS ${args_MSVC_FLAGS}
         EXTRA_CC_FLAGS   ${args_CC_FLAGS})
+
+    foreach(_flag IN LISTS args_EXCLUDED_WARNING_FLAGS)
+        list(REMOVE_ITEM _cc_flags "${_flag}")
+        list(REMOVE_ITEM _nvcc_warning_flags "-Xcompiler=${_flag}")
+        list(REMOVE_ITEM _hipcc_warning_flags "${_flag}")
+    endforeach()
 
     if(MSVC)
         set(lib_cc_flags ${_msvc_flags})

--- a/fbgemm_gpu/cmake/Asmjit.cmake
+++ b/fbgemm_gpu/cmake/Asmjit.cmake
@@ -27,5 +27,8 @@ gpu_cpp_library(
     ${fbgemm_thirdparty_include_directories}
   OTHER_SRCS
     ${asmjit_sources}
+  # asmjit is third-party code, so do not apply this warning to its sources.
+  EXCLUDED_WARNING_FLAGS
+    -Wunused-const-variable
   DESTINATION
     fbgemm_gpu)

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.h
@@ -13,10 +13,11 @@
 // These values are adjusted in backward based on B and T
 constexpr int DEFAULT_INFO_NUM_BITS = 32;
 constexpr int DEFAULT_INFO_B_NUM_BITS = 26;
-constexpr uint32_t DEFAULT_INFO_B_MASK = (1u << DEFAULT_INFO_B_NUM_BITS) - 1;
-constexpr uint32_t MAX_T =
+[[maybe_unused]] constexpr uint32_t DEFAULT_INFO_B_MASK =
+    (1u << DEFAULT_INFO_B_NUM_BITS) - 1;
+[[maybe_unused]] constexpr uint32_t MAX_T =
     (1u << (DEFAULT_INFO_NUM_BITS - DEFAULT_INFO_B_NUM_BITS)) - 1;
-constexpr uint32_t MAX_B = (1u << DEFAULT_INFO_B_NUM_BITS) - 1;
+[[maybe_unused]] constexpr uint32_t MAX_B = (1u << DEFAULT_INFO_B_NUM_BITS) - 1;
 
 std::tuple<int64_t, int64_t>
 get_infos_metadata(at::Tensor unused, int64_t B, int64_t T);

--- a/include/fbgemm/QuantUtilsAvx2.h
+++ b/include/fbgemm/QuantUtilsAvx2.h
@@ -19,7 +19,7 @@ namespace fbgemm {
 
 /// Number of columns in the rowwise min/max buffer passed to the quantization
 /// function(s)
-constexpr int kRowwiseMinMaxNumCols = 2;
+[[maybe_unused]] constexpr int kRowwiseMinMaxNumCols = 2;
 
 /// Struct from <a href="https://github.com/google/gemmlowp">`gemmlowp`</a>
 ///

--- a/src/EmbeddingSpMDMPrefetch.h
+++ b/src/EmbeddingSpMDMPrefetch.h
@@ -20,7 +20,7 @@ namespace fbgemm {
 // Tuning constants (Neoverse-V2 / CG1).
 constexpr int64_t CACHE_LINE_SIZE = 64;
 constexpr int64_t DEFAULT_L1_PREFETCH_DISTANCE = 16;
-constexpr int64_t MAX_TLB_PRIME_INDEX_SIZE = 256;
+[[maybe_unused]] constexpr int64_t MAX_TLB_PRIME_INDEX_SIZE = 256;
 constexpr int64_t DEFAULT_L2_LARGE_TABLE_MB = 64;
 
 // Enable the farther L2 tier only when its per-row overhead can pay off: the

--- a/src/MaskAvx2.h
+++ b/src/MaskAvx2.h
@@ -14,7 +14,7 @@ namespace fbgemm::internal {
 // A constant array to initialize an AVX2 register to be used as a 32-bit
 // granularity mask.
 // clang-format off
-alignas(64) static constexpr int avx2_ps_or_epi32_masks[9][8] = {
+[[maybe_unused]] alignas(64) static constexpr int avx2_ps_or_epi32_masks[9][8] = {
   // NOTE: clang-format wants to use a different formatting but the current
   // formatting should be easier to read.
   {  0,  0,  0,  0,  0,  0,  0,  0,  },
@@ -29,13 +29,13 @@ alignas(64) static constexpr int avx2_ps_or_epi32_masks[9][8] = {
 };
 
 // mask can be accessed by avx2_ps_or_epi32_combined_mask[(8 - remainder) % 8]
-static constexpr int avx2_ps_or_epi32_combined_mask[16] = {
+[[maybe_unused]] static constexpr int avx2_ps_or_epi32_combined_mask[16] = {
   -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 
 // A constant array to initialize an SSE register to be used as a 8-bit
 // granularity mask.
-alignas(64) static constexpr std::int8_t sse_epi8_masks[17][16] = {
+[[maybe_unused]] alignas(64) static constexpr std::int8_t sse_epi8_masks[17][16] = {
   {  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, },
   { -1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, },
   { -1, -1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, },


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3131


NOTE: No linked task. Please associate a task with this diff.

Adds `-Wunused-variable`, `-Wunused-const-variable`, and `-Wunused-but-set-variable` to the portable OSS warning list. The first and third are already implied by `-Wall`/`-Wextra`; explicitly naming them also makes the existing `-Wno-error=unused-but-set-variable` escapes effective. `-Wunused-const-variable` adds GCC coverage.

Marks configuration- and architecture-dependent header constants and mask tables `[[maybe_unused]]` when some GCC translation units intentionally omit them. This includes `avx2_ps_or_epi32_combined_mask`, which is unused in ARM CPU builds but used by x86 vectorized paths. The existing asmjit target exclusion remains because asmjit is third-party code.

Reviewed By: cthi

Differential Revision: D117103728


