### PR TITLE
Add four clang-only warnings for Objective-C and C

### DIFF
--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -251,7 +251,16 @@ function(fbgemm_get_warning_flags)
     # are casts in index arithmetic, where a wrong cast is a silent numerical
     # or OOB bug rather than a compile error. Enabling it demoted makes the
     # backlog visible without forcing rushed casts.
-    -Wshorten-64-to-32)
+    -Wshorten-64-to-32
+    # ---- Parity gap G2: clang-only, ObjC/C-oriented -------------------------
+    # g++ rejects all four outright (probed), so they are clang-only. They are
+    # no-ops for C++/CUDA/HIP translation units, but they are in fbcode's
+    # global CLANG_WARNINGS_TO_ENABLE and carrying them keeps the two lists
+    # literally in sync -- which is the whole point of the parity work.
+    -Wdeprecated-implementations
+    -Wsemicolon-before-method-body
+    -Wimport-preprocessor-directive-pedantic
+    -Wincompatible-function-pointer-types)
 
   # Clang-only flags that also need a RECENT clang. An older clang does not
   # know these flags, and an unknown `-W` option stops the build when `-Werror`


### PR DESCRIPTION
Summary:
NOTE: No linked task. Please associate a task with this diff.

Adds four warnings:

  -Wdeprecated-implementations
  -Wsemicolon-before-method-body
  -Wimport-preprocessor-directive-pedantic
  -Wincompatible-function-pointer-types

GCC does not know these four flags. Clang knows them. The flags go in the
clang-only list.

These four warnings do nothing for C++, CUDA or HIP code. They apply to
Objective-C methods and to C function pointers. The change adds them so that
the two flag lists stay the same. A later comparison of the two lists then
gives an empty result.

The change adds no `-Wno-error=` line. These warnings cannot occur, so no
`-Wno-error=` line is necessary.

Differential Revision: D117103727


