### PR TITLE
Mark platform-conditioned GPU parameters unused

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
@@ -167,7 +167,9 @@ struct __attribute__((visibility("hidden"))) KernelLauncher {
 
   constexpr inline void checkThreadCountNotExceeded(
       const cudaDeviceProp& properties,
-      const dim3& grid,
+      // Read only by the total-thread bound check below, which is compiled for
+      // HIP and pre-SM70 CUDA.
+      [[maybe_unused]] const dim3& grid,
       const dim3& block) const {
     const uint64_t threads_per_block =
         U64(block.x) * U64(block.y) * U64(block.z);

--- a/fbgemm_gpu/src/sparse_ops/sparse_group_index.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_group_index.cu
@@ -398,9 +398,11 @@ DLL_PUBLIC void group_index_select_or_add_cuda(
     const int group_size,
     const bool use_index_select,
     const bool use_var_cols,
-    const bool use_contiguous_warps,
-    const bool use_cache,
-    const bool use_packed_rows) {
+    // Read only by the ROCm variant selection below; the CUDA build pins all
+    // three to std::false_type.
+    [[maybe_unused]] const bool use_contiguous_warps,
+    [[maybe_unused]] const bool use_cache,
+    [[maybe_unused]] const bool use_packed_rows) {
   if (group_size == 0) {
     return;
   }


### PR DESCRIPTION
Summary:
NOTE: No linked task. Please associate a task with this diff.

Resolve GPU warnings for parameters that are read only in particular CUDA or ROCm configurations.

Annotate `KernelLauncher::checkThreadCountNotExceeded()`'s grid argument and the ROCm-only sparse group-index launch-selection values without changing signatures or launch behavior.

Reviewed By: spcyppt

Differential Revision: D117024949


