### PR TITLE
[import] fix oss import issue

### DIFF
--- a/cmake/modules/CudaSetup.cmake
+++ b/cmake/modules/CudaSetup.cmake
@@ -47,3 +47,30 @@ BLOCK_PRINT(
   ""
   "CUDA_DRIVER_LIBRARIES=${CUDA_DRIVER_LIBRARIES}"
 )
+
+# cuBLAS is called directly from src/sparse_ops/sparse_permute102.cu, but
+# ${TORCH_LIBRARIES} does not put a libcublas DT_NEEDED entry on our targets.
+# Consumers dlopen() our .SO files with RTLD_LOCAL, so the cuBLAS that PyTorch
+# preloads is not visible in our lookup scope either, and the symbols come out
+# undefined at import time.  Link it ourselves.
+set(CUDA_CUBLAS_LIBRARIES "")
+if(FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_CUDA)
+  if(NOT TARGET CUDA::cublas)
+    find_package(CUDAToolkit QUIET)
+  endif()
+
+  if(TARGET CUDA::cublas)
+    set(CUDA_CUBLAS_LIBRARIES CUDA::cublas)
+  else()
+    message(WARNING
+      "CUDA::cublas target not found; fbgemm_gpu_py will be built without an "
+      "explicit libcublas link and may fail to load with an undefined "
+      "cublas* symbol.")
+  endif()
+endif()
+
+BLOCK_PRINT(
+  "CUDA cuBLAS"
+  ""
+  "CUDA_CUBLAS_LIBRARIES=${CUDA_CUBLAS_LIBRARIES}"
+)

--- a/fbgemm_gpu/FbgemmGpu.cmake
+++ b/fbgemm_gpu/FbgemmGpu.cmake
@@ -210,6 +210,9 @@ gpu_cpp_library(
     fbgemm_gpu_tbe_cache
     fbgemm_gpu_tbe_optimizers
     fbgemm_gpu_tbe_utils
+    # sparse_permute102.cu calls cublasGemmStridedBatchedEx() directly; see the
+    # note in cmake/modules/CudaSetup.cmake.  Empty for CPU and ROCm builds.
+    ${CUDA_CUBLAS_LIBRARIES}
     ${DEP_MAYBE_TBB}
   DESTINATION
     fbgemm_gpu)

--- a/fbgemm_gpu/cmake/TbeTraining.cmake
+++ b/fbgemm_gpu/cmake/TbeTraining.cmake
@@ -245,6 +245,15 @@ gpu_cpp_library(
     ${TORCH_CUDA_OPTIONS}
   DEPS
     fbgemm_gpu_tbe_training_backward
+    # NOTE: These are symbol providers for this target, and must be listed
+    # explicitly even though fbgemm_gpu_tbe_training_backward already links
+    # them.  fbgemm_gpu/__init__.py dlopen()s each .SO with RTLD_LOCAL, and once
+    # fbgemm_gpu_tbe_training_backward.so is already in the process, the loader
+    # does not re-expand its DT_NEEDED entries into this target's lookup scope.
+    # Relying on the transitive edge yields `undefined symbol` at import time.
+    fbgemm_gpu_config
+    fbgemm_gpu_sparse_async_cumsum
+    fbgemm_gpu_tbe_utils
   DESTINATION
     fbgemm_gpu)
 
@@ -263,6 +272,11 @@ gpu_cpp_library(
     ${TORCH_CUDA_OPTIONS}
   DEPS
     fbgemm_gpu_tbe_training_backward
+    # NOTE: See the note on fbgemm_gpu_tbe_training_backward_gwd above -- these
+    # symbol providers cannot be inherited transitively under RTLD_LOCAL.
+    fbgemm_gpu_config
+    fbgemm_gpu_sparse_async_cumsum
+    fbgemm_gpu_tbe_utils
   DESTINATION
     fbgemm_gpu)
 
@@ -282,6 +296,10 @@ gpu_cpp_library(
   DEPS
     fbgemm_gpu_tbe_training_backward
     fbgemm_gpu_config
+    # NOTE: See the note on fbgemm_gpu_tbe_training_backward_gwd above -- this
+    # target calls transpose_embedding_input() et al. directly, so it needs its
+    # own DT_NEEDED entry rather than inheriting one under RTLD_LOCAL.
+    fbgemm_gpu_tbe_utils
   DESTINATION
     fbgemm_gpu)
 


### PR DESCRIPTION
PyTorch version: 2026.08.31+cu130
fbgemm_gpu nightly version: 2026.8.31+cu130

The following command reproduces the error:

```
$ python -c 'import fbgemm_gpu'

ERROR:root:Could not load the library 'fbgemm_gpu_tbe_training_backward_dense.so'!


Could not load this library: /data/users/xzhao9/py312/lib/python3.12/site-packages/fbgemm_gpu/fbgemm_gpu_tbe_training_backward_dense.so



Traceback (most recent call last):
  File "/data/users/xzhao9/py312/lib/python3.12/site-packages/torch/_ops.py", line 1516, in load_library
    ctypes.CDLL(path)
  File "/usr/local/fbcode/platform010/lib/python3.12/ctypes/__init__.py", line 379, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: /data/users/xzhao9/py312/lib/python3.12/site-packages/fbgemm_gpu/fbgemm_gpu_tbe_training_backward_dense.so: undefined symbol: _Z25transpose_embedding_inputN2at6TensorElS0_S0_bRKSt8optionalIS0_ElllbS4_ll

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/data/users/xzhao9/py312/lib/python3.12/site-packages/fbgemm_gpu/__init__.py", line 186, in <module>
    _load_library(f"{library}.so", info["version"], info["variant"] == "docs")
  File "/data/users/xzhao9/py312/lib/python3.12/site-packages/fbgemm_gpu/__init__.py", line 114, in _load_library
    raise error
  File "/data/users/xzhao9/py312/lib/python3.12/site-packages/fbgemm_gpu/__init__.py", line 108, in _load_library
    torch.ops.load_library(os.path.join(os.path.dirname(__file__), filename))
  File "/data/users/xzhao9/py312/lib/python3.12/site-packages/torch/_ops.py", line 1518, in load_library
    raise OSError(f"Could not load this library: {path}") from e
OSError: Could not load this library: /data/users/xzhao9/py312/lib/python3.12/site-packages/fbgemm_gpu/fbgemm_gpu_tbe_training_backward_dense.so
```

The reason of this failure:

1. fbgemm_gpu_tbe_training_backward_dense.so → transpose_embedding_input

  - transpose_embedding_input(...) is defined, as global T, in fbgemm_gpu_tbe_utils.so.
  - Six libs reference it. fbgemm_gpu_tbe_index_select.so, fbgemm_gpu_tbe_training_backward.so and fbgemm_gpu_py.so all carry a direct DT_NEEDED on fbgemm_gpu_tbe_utils.so.
    ..._backward_dense.so, ..._backward_gwd.so and ..._backward_vbe.so do not — they only need fbgemm_gpu_tbe_training_backward.so, and rely on reaching tbe_utils transitively through it.
  - That transitive hop doesn't happen here. fbgemm_gpu/__init__.py:108 loads each library with torch.ops.load_library → ctypes.CDLL(path), which is RTLD_LOCAL.
    ..._backward.so is loaded first (list order at __init__.py:137-151), so by the time dense is dlopen'd, backward.so is an already-loaded object and the loader does not re-expand its DT_NEEDED into dense's scope. LD_DEBUG=scopes confirms it — dense's scope 1 is exactly its own direct needs, with no fbgemm_gpu_tbe_utils.so in it, then immediately: symbol lookup error: undefined symbol: _Z25transpose_embedding_input... (fatal).
  
  Proof of the mechanism: ctypes.CDLL(dense) alone in a fresh process succeeds (then backward.so is loaded as part of the same dlopen, so its deps do land in scope). Load
  backward.so first with RTLD_LOCAL → dense fails; with RTLD_GLOBAL → dense loads.

  2. fbgemm_gpu_py.so → cublasGemmStridedBatchedEx

  Once 1) is worked around, the next failure is fbgemm_gpu_py.so: undefined symbol: cublasGemmStridedBatchedEx — same shape: no DT_NEEDED on libcublas.so.13, relying on libtorch_cuda having published cuBLAS globally, which RTLD_LOCAL loading also prevents.
 