### PR TITLE
Make the HIP warnings stop the build

### DIFF
--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -459,7 +459,10 @@ function(fbgemm_get_warning_flags)
     # already be unnecessary. It is kept until a full ROCm census confirms a
     # zero count -- 02c.3 has only covered 13% of the build so far.
     # TODO(T169200065): drop once the ROCm census shows zero header-hygiene.
-    -Wno-error=header-hygiene)
+    -Wno-error=header-hygiene
+    # ROCm can miss Composable Kernel's requested occupancy for some gfx908
+    # kernels. This is a backend tuning diagnostic, not an invalid program.
+    -Wno-error=pass-failed)
 
   set(_hipcc
     ${_cc_common}

--- a/cmake/modules/GpuCppLibrary.cmake
+++ b/cmake/modules/GpuCppLibrary.cmake
@@ -226,9 +226,9 @@ function(gpu_cpp_library)
     # Computed BEFORE the library is created, because `hip_add_library()` takes
     # HIPCC_OPTIONS as a creation-time argument (it is a legacy FindHIP concept,
     # not a target property that can be set afterwards), so the HIPCC list has to
-    # exist by then. Both lists are now consumed, and both minus `-Werror`:
-    # `_nvcc_warning_flags` by the CUDA genex near the bottom of this function,
-    # and `_hipcc_warning_flags` by `hip_add_library()` below.
+    # exist by then. Both lists are now consumed: `_nvcc_warning_flags` minus
+    # `-Werror` by the CUDA genex near the bottom of this function, and the full
+    # `_hipcc_warning_flags` list by `hip_add_library()` below.
     #
     # Only the flag computation moved here. The MSVC `target_compile_definitions`
     # that used to sit in the same block stays after library creation, because it
@@ -292,24 +292,6 @@ function(gpu_cpp_library)
             list(APPEND lib_hipcc_system_includes "-isystem${include_dir}")
         endforeach()
 
-        # RECONNAISSANCE: warnings ON, `-Werror` OFF.
-        #
-        # OSS HIP compilation has never had `-Wall`/`-Wextra` at all, and there is
-        # no local ROCm build to measure with, so this lands warn-only to size the
-        # fixup work from CI before it can break anyone. **This is temporary** --
-        # a follow-up deletes the two lines below and passes
-        # `_hipcc_warning_flags` directly, at which point ROCm CI becomes a real
-        # device-code gate.
-        #
-        # Strip every `-Werror*` entry, not just the bare token. `REMOVE_ITEM`
-        # with the literal would leave a targeted `-Werror=<name>` behind if the
-        # warning list ever grows one, and the surface would silently stop being
-        # warn-only. The `^-Werror` anchor deliberately does not match the
-        # `-Wno-error=<name>` entries -- those are inert once `-Werror` is gone,
-        # and removing them would be a behaviour change.
-        set(_hipcc_recon ${_hipcc_warning_flags})
-        list(FILTER _hipcc_recon EXCLUDE REGEX "^-Werror")
-
         # Create the HIP library
         #
         # Warning flags come FIRST, before HIP_HCC_FLAGS. The tail of
@@ -321,7 +303,7 @@ function(gpu_cpp_library)
             ${lib_sources_hipified}
             ${args_OTHER_SRCS}
             ${FBGEMM_HIP_HCC_LIBRARIES}
-            HIPCC_OPTIONS ${_hipcc_recon} ${HIP_HCC_FLAGS} ${lib_hipcc_system_includes} ${args_HIPCC_FLAGS})
+            HIPCC_OPTIONS ${_hipcc_warning_flags} ${HIP_HCC_FLAGS} ${lib_hipcc_system_includes} ${args_HIPCC_FLAGS})
 
         # Append ROCM includes
         target_include_directories(${lib_name} PUBLIC
@@ -448,8 +430,7 @@ function(gpu_cpp_library)
     # `-Wno-strict-aliasing` and friends to cl.exe, which does not accept them.
     # The host CXX path already handles this by selecting `_msvc_flags` into
     # `lib_cc_flags`; there is no MSVC-shaped equivalent for the nvcc list today.
-    # RECONNAISSANCE: warnings ON, `-Werror` OFF -- the same treatment the HIPCC
-    # list gets above, for a different reason.
+    # RECONNAISSANCE: warnings ON, `-Werror` OFF.
     #
     # nvcc hands its own generated stubs (`/tmp/tmpxft_*.cudafe1.stub.c`) to the
     # host compiler, so `-Xcompiler=-Werror` lands on code this repo does not
@@ -460,8 +441,8 @@ function(gpu_cpp_library)
     # carries NO `-W<name>`, so unlike every other noisy warning here it cannot
     # be demoted with `-Wno-error=<name>`; dropping `-Werror` is the only lever.
     #
-    # Same anchor rationale as the HIPCC list: `^-Xcompiler=-Werror` strips bare
-    # `-Werror` and any future `-Werror=<name>`, and deliberately does not match
+    # `^-Xcompiler=-Werror` strips bare `-Werror` and any future
+    # `-Werror=<name>`, and deliberately does not match
     # `-Xcompiler=-Wno-error=<name>`, which is inert once `-Werror` is gone.
     set(_nvcc_recon ${_nvcc_warning_flags})
     list(FILTER _nvcc_recon EXCLUDE REGEX "^-Xcompiler=-Werror")
@@ -545,9 +526,6 @@ function(gpu_cpp_library)
         " "
         "RESOLVED WARNING FLAGS (HIPCC, full set):"
         "${_hipcc_warning_flags}"
-        " "
-        "RESOLVED WARNING FLAGS (HIPCC, AS APPLIED -- recon strips -Werror*):"
-        "${_hipcc_recon}"
         " "
         "NVCC_FLAGS:"
         "${args_NVCC_FLAGS}"

--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
@@ -199,7 +199,6 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
 
         #pragma unroll
         for (uint32_t inner_i = 0; inner_i < kRowUnroll; ++inner_i) {
-          uint32_t i = outer_i + inner_i;
           bool cache_valid = !DeviceOnly && (placement == PlacementType::MANAGED_CACHING && row_valid_v[inner_i]);
           bool final_valid = row_valid_v[inner_i] && (idx_v[inner_i] != -1);
           if (!DeviceOnly && cache_valid && cache_idx_v[inner_i] != kCacheLocationMissing) {

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_grad_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_grad_template.cu
@@ -157,7 +157,6 @@ __global__ __launch_bounds__(kMaxThreads) void grad_mean{{ vdesc }}_kernel(
     FixedDivisor fd_B
     {% endif %}
 ) {
-  int32_t T = D_offsets.size(0) - 1;
   [[maybe_unused]] int32_t b;
   int32_t t;
   const auto total_B = offsets.size(0) - 1;

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_indice_weights_template.cu
@@ -106,7 +106,6 @@ __global__ __launch_bounds__(kForwardMaxThreads) void
     [[maybe_unused]] int error_code = 0;
     [[maybe_unused]] int64_t error_value = 0;
 
-    int32_t T = D_offsets.size(0) - 1;
     // On ROCm the launch caps the grid to stay within the HIP 2^32
     // threads-per-launch limit, so we grid-stride to cover the full workload.
     // On CUDA the grid is not capped and the loop body runs once per warp.

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
@@ -173,7 +173,9 @@ batch_index_select_dim0_codegen_backward_kernel_cta_per_row(
   const unsigned int shfl_sync_mask = 0xffffffffu;
 #endif
   constexpr int VEC_WIDTH = 4;
+  {%- if not dense and optimizer != "none" %}
   constexpr auto kIsInt8 = std::is_same_v<emb_t, uint8_t>;
+  {%- endif %}
   int32_t T = weights_offsets.size(0);
   const int32_t num_long_runs = num_long_run_ids[0];
   const auto warp_id = threadIdx.y;
@@ -330,7 +332,7 @@ batch_index_select_dim0_codegen_backward_kernel_cta_per_row(
                 )
             }}
 
-            int counter;
+            int counter = 0;
             if (threadIdx.x == 0) {
                 __threadfence();
                 counter = gpuAtomicAdd(&grad_accum_counter[really_long_run_id], -1);

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -220,7 +220,6 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row(
 
         {{ compute_global_weight_decay(is_gwd_kernel) }}
 
-        const int32_t SL_per_warp = div_round_up(SL, blockDim.y);
         const int32_t sl_start = 0;
         const int32_t sl_end = SL;
         Vec4TAcc<cache_t> grad_sum[kFixedMaxVecsPerThread];
@@ -477,7 +476,6 @@ hip_mixed_d_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc
 
             {{ compute_global_weight_decay(is_gwd_kernel) }}
 
-            const int32_t SL_per_warp = div_round_up(SL, blockDim.y);
             const int32_t sl_start = 0;
             const int32_t sl_end = SL;
             Vec4TAcc<cache_t> grad_sum[kFixedMaxVecsPerThread];
@@ -668,7 +666,6 @@ hip_mixed_d_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc
             // now, each segment corresponds to exactly one table `t` and row in
             // that table (`idx`). Thus, we can hoist out some of the book-keeping.
 
-            const int32_t SL_per_warp = div_round_up(SL, blockDim.y);
             const int32_t sl_start = 0;
             const int32_t sl_end = SL;
 

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_nobag_small_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_nobag_small_template.cu
@@ -67,7 +67,9 @@ batch_index_select_dim0_codegen_forward_small_kernel(
     // If 2D, shape is [B][total_D]
     pta::PackedTensorAccessor64<output_t, {{ "1" if is_index_select else "2" }}, at::RestrictPtrTraits> output
     ) {
+    {%- if is_index_select %}
     int32_t T = weights_offsets.size(0);
+    {%- endif %}
     {%- if not is_index_select %}
     // On ROCm the launch caps the grid to stay within the HIP 2^32
     // threads-per-launch limit, so we grid-stride to cover the full workload.

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
@@ -350,7 +350,7 @@ using namespace fbgemm_gpu;
 
             for (auto inner_j = 0; inner_j < kManualUnrollLength; ++inner_j)
             {
-                auto j = outer_j + inner_j;
+                [[maybe_unused]] auto j = outer_j + inner_j;
                 {%- if is_index_select %}
                 overflow_safe_int_t output_j = L_start + l_start + j;
                 {%- elif nobag %}
@@ -366,7 +366,8 @@ using namespace fbgemm_gpu;
 
                 {%- endif %}
                 {%- if weighted %}
-                at::acc_type<cache_t, true> idx_weight_j = idx_weight_j_[inner_j];
+                [[maybe_unused]] at::acc_type<cache_t, true> idx_weight_j =
+                    idx_weight_j_[inner_j];
                 {%- endif %}
 
 
@@ -407,7 +408,7 @@ using namespace fbgemm_gpu;
             {%- if not nobag %}
             for (auto inner_j = 0; inner_j < kManualUnrollLength; ++inner_j)
             {
-                auto j = outer_j + inner_j;
+                [[maybe_unused]] auto j = outer_j + inner_j;
 
                 {%- if is_index_select %}
                 overflow_safe_int_t output_j = L_start + l_start + j;
@@ -422,7 +423,8 @@ using namespace fbgemm_gpu;
                 [[maybe_unused]] {{ locs_or_addrs_type }} {{ locs_or_addrs_idx }}_j = {{ locs_or_addrs_idx }}_j_[inner_j];
                 {%- endif %}
                 {%- if weighted %}
-                at::acc_type<cache_t, true> idx_weight_j = idx_weight_j_[inner_j];
+                [[maybe_unused]] at::acc_type<cache_t, true> idx_weight_j =
+                    idx_weight_j_[inner_j];
                 {%- endif %}
                 {%- if is_gwd_kernel %}
                 const auto global_weight_decay_j = SHFL_SYNC(global_weight_decay, j);
@@ -489,7 +491,8 @@ using namespace fbgemm_gpu;
 
             {%- if weighted %}
             // Load positional weight index from thread j in the group
-            at::acc_type<cache_t, true> idx_weight_j = SHFL_SYNC(idx_weight, j);
+            [[maybe_unused]] at::acc_type<cache_t, true> idx_weight_j =
+                SHFL_SYNC(idx_weight, j);
             {%- endif %}
             {%- if is_gwd_kernel %}
             const auto global_weight_decay_j = SHFL_SYNC(global_weight_decay, j);
@@ -655,8 +658,10 @@ batch_index_select_dim0_codegen_forward_kernel(
     fd_B.DivMod(b_t, &t, &b);
     {%- endif %}
 
+    {%- if is_index_select %}
     // Get total number of tables
     int32_t T = weights_offsets.size(0);
+    {%- endif %}
 
     {%- if is_index_select %}
     overflow_safe_int_t indices_start;

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
@@ -477,7 +477,9 @@ batch_index_select_dim0_codegen_forward_cuda(
     {%- if not nobag %}
     int32_t T = D_offsets.numel() - 1;
     {%- else %}
+    {%- if not is_index_select %}
     int32_t total_L = indices.numel();
+    {%- endif %}
     int32_t T = weights_offsets.numel();
     {%- endif %}
     TORCH_CHECK_GT(T, 0);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_blockwise_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_blockwise_gemm.hip
@@ -97,9 +97,7 @@ at::Tensor f8f8bf16_blockwise_impl(
   using EDataType = ck::bhalf_t;
 
   using ALayout = Row;
-  using AScaleLayout = Row;
   using BLayout = Col;
-  using BScaleLayout = Col;
   using DsLayout = ck::Tuple<>;
   using ELayout = Row;
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v1.hip
@@ -16,8 +16,6 @@ fp8_rowwise_batched_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
     at::Tensor w_scale,
     at::Tensor Y) {
   // Check if this input needs to be padded.
-  int M = XQ.size(1);
-  int N = WQ.size(1);
   int K = WQ.size(2);
   bool pad = (K % 256 != 0);
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
@@ -16,8 +16,6 @@ fp8_rowwise_batched_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
     at::Tensor w_scale,
     at::Tensor Y) {
   // Check if this input needs to be padded.
-  int M = XQ.size(1);
-  int N = WQ.size(1);
   int K = WQ.size(2);
   bool pad = (K % 256 != 0);
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1.hip
@@ -16,8 +16,6 @@ fp8_rowwise_batched_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
     at::Tensor w_scale,
     at::Tensor Y) {
   // Check if this input needs to be padded.
-  int M = XQ.size(1);
-  int N = WQ.size(1);
   int K = WQ.size(2);
   bool pad = (K % 256 != 0);
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
@@ -16,8 +16,6 @@ fp8_rowwise_batched_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
     at::Tensor w_scale,
     at::Tensor Y) {
   // Check if this input needs to be padded.
-  int M = XQ.size(1);
-  int N = WQ.size(1);
   int K = WQ.size(2);
   bool pad = (K % 256 != 0);
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1.hip
@@ -16,8 +16,6 @@ fp8_rowwise_batched_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
     at::Tensor w_scale,
     at::Tensor Y) {
   // Check if this input needs to be padded.
-  int M = XQ.size(1);
-  int N = WQ.size(1);
   int K = WQ.size(2);
   bool pad = (K % 512 != 0);
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
@@ -16,8 +16,6 @@ fp8_rowwise_batched_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
     at::Tensor w_scale,
     at::Tensor Y) {
   // Check if this input needs to be padded.
-  int M = XQ.size(1);
-  int N = WQ.size(1);
   int K = WQ.size(2);
   bool pad = (K % 512 != 0);
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_128x32x128x128_32x32_1x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_128x32x128x128_32x32_1x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_interwave_v2.hip
@@ -18,8 +18,6 @@ fp8_rowwise_batched_128x32x128x128_32x32_1x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_in
   // A kernel that seems to work well on mid sized tensors.
 
   // Check if this input needs to be padded.
-  int M = XQ.size(1);
-  int N = WQ.size(1);
   int K = WQ.size(2);
   bool pad = (K % 128 != 0);
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_256x128x128x128_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v4.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_256x128x128x128_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v4.hip
@@ -16,8 +16,6 @@ fp8_rowwise_batched_256x128x128x128_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_i
     at::Tensor w_scale,
     at::Tensor Y) {
   // Check if this input needs to be padded.
-  int M = XQ.size(1);
-  int N = WQ.size(1);
   int K = WQ.size(2);
   bool pad = (K % 128 != 0);
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4_1x1_interwave_v1.hip
@@ -16,8 +16,6 @@ fp8_rowwise_batched_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4_1x1_interwave_
     at::Tensor w_scale,
     at::Tensor Y) {
   // Check if this input needs to be padded.
-  int M = XQ.size(1);
-  int N = WQ.size(1);
   int K = WQ.size(2);
   bool pad = (K % 512 != 0);
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4_1x1_interwave_v2.hip
@@ -16,8 +16,6 @@ fp8_rowwise_batched_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4_1x1_interwave_
     at::Tensor w_scale,
     at::Tensor Y) {
   // Check if this input needs to be padded.
-  int M = XQ.size(1);
-  int N = WQ.size(1);
   int K = WQ.size(2);
   bool pad = (K % 512 != 0);
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fused_moe/fused_moe_kernel.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fused_moe/fused_moe_kernel.hip
@@ -110,7 +110,8 @@ at::Tensor fused_moe_impl(
       static_cast<int>(block_m),
       1,
       static_cast<int>(gate_only),
-      static_cast<int>(fused_quant)};
+      static_cast<int>(fused_quant),
+      false};
 
   // Set up arguments structure
   fused_moe_args args{

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/rocm/sparse_group_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/rocm/sparse_group_utils.h
@@ -62,7 +62,6 @@ __device__ __forceinline__ void warp_upper_bound(
   const auto active_mask = __activemask();
   using mask_t = std::remove_const_t<decltype(active_mask)>;
 
-  constexpr int kHardwareWarpSize = kWarpSize;
   constexpr int kMaskBits = sizeof(mask_t) * 8;
 
   const int hardware_lane = __lane_id();

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_to_padded_dense_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_to_padded_dense_forward.cu
@@ -137,7 +137,6 @@ stacked_jagged_2d_to_dense_forward_cuda(
   CUDA_DEVICE_GUARD(values);
 
   const auto lengths_contig = lengths.contiguous();
-  int32_t D = values.size(1);
   int32_t B = lengths.size(1);
   int32_t T = lengths.size(0);
   std::vector<Tensor> padded_values_per_key;

--- a/fbgemm_gpu/src/sparse_ops/sparse_async_batched_cumsum.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_async_batched_cumsum.cu
@@ -14,7 +14,7 @@
 #include <algorithm>
 #include "common.cuh"
 
-static constexpr uint32_t kMaxThreads = 1024;
+[[maybe_unused]] static constexpr uint32_t kMaxThreads = 1024;
 
 #ifdef __HIP_PLATFORM_AMD__
 namespace cub = hipcub;

--- a/fbgemm_gpu/src/sparse_ops/sparse_segment_sum_csr.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_segment_sum_csr.cu
@@ -38,7 +38,7 @@ __global__ __launch_bounds__(kMaxThreads) void _segment_sum_csr_cuda_kernel(
     values_t sum = 0;
 
     for (int64_t i = seg_start; i < seg_end; i += blockDim.x) {
-      values_t thread_data;
+      values_t thread_data = 0;
       if (threadIdx.x < seg_end - i) {
         thread_data = values_data[i + threadIdx.x];
       }

--- a/fbgemm_gpu/src/split_embeddings_cache/common.cuh
+++ b/fbgemm_gpu/src/split_embeddings_cache/common.cuh
@@ -84,7 +84,7 @@ cache_slot(const int64_t h_in, const int32_t C) {
 // too small nor too big.
 constexpr int MAX_THREAD_BLOCKS_PER_SM_FOR_CACHE_KERNELS = 16;
 
-int get_max_thread_blocks_for_cache_kernels_() {
+[[maybe_unused]] int get_max_thread_blocks_for_cache_kernels_() {
   return get_device_sm_cnt_() * MAX_THREAD_BLOCKS_PER_SM_FOR_CACHE_KERNELS;
 }
 


### PR DESCRIPTION
Summary:
NOTE: No linked task. Please associate a task with this diff.

Make the shared FBGEMM warning policy effective for HIP so actionable host and device warnings stop OSS ROCm builds.

Remove the filter that deleted every `-Werror` entry from the HIP warning list. Keep the warning list before `HIP_HCC_FLAGS`, preserve targeted demotions for known warning backlogs, and keep the parallel fbcode and xplat CMake files identical.

Fix each hard diagnostic exposed by successive OSS CUDA and ROCm builds: CK occupancy `pass-failed`, unused FP8 aliases and dimensions, the hipified cache helper, generated inference and backward locals, and the CTA shuffle input. Generated locals are removed where no specialization consumes them, marked `[[maybe_unused]]` only when variant-dependent, or emitted behind the same Jinja condition as their use. In particular, `kIsInt8` is emitted only for non-dense optimizer CTA kernels, avoiding both the original unused warning and the CUDA/ROCm undefined-identifier regression.

The final ROCm audit also guards the small no-bag forward kernel's `T` declaration by its index-select use, removes dead sparse-group and jagged-tensor locals, initializes the sparse segment reduction lane value, marks the launch-bounds constant as device-only usage, and explicitly initializes CK's new `local_expert_masking` trait field.

Reviewed By: cthi

Differential Revision: D117103730


