### PR TITLE
Add tensor device relocation helper

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_utils.h
@@ -72,6 +72,31 @@ inline bool torch_tensor_on_same_device_check(
   return !ten2.has_value() || ten1.get_device() == ten2->get_device();
 }
 
+inline at::Tensor torch_tensor_to_same_device(
+    const at::Tensor& source,
+    const at::Tensor& target,
+    const char* source_name,
+    const char* target_name,
+    bool non_blocking) {
+  const auto target_device = target.device();
+  if (source.device() == target_device) {
+    return source;
+  }
+  TORCH_WARN_ONCE(
+      source_name,
+      " is on ",
+      source.device(),
+      ", but ",
+      target_name,
+      " is on ",
+      target_device,
+      "; moving ",
+      source_name,
+      " to the same device as ",
+      target_name);
+  return source.to(target_device, non_blocking);
+}
+
 inline bool torch_tensor_undefined(const at::Tensor& ten) {
   return ten.defined();
 }

--- a/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
@@ -251,24 +251,24 @@ std::vector<Tensor> permute_multi_embedding_function_gpu(
   // Relocate them rather than failing. `in_ptr`/`out_ptr` below already do
   // exactly this, and so does `kt_regroup_arguments_gpu` for these same three
   // tensors.
-  const auto to_device = [&device](const Tensor& t, const char* name) {
-    if (t.device() == device) {
-      return t;
-    }
-    TORCH_WARN_ONCE(
-        "permute_multi_embedding: ",
-        name,
-        " is on ",
-        t.device(),
-        " but pooled_embs[0] is on ",
-        device,
-        "; relocating. Expected when the index buffers are pinned to a single "
-        "device and the op runs on several, unexpected otherwise.");
-    return t.to(device, /*non_blocking=*/true);
-  };
-  const auto permutes_dev = to_device(permutes, "permutes");
-  const auto in_shapes_dev = to_device(in_shapes, "in_shapes");
-  const auto out_shapes_dev = to_device(out_shapes, "out_shapes");
+  const auto permutes_dev = torch_tensor_to_same_device(
+      permutes,
+      pooled_embs[0],
+      "permutes",
+      "pooled_embs[0]",
+      /*non_blocking=*/true);
+  const auto in_shapes_dev = torch_tensor_to_same_device(
+      in_shapes,
+      pooled_embs[0],
+      "in_shapes",
+      "pooled_embs[0]",
+      /*non_blocking=*/true);
+  const auto out_shapes_dev = torch_tensor_to_same_device(
+      out_shapes,
+      pooled_embs[0],
+      "out_shapes",
+      "pooled_embs[0]",
+      /*non_blocking=*/true);
 
   TORCH_CHECK(in_shapes_dev.is_contiguous());
   TORCH_CHECK(out_shapes_dev.is_contiguous());


### PR DESCRIPTION
Summary:
NOTE: No linked task. Please associate a task with this diff.

Add a reusable `torch_tensor_to_same_device(...)` function beside the tensor device-validation helpers. It returns the source unchanged when devices match; otherwise it warns and moves the source to the target device using caller-selected blocking semantics.

Refactor the metadata relocation introduced by D117957553 to use the shared helper. Using an inline function avoids macro identifier capture and makes the value-returning contract explicit.

Reviewed By: georgiaphillips

Differential Revision: D118157970


