### PR TITLE
Guard GPU device queries on CPU lane in verify script

### DIFF
--- a/.github/scripts/utils_pytorch.bash
+++ b/.github/scripts/utils_pytorch.bash
@@ -27,10 +27,19 @@ __verify_pytorch_gpu_integration () {
   local torch_version_cuda=$(conda run ${env_prefix} python -c "import torch; print(torch.version.cuda)")
   # shellcheck disable=SC2086,SC2155
   local torch_version_hip=$(conda run ${env_prefix} python -c "import torch; print(torch.version.hip)")
-  # shellcheck disable=SC2086,SC2155
-  local torch_device_compatibility=$(conda run ${env_prefix} python -c "import torch; print(torch.cuda.get_device_capability())")
-  # shellcheck disable=SC2086,SC2155
-  local torch_device_name=$(conda run ${env_prefix} python -c "import torch; print(torch.cuda.get_device_name(torch.cuda.current_device()))")
+  # Only query CUDA device properties when CUDA is actually available.  On the
+  # CPU lane (torch built without CUDA), get_device_capability()/get_device_name()
+  # raise "Torch not compiled with CUDA enabled" and fail the whole check.
+  local torch_device_compatibility torch_device_name
+  if [ "${torch_cuda_available}" == "True" ]; then
+    # shellcheck disable=SC2086,SC2155
+    torch_device_compatibility=$(conda run ${env_prefix} python -c "import torch; print(torch.cuda.get_device_capability())")
+    # shellcheck disable=SC2086,SC2155
+    torch_device_name=$(conda run ${env_prefix} python -c "import torch; print(torch.cuda.get_device_name(torch.cuda.current_device()))")
+  else
+    torch_device_compatibility="N/A (CUDA not available)"
+    torch_device_name="N/A (CUDA not available)"
+  fi
 
   echo ""
   echo "################################################################################"


### PR DESCRIPTION
Summary:
`__verify_pytorch_gpu_integration` in .github/scripts/utils_pytorch.bash
computed `torch_cuda_available` but never used it, then called
`torch.cuda.get_device_capability()` and `get_device_name()`
unconditionally. On the CPU lane (torch built without CUDA) these raise
"Torch not compiled with CUDA enabled", failing the whole GPU-integration
check and the fbgemm_gpu_ci_cpu job.

Guard both device-property queries behind `torch_cuda_available == True`;
print an explicit "N/A (CUDA not available)" placeholder on CPU so the
report block still renders. Surfaced during the torch-2.14 CI triage
(T277878947); independent of any torch version.

Differential Revision: D118316051


