### PR TITLE
example_counter pruning state on rowwise_adagrad_with_counter — backend/codegen (D1)

### DIFF
--- a/fbgemm_gpu/codegen/genscript/optimizers.py
+++ b/fbgemm_gpu/codegen/genscript/optimizers.py
@@ -507,6 +507,22 @@ def rowwise_adagrad_with_counter() -> dict[str, Any]:
             row_counter[idx] += 1.0;
         }
         freq = counter_halflife / row_counter[idx];
+
+        // example_counter: opt-in per-sample pruning side state. Decayed
+        // independently by example_counter_halflife; segment_length = number of
+        // samples touching this row in the current batch. Gated so the counter
+        // weight update is unchanged when the pruning counter is not in use.
+        if (use_example_counter) {
+            const auto ec_iter_delta = prev_iter[idx] == 0 ? 1.0 : iter * 1.0 - prev_iter[idx];
+            if (example_counter_halflife > 0) {
+                example_counter[idx] = segment_length +
+                    expf(-ec_iter_delta * logf(2.0) / example_counter_halflife) * example_counter[idx];
+            } else if (example_counter_halflife == 0) {
+                example_counter[idx] = segment_length;
+            } else { // raw cumulative (recency decay applied at publish)
+                example_counter[idx] += segment_length;
+            }
+        }
     }
     freq = SHFL_SYNC(freq, 0);
     tail_id_threshold_val = SHFL_SYNC(tail_id_threshold_val, 0);
@@ -628,6 +644,12 @@ def rowwise_adagrad_with_counter() -> dict[str, Any]:
         }
         freq = counter_halflife / row_counter[idx];
 
+        // NOTE: example_counter (the opt-in per-sample pruning side state) is
+        // tracked on the GPU path only (see split_precomputation). The CPU exact
+        // backward kernel does not materialize a pointer for optional optimizer
+        // state tensors, and the pruning use case (AFOC/CMF) is GPU-only, so the
+        // CPU path intentionally leaves example_counter unchanged.
+
         at::acc_type<grad_t, true> g_sum_square = 0.0;
         at::acc_type<grad_t, true> w_sum_square = 0.0;
         for (int64_t d = 0; d < D; ++d) {
@@ -728,6 +750,13 @@ def rowwise_adagrad_with_counter() -> dict[str, Any]:
                 OptimItem(ArgType.INT, "regularization_mode", 0),
                 OptimItem(ArgType.FLOAT, "weight_norm_coefficient", 0.0),
                 OptimItem(ArgType.FLOAT, "lower_bound", 0.0),
+                # Opt-in per-sample pruning side state (post-training embedding-
+                # row pruning). These flow only into the V2/PT2 interface; the
+                # V1 schema below is deliberately frozen (unchanged arg count),
+                # so example_counter is unreachable from the V1 lookup path.
+                OptimItem(ArgType.BOOL, "use_example_counter", False),
+                OptimItem(ArgType.INT, "example_counter_halflife", -1),
+                OptimItem(ArgType.TENSOR, "example_counter", is_optional=True),
             ],
             {
                 "v1": "Tensor momentum1, Tensor prev_iter, Tensor row_counter, float eps = 0, float learning_rate = 0, float weight_decay = 0.0, int iter = 0, int counter_halflife = -1, int adjustment_iter = -1, float adjustment_ub = 1.0, int learning_rate_mode = -1, int weight_decay_mode = 1, int grad_sum_decay = -1, float max_counter = 0, float tail_id_threshold = 0.0, int is_tail_id_thresh_ratio = 0, int regularization_mode = 0, float weight_norm_coefficient = 0.0, float lower_bound = 0.0"

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_cpu_template.cpp
@@ -437,6 +437,17 @@ for (const auto d : c10::irange(D)) {
     {{ args.split_function_args | join(", ") }}
     {% endif %}
 ) {
+  {%- if "use_example_counter" in args.split_function_arg_names %}
+  // example_counter (the opt-in per-sample pruning side state) is updated on
+  // the GPU path only; the CPU backward kernel leaves it unchanged. Warn once
+  // so a model that enables it on CPU knows the counter stays zero rather than
+  // silently getting no signal.
+  if (use_example_counter) {
+    TORCH_WARN_ONCE(
+        "use_example_counter=true has no effect on the CPU backward path; "
+        "example_counter is maintained on GPU only and will remain zero on CPU.");
+  }
+  {%- endif %}
   {% if not nobag %}
   int64_t T = D_offsets.numel() - 1;
   const auto D_offsets_data = D_offsets.accessor<int, 1>();
@@ -586,13 +597,13 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
     "Tensor indice_weights, "
     {%- endif %}
     "bool stochastic_rounding, "
-    "{{ (args.split_function_args | join(", ")).replace("double", "float").replace("int64_t", "int").replace("Tensor momentum1_host", "Tensor(b!) momentum1_host")}}"
+    "{{ (args.split_function_args | join(", ")).replace("double", "float").replace("int64_t", "int").replace("Tensor momentum1_host", "Tensor(b!) momentum1_host").replace("= false", "= False").replace("= true", "= True")}}"
     {%- if not nobag %}
     ", int output_dtype = 0"
     {%- endif %}
     ") -> ()");
   {% else %}
-  m.def("split_embedding_backward_codegen_{{ optimizer }}_cpu(Tensor grad_output, Tensor(a!) host_weights, Tensor weights_offsets, Tensor D_offsets, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets,int pooling_mode, Tensor indice_weights, {{ (args.split_function_args | join(", ")).replace("double", "float").replace("int64_t", "int").replace("Tensor momentum1_host", "Tensor(b!) momentum1_host")}}) -> Tensor");
+  m.def("split_embedding_backward_codegen_{{ optimizer }}_cpu(Tensor grad_output, Tensor(a!) host_weights, Tensor weights_offsets, Tensor D_offsets, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets,int pooling_mode, Tensor indice_weights, {{ (args.split_function_args | join(", ")).replace("double", "float").replace("int64_t", "int").replace("Tensor momentum1_host", "Tensor(b!) momentum1_host").replace("= false", "= False").replace("= true", "= True")}}) -> Tensor");
   {% endif %}
   DISPATCH_TO_CPU("split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_cpu", split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_cpu);
 

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
@@ -227,6 +227,18 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(
   // The unified PT2 interface already accepts learning rate as tensor.
   const auto learning_rate_tensor = at::tensor({learning_rate}, at::TensorOptions().dtype(at::kFloat).device(at::kCPU));
   {%- endif %}
+  {%- if "use_example_counter" in args.split_function_arg_names_autograd %}
+  // `example_counter` is a V2/PT2-only pruning side state. The V1 interface is
+  // frozen (its schema does not carry example_counter or its knobs), so
+  // synthesize inert defaults here to feed the shared backend call. The counter
+  // kernel's example_counter path is gated off by `use_example_counter == false`,
+  // so V1 behavior is unchanged. (Mirrors the learning_rate_tensor shim above.)
+  const bool use_example_counter = false;
+  const int64_t example_counter_halflife = -1;
+  const std::optional<Tensor> example_counter_host = std::nullopt;
+  const std::optional<Tensor> example_counter_placements = std::nullopt;
+  const std::optional<Tensor> example_counter_offsets = std::nullopt;
+  {%- endif %}
   return SplitLookupFunction_{{ optimizer }}_Op::apply(
       host_weights,
       weights_placements,

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -1147,6 +1147,21 @@ Tensor {{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function(
     learning_rate_tensor.fill_(learning_rate);
     {%- endif %}
 
+    {%- if "use_example_counter" in args.split_function_arg_names %}
+    // `example_counter` is a V2/PT2-only pruning side state (post-training
+    // embedding-row pruning). The V1 interface is frozen -- its schema does not
+    // carry example_counter or its knobs -- so synthesize inert defaults here to
+    // feed the shared backend call. The counter kernel's example_counter path is
+    // gated off by `use_example_counter == false`, so V1 behavior is unchanged.
+    // (Mirrors the learning_rate_tensor backward-compat shim above.)
+    const bool use_example_counter = false;
+    const int64_t example_counter_halflife = -1;
+    const std::optional<Tensor> example_counter_dev = std::nullopt;
+    const std::optional<Tensor> example_counter_uvm = std::nullopt;
+    const std::optional<Tensor> example_counter_placements = std::nullopt;
+    const std::optional<Tensor> example_counter_offsets = std::nullopt;
+    {%- endif %}
+
     {%- if not dense %}
     // Load the config value from JK once
     static auto is_tbev2_enabled = config::is_feature_enabled(config::FeatureGateName::TBE_V2);

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
@@ -389,6 +389,15 @@ batch_index_select_dim0_codegen_backward_kernel_cta_per_row(
               {%- endif %}
               shfl_sync_mask,
               max_vecs,
+              {%- if optimizer == "rowwise_adagrad_with_counter" %}
+              // segment_length = full run_length (# samples touching this row in
+              // this batch). The weight/state update runs EXACTLY ONCE per run
+              // (the sole CTA for a normal run, or the last CTA via
+              // grad_accum_counter for a CTA-split run — see the guard above), so
+              // pass run_length unconditionally: there is no double-count to avoid,
+              // and split runs (large rows) are no longer missed.
+              run_length,
+              {%- endif %}
               {%- if ssd %}
               enable_optimizer_offloading,
               {%- endif %}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -307,6 +307,9 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row(
               {%- endif %}
               shfl_sync_mask,
               max_vecs,
+              {%- if optimizer == "rowwise_adagrad_with_counter" %}
+              SL, // segment_length: #samples in this batch touching this row
+              {%- endif %}
               {%- if ssd %}
               enable_optimizer_offloading,
               {%- endif %}

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_device_kernel_template.cuh
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_device_kernel_template.cuh
@@ -98,6 +98,11 @@ DEVICE_INLINE void {{ mdesc }}_{{ optimizer }}_table_update_kernel(
     {%- endif %}
     const uint32_t shfl_sync_mask,
     const int32_t max_vecs_per_thread,
+    {%- if optimizer == "rowwise_adagrad_with_counter" %}
+    // Number of samples in the current batch that touched this row. Used to
+    // maintain the decayed per-sample `example_counter` pruning side state.
+    const float segment_length,
+    {%- endif %}
     {%- if ssd %}
     const bool enable_optimizer_offloading [[maybe_unused]],
     {%- endif %}
@@ -142,6 +147,22 @@ DEVICE_INLINE void {{ mdesc }}_{{ optimizer }}_table_update_kernel(
         {{ tensor }} = &{{ tensor }}_uvm[{{ tensor }}_offset];
     }
     {%- endfor %}
+    {%- if optimizer == "rowwise_adagrad_with_counter" %}
+    // example_counter is an opt-in optional pruning state (not in split_tensors,
+    // so it is not set up by the loop above). Its accessors are empty tensors
+    // when the feature is off, so only build the pointer when use_example_counter
+    // is set; split_precomputation guards every dereference on the same flag.
+    at::acc_type<cache_t, true>* __restrict__ example_counter = nullptr;
+    if (use_example_counter) {
+        const auto example_counter_placement = static_cast<PlacementType>(example_counter_placements[t]);
+        const int64_t example_counter_offset = example_counter_offsets[t];
+        if (example_counter_placement == PlacementType::DEVICE) {
+            example_counter = &example_counter_dev[example_counter_offset];
+        } else {
+            example_counter = &example_counter_uvm[example_counter_offset];
+        }
+    }
+    {%- endif %}
 
     auto weight_row_template =
         WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
@@ -107,6 +107,18 @@ void split_{{ optimizer }}_update_kernel(
           {%- endif %}
           shfl_sync_mask,
           kMaxVecsPerThread,
+          {%- if optimizer == "rowwise_adagrad_with_counter" %}
+          // NOTE: this standalone-optimizer branch is currently DEAD for the
+          // counter optimizer. rowwise_adagrad_with_counter is not in
+          // DEFUSED_OPTIMIZERS (codegen/BUCK, cmake/tbe_sources.py), so no
+          // standalone `split_embedding_rowwise_adagrad_with_counter_update` op
+          // is generated and use_example_counter is unreachable on this path.
+          // If this optimizer is ever defused, note that segment_length=0 does
+          // NOT make the example_counter update inert for
+          // example_counter_halflife >= 0 (the update still decays/zeroes the
+          // counter, see split_precomputation); a real skip would be required.
+          0, // segment_length (unreachable placeholder; see note above)
+          {%- endif %}
           {{ args.split_kernel_arg_names | join(", ") }});
 #ifdef USE_ROCM
     } // for run_id (grid-stride loop, ROCm only)


### PR DESCRIPTION
Summary:
Backend (C++/CUDA codegen) half of the example_counter pruning-state work,
rebased onto the landed D113869217 (TBE backward-arg TensorList packing).

Adds the optional per-sample `example_counter` state to the existing
`rowwise_adagrad_with_counter` optimizer at the C++/codegen layer (no new
optimizer, no new WeightDecayMode):
- optimizers.py: example_counter (is_optional) + use_example_counter +
  example_counter_halflife on the op; gated example_counter update in the GPU
  precomputation (segment_length passed as float, no static_cast); V1 schema
  string frozen.
- kernel templates (cta / warp / device / standalone): segment_length threading
  (float) + guarded example_counter pointer setup (nullptr when off). The CTA
  long-run path passes run_length unconditionally — the weight/state update runs
  exactly once per run (sole CTA, or last CTA via grad_accum_counter), so there
  is no double-count and split runs are not missed.
- host templates (gpu + cpu): synthesize inert example_counter defaults on the
  frozen V1 path (mirrors the learning_rate_tensor V1 shim); both shims key on
  the same use_example_counter sentinel.
- CPU backward template: emit torch-schema bool casing (False/True) in the
  generated m.def; TORCH_WARN_ONCE when use_example_counter is set on CPU
  (example_counter is maintained on GPU only).
- MTIA (fbgemm_mtia_ops.cpp): the 4 hand-written
  rowwise_adagrad_with_counter *_pt2_mtia_wrapper registrations mirror this op's
  flat PT2 schema, so they are extended to accept (and ignore) the 7 new
  example_counter args, matching the generated 59-arg schema. example_counter is
  GPU-only pruning state; MTIA does not maintain it. Without this, the op fails
  registration (59 vs 52) in every binary linking torch_mtia. Mirrors how
  D113869217 synced this same file for the packing.

The Python-generating templates (lookup_args / invoker) and all runtime Python
live in the stacked frontend diff D114133366. Existing optimizers are
byte-unchanged; the counter path is byte-identical when use_example_counter is
unset.

Reviewed By: gchalump, q10, spcyppt, trirpi

Differential Revision: D112412933


