### PR TITLE
Guard optional CPU pragmas

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
@@ -64,18 +64,24 @@ inline void parallel_for_table_threads(
   bool have_err = false;
   std::exception_ptr eptr;
 
+  #ifdef _OPENMP
   #pragma omp parallel num_threads(num_threads)
+  #endif
   {
     try {
         const at::ThreadLocalStateGuard tls_guard(tls);
+        #ifdef _OPENMP
         #pragma omp for schedule(dynamic) nowait
+        #endif
         for (int t = begin; t < end; ++t) {
             try {
                 f(t, t + 1);
             } catch (...) {
                 // std::exception_ptr is not atomic,
                 // hence we need a critical section here in case multiple threads have exceptions
+                #ifdef _OPENMP
                 #pragma omp critical(tbe_table_threads_err)
+                #endif
                 {
                     if (!have_err) {
                         have_err = true;
@@ -85,7 +91,9 @@ inline void parallel_for_table_threads(
             }
         }
     } catch (...) {
+        #ifdef _OPENMP
         #pragma omp critical(tbe_table_threads_err)
+        #endif
         {
             if (!have_err) {
                 have_err = true;

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -47,7 +47,6 @@ inline bool walk_down_tensor_storage_tree_except_last_(
   // compute coorindates
   int jagged_coords[NUM_JAGGED_DIM];
   int j_temp = flattened_jagged_idx;
-#pragma unroll
   for (int d = NUM_JAGGED_DIM - 2; d >= 0; --d) {
     const auto jagged_size = jagged_dims[d + 1];
     jagged_coords[d] = j_temp % jagged_size;
@@ -55,7 +54,6 @@ inline bool walk_down_tensor_storage_tree_except_last_(
   }
 
   bool is_zero = false;
-#pragma unroll
   for (int d = 0; d < NUM_JAGGED_DIM - 1; ++d) {
     const auto begin = x_offsets[d][offset];
     const auto end = x_offsets[d][offset + 1];

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -594,7 +594,9 @@ void radix_sort_kernel(
     local_histogram[i] = 0;
   }
 
+#ifdef _OPENMP
 #pragma omp for schedule(static)
+#endif
   for (int64_t i = 0; i < elements_count_4; i += 4) {
     const auto key_1 = input_keys[i];
     const auto key_2 = input_keys[i + 1];
@@ -612,7 +614,9 @@ void radix_sort_kernel(
       local_histogram[(key >> (pass * 8)) & 0xFF]++;
     }
   }
+#ifdef _OPENMP
 #pragma omp barrier
+#endif
   // Step 2: prefix sum
   if (tid == 0) {
     if (pass_with_sign_bit) {
@@ -623,10 +627,14 @@ void radix_sort_kernel(
       combine_prefix_sum(nthreads, elements_count, histogram, histogram_ps);
     }
   }
+#ifdef _OPENMP
 #pragma omp barrier
+#endif
 
   // Step 3: scatter
+#ifdef _OPENMP
 #pragma omp for schedule(static)
+#endif
   for (int64_t i = 0; i < elements_count_4; i += 4) {
     const auto key_1 = input_keys[i];
     const auto key_2 = input_keys[i + 1];
@@ -700,7 +708,9 @@ std::pair<K*, V*> radix_sort_parallel(
 
   const unsigned int num_passes = (num_bits + 7) / 8;
 
+#ifdef _OPENMP
 #pragma omp parallel
+#endif
   {
     K* input_keys = inp_key_buf;
     V* input_values = inp_value_buf;
@@ -721,7 +731,9 @@ std::pair<K*, V*> radix_sort_parallel(
 
       std::swap(input_keys, output_keys);
       std::swap(input_values, output_values);
+#ifdef _OPENMP
 #pragma omp barrier
+#endif
       {
       }
     }


### PR DESCRIPTION
Summary:
NOTE: No linked task. Please associate a task with this diff.

Make CPU warning behavior portable when optional compiler features are disabled.

Guard OpenMP directives in the mirrored `Utils.cc` sources and generated quantized CPU template, while removing invalid CUDA-style unroll pragmas from the jagged CPU helper. OpenMP-enabled behavior and the serial fallback remain unchanged.

Reviewed By: gchalump

Differential Revision: D117024953


