### PR TITLE
Add v1.9.0 -> torch 2.14 to compat table

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/__init__.py
@@ -15,6 +15,7 @@ import torch
 # Based on the FBGEMM-PyTorch compatibility table at
 # https://docs.pytorch.org/FBGEMM/general/Releases.html#fbgemm-releases-compatibility
 _fbgemm_torch_compat_table = {
+    "1.9": "2.14",
     "1.8": "2.13",
     "1.7": "2.12",
     "1.6": "2.11",


### PR DESCRIPTION
Summary:
Release prep for FBGEMM OSS v1.9.0 (PyTorch 2.14). Adds the
"1.9": "2.14" entry to _fbgemm_torch_compat_table so
fbgemm_gpu.__init__ can derive the version <-> torch compatibility
at runtime and emit the correct warning for mismatched torch builds.

Docs (Releases.rst) compat table + release-notes rows are handled
separately in the Phase 3 docs update once the stable matrix is locked.

Differential Revision: D118333185


