### PR TITLE
Add four clang-only warnings that can occur in C++ (#6253)

### DIFF
--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -260,7 +260,13 @@ function(fbgemm_get_warning_flags)
     -Wdeprecated-implementations
     -Wsemicolon-before-method-body
     -Wimport-preprocessor-directive-pedantic
-    -Wincompatible-function-pointer-types)
+    -Wincompatible-function-pointer-types
+    # g++ does not know these four flags. Unlike the four flags above, these
+    # four can occur in C++ code.
+    -Wambiguous-reversed-operator
+    -Wbitwise-instead-of-logical
+    -Wunreachable-code-fallthrough
+    -Wunused-local-typedef)
 
   # Clang-only flags that also need a RECENT clang. An older clang does not
   # know these flags, and an unknown `-W` option stops the build when `-Werror`


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3140


NOTE: No linked task. Please associate a task with this diff.

Adds four warnings:

  -Wambiguous-reversed-operator
  -Wbitwise-instead-of-logical
  -Wunreachable-code-fallthrough
  -Wunused-local-typedef

GCC does not know these four flags. Clang knows them. The flags go in the
clang-only list.

These four warnings can occur in this code. `-Wbitwise-instead-of-logical`
finds `&` where `&&` is correct. `-Wunused-local-typedef` finds a typedef
that the code does not use.

The change adds no `-Wno-error=` line, so these warnings stop the build. If
one of them occurs too often, add a `-Wno-error=` line to the clang-only
list. Do not add it to the portable list, because GCC stops with an error if
it gets `-Wno-error=` for a warning that it does not know.

Differential Revision: D117103729


