### PR TITLE
Return zeros on inference cache miss in embedding cache mode

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
@@ -165,6 +165,9 @@ c10::List<at::Tensor> DramKVEmbeddingInferenceWrapper::serialize() const {
   results.push_back(
       torch::tensor(
           {uniform_init_lower_, uniform_init_upper_}, torch::kDouble));
+  results.push_back(
+      torch::tensor(
+          {static_cast<int64_t>(disable_random_init_)}, torch::kInt64));
   return results;
 }
 
@@ -183,6 +186,12 @@ void DramKVEmbeddingInferenceWrapper::deserialize(
   const auto* floatPtr = states[1].const_data_ptr<double>();
   uniform_init_lower_ = floatPtr[0];
   uniform_init_upper_ = floatPtr[1];
+
+  // Payloads published before disable_random_init_ was serialized carry only
+  // the two entries above; leave the constructor default in place for those.
+  if (states.size() >= 3 && states[2].numel() >= 1) {
+    disable_random_init_ = states[2].const_data_ptr<int64_t>()[0] != 0;
+  }
 }
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_inference_embedding.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_inference_embedding.h
@@ -136,7 +136,7 @@ class DramKVInferenceEmbedding
         uniform_init_lower,
         uniform_init_upper,
         row_storage_bitwidth,
-        false /* disable_random_init */);
+        disable_random_init);
     if (table_dims.has_value()) {
       TORCH_CHECK_TENSOR_PROPERTIES(table_dims, at::ScalarType::Long);
       TORCH_NUM_CHECK_AND_ASSIGN_TENSOR_DATA(


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/torchrec/pull/4676

X-link: https://github.com/facebookresearch/FBGEMM/pull/3135

### Summary
#### [KVZCH] Enable random init

This diff enables the random initialization of weights in the KV embedding inference wrapper.

The change is done in three stages:

*   In `dram_kv_embedding_inference_wrapper.cpp`, we added a new tensor to the results containing whether random initialization is disabled.
*   In `dram_kv_inference_embedding.h`, we changed the default value of `disable_random_init` to be a variable instead of `false`. This allows the user to choose whether to disable random initialization.
*   In `KVInferenceWrapperTest.cpp`, we updated the test to include the new tensor in the serialized results.

With this change, users can now choose to disable random initialization of weights in the KV embedding inference wrapper.

Reviewed By: emlin, EddyLXJ

Differential Revision: D118223145


