### PR TITLE
Relocate permute_multi_embedding index tensors instead of failing

### DIFF
--- a/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
@@ -239,16 +239,44 @@ std::vector<Tensor> permute_multi_embedding_function_gpu(
   // it should be enforced from the caller side who has the knowledge.
   TORCH_CHECK(!pooled_embs.empty());
   CUDA_DEVICE_GUARD(pooled_embs[0]);
-  TENSORS_ON_SAME_DEVICE(permutes, pooled_embs[0]);
-  TENSORS_ON_SAME_DEVICE(permutes, in_shapes);
-  TENSORS_ON_SAME_DEVICE(permutes, out_shapes);
-  TORCH_CHECK(in_shapes.is_contiguous());
-  TORCH_CHECK(out_shapes.is_contiguous());
+  auto device = pooled_embs[0].device();
 
-  int32_t num_of_input_tensors = in_shapes.size(0);
+  // `permutes`, `in_shapes` and `out_shapes` are small constant index tensors
+  // describing how to slice `pooled_embs` -- together on the order of a few
+  // KiB, against pooled embeddings that are typically hundreds of MiB.
+  // Requiring the caller to place them on the same device is not always
+  // satisfiable: in a statically exported graph they are buffers, resolved to a
+  // device once when the weights are materialized, while `pooled_embs` follows
+  // whichever device the runtime executing the request happens to be on.
+  // Relocate them rather than failing. `in_ptr`/`out_ptr` below already do
+  // exactly this, and so does `kt_regroup_arguments_gpu` for these same three
+  // tensors.
+  const auto to_device = [&device](const Tensor& t, const char* name) {
+    if (t.device() == device) {
+      return t;
+    }
+    TORCH_WARN_ONCE(
+        "permute_multi_embedding: ",
+        name,
+        " is on ",
+        t.device(),
+        " but pooled_embs[0] is on ",
+        device,
+        "; relocating. Expected when the index buffers are pinned to a single "
+        "device and the op runs on several, unexpected otherwise.");
+    return t.to(device, /*non_blocking=*/true);
+  };
+  const auto permutes_dev = to_device(permutes, "permutes");
+  const auto in_shapes_dev = to_device(in_shapes, "in_shapes");
+  const auto out_shapes_dev = to_device(out_shapes, "out_shapes");
+
+  TORCH_CHECK(in_shapes_dev.is_contiguous());
+  TORCH_CHECK(out_shapes_dev.is_contiguous());
+
+  int32_t num_of_input_tensors = in_shapes_dev.size(0);
   int32_t num_of_output_tensors = out_lengths.size();
   int32_t batch_size = pooled_embs[0].size(0);
-  int32_t permute_size = permutes.size(0);
+  int32_t permute_size = permutes_dev.size(0);
 
   // check input tensors
   std::vector<Tensor> inputs;
@@ -268,7 +296,6 @@ std::vector<Tensor> permute_multi_embedding_function_gpu(
         at::empty({batch_size, lengths[i]}, pooled_embs[0].options());
     outputs.push_back(output);
   }
-  auto device = pooled_embs[0].device();
 
   // This kernel is moving one feature/key per warp.
   // We are launching ( permute_size//warp_per_block, batch_size, ?)
@@ -314,9 +341,9 @@ std::vector<Tensor> permute_multi_embedding_function_gpu(
             at::cuda::getCurrentCUDAStream(),
             reinterpret_cast<const scalar_t**>(in_ptr.data_ptr()),
             reinterpret_cast<scalar_t**>(out_ptr.mutable_data_ptr()),
-            PTA_B(permutes, int32_t, 2, 32),
-            PTA_B(in_shapes, int32_t, 1, 32),
-            PTA_B(out_shapes, int32_t, 1, 32),
+            PTA_B(permutes_dev, int32_t, 2, 32),
+            PTA_B(in_shapes_dev, int32_t, 1, 32),
+            PTA_B(out_shapes_dev, int32_t, 1, 32),
             batch_size,
             permute_size);
       });

--- a/fbgemm_gpu/test/permute/permute_multi_embedding_ops_test.py
+++ b/fbgemm_gpu/test/permute/permute_multi_embedding_ops_test.py
@@ -80,6 +80,55 @@ class PermuteMultiEmbeddingOpsTest(unittest.TestCase):
         torch.testing.assert_close(outputs[1], pooled_embs[1])
 
     @unittest.skipIf(*gpu_unavailable)
+    def test_permute_multi_embedding_index_tensors_on_other_device(self) -> None:
+        """The index tensors are relocated to pooled_embs[0]'s device instead of
+        being required to already match it.
+
+        A statically exported graph resolves these buffers to one device when
+        the weights are materialized, while pooled_embs follows whichever device
+        the executing runtime is on, so the two legitimately disagree. Uses CPU
+        index tensors so the relocation path is covered on a single-GPU host;
+        the cross-GPU case takes the identical branch.
+        """
+        device = torch.accelerator.current_accelerator()
+        batch_size = 4
+        in_lengths = [4, 8]
+        out_lengths = [4, 8]
+
+        # Deliberately left on CPU while pooled_embs are on the accelerator.
+        permutes = torch.tensor(
+            [
+                [0, 0, 0, 0, 4, -1],
+                [1, 1, 0, 0, 8, -1],
+            ],
+            dtype=PERMUTES_DTYPE,
+        )
+        in_shapes = torch.tensor(in_lengths, dtype=SHAPES_DTYPE)
+        out_shapes = torch.tensor(out_lengths, dtype=SHAPES_DTYPE)
+        self.assertEqual(permutes.device.type, "cpu")
+
+        pooled_embs = [
+            torch.arange(batch_size * length, dtype=torch.float32, device=device)
+            .view(batch_size, length)
+            .contiguous()
+            for length in in_lengths
+        ]
+
+        outputs = torch.ops.fbgemm.permute_multi_embedding(
+            pooled_embs,
+            permutes,
+            in_shapes,
+            out_shapes,
+            out_lengths,
+        )
+
+        self.assertEqual(len(outputs), 2)
+        torch.testing.assert_close(outputs[0], pooled_embs[0])
+        torch.testing.assert_close(outputs[1], pooled_embs[1])
+        # The caller's tensors are not mutated by the relocation.
+        self.assertEqual(permutes.device.type, "cpu")
+
+    @unittest.skipIf(*gpu_unavailable)
     @unittest.skipIf(*gpu_memory_lt_gb(4))
     def test_permute_multi_embedding_large_grid(self) -> None:
         """


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3130

`permute_multi_embedding_function_gpu` requires `permutes`, `in_shapes` and
`out_shapes` to already sit on `pooled_embs[0]`'s device:

```
TENSORS_ON_SAME_DEVICE(permutes, pooled_embs[0]);
TENSORS_ON_SAME_DEVICE(permutes, in_shapes);
TENSORS_ON_SAME_DEVICE(permutes, out_shapes);
```

A statically exported (Sigmoid / nativert) graph cannot always satisfy that.
Those three are graph **buffers**: their device is resolved once, when the
weights are materialized, against whatever card the loading thread was on.
`pooled_embs` is an **activation** produced by an all-to-one whose target device
is index-less `cuda`, so it follows whichever runtime is executing the request.
On a 4-card host the buffers sit on cuda:0 while `pooled_embs` arrives on
cuda:0..3, and roughly three quarters of requests abort:

```
arg0 pooled_embs: GenericList [c10::Half[377, 161628]cuda:1, ]
arg1 permutes:    Tensor int[395, 6]cuda:0
arg2 in_shapes:   Tensor int[1]cuda:0
arg3 out_shapes:  Tensor int[11]cuda:0
permutes must be on the same device as pooled_embs[0]!
```

Relocate rather than fail. The three tensors are small constant index tensors --
9,480 + 4 + 44 = 9,528 B here, about 0.008% of the 116 MiB of pooled embeddings
they describe, and ~1/12000th of what the preceding all-to-one already moves
across cards. The same function already relocates its own `in_ptr`/`out_ptr` a
few lines below, and `kt_regroup_arguments_gpu` does it for these very tensors,
so this makes the op internally consistent rather than introducing a new idiom.

Relaxing a check that used to be fatal can hide a real misplacement, so the
relocation path emits `TORCH_WARN_ONCE` naming both devices. A caller that was
already correct sees no warning and no copy -- the lambda returns the tensor
unchanged when the devices match.

`permute_multi_embedding` and `regroup_keyed_tensor` both route through this
function, so both are covered.

Not changed: the CPU implementation, which has no such check, and
`mtia/tools/experimental/Tritor/kernel_gen/docs/fbgemm/permute_multi_embedding.md`,
which documents the same-device requirement as a *wrapper* contract for MTIA
kernel generation and is unaffected by the CUDA implementation relaxing it.

Reviewed By: q10

Differential Revision: D117957553


