### PR TITLE
Keep C++ attributes out of generated Torch schemas

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_cpu_template.cpp
@@ -586,13 +586,13 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
     "Tensor indice_weights, "
     {%- endif %}
     "bool stochastic_rounding, "
-    "{{ (args.split_function_args | join(", ")).replace("double", "float").replace("int64_t", "int").replace("Tensor momentum1_host", "Tensor(b!) momentum1_host")}}"
+    "{{ args.split_function_schemas | join(", ") }}"
     {%- if not nobag %}
     ", int output_dtype = 0"
     {%- endif %}
     ") -> ()");
   {% else %}
-  m.def("split_embedding_backward_codegen_{{ optimizer }}_cpu(Tensor grad_output, Tensor(a!) host_weights, Tensor weights_offsets, Tensor D_offsets, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets,int pooling_mode, Tensor indice_weights, {{ (args.split_function_args | join(", ")).replace("double", "float").replace("int64_t", "int").replace("Tensor momentum1_host", "Tensor(b!) momentum1_host")}}) -> Tensor");
+  m.def("split_embedding_backward_codegen_{{ optimizer }}_cpu(Tensor grad_output, Tensor(a!) host_weights, Tensor weights_offsets, Tensor D_offsets, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets,int pooling_mode, Tensor indice_weights, {{ args.split_function_schemas | join(", ") }}) -> Tensor");
   {% endif %}
   DISPATCH_TO_CPU("split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_cpu", split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_cpu);
 


### PR DESCRIPTION
Summary:
NOTE: No linked task. Please associate a task with this diff.

Make generated Torch schemas independent of C++ declaration rendering.

The CPU backward template now consumes `split_function_schemas` directly instead of rewriting `split_function_args`, preventing declaration-only attributes such as `[[maybe_unused]]` from entering `m.def(...)` strings.

Reviewed By: spcyppt

Differential Revision: D117038101


