### PR TITLE
Avoid redundant zero fill in pack_segments

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_pack_segments_forward.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_pack_segments_forward.cu
@@ -119,11 +119,12 @@ DLL_PUBLIC Tensor pack_segments_forward_cuda(
     shape[0] = max_length; // Set first element to max_len
     shape.insert(
         shape.begin(), lengths_c.numel()); // Insert batch size at beginning
-    packed_tensor = at::zeros(shape, t_in_c.options());
 
     if (t_in_c.size(0) == 0 || lengths_c.size(0) == 0) {
+      packed_tensor = at::zeros(shape, t_in_c.options());
       return; // Return empty output (with the proper shape)
     }
+    packed_tensor = at::empty(shape, t_in_c.options());
 
     auto lengths_prefix_sum =
         fbgemm_gpu::asynchronous_exclusive_cumsum_gpu(lengths_c);

--- a/fbgemm_gpu/test/sparse/pack_segments_test.py
+++ b/fbgemm_gpu/test/sparse/pack_segments_test.py
@@ -247,6 +247,42 @@ class PackedSegmentsTest(unittest.TestCase):
                 packed_cuda.backward(grad_cpu.cuda())
                 packed_cuda_v2.backward(grad_cpu_v2.cuda())
 
+    @unittest.skipIf(*gpu_unavailable)
+    def test_pack_segments_nonempty_input_writes_padding(self) -> None:
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        lengths = torch.tensor([2, 0, 1], dtype=torch.int32, device=device)
+        t_input = torch.tensor(
+            [[1, 2], [3, 4], [5, 6]], dtype=torch.int32, device=device
+        )
+        expected = torch.tensor(
+            [
+                [[1, 2], [3, 4], [0, 0]],
+                [[0, 0], [0, 0], [0, 0]],
+                [[5, 6], [0, 0], [0, 0]],
+            ],
+            dtype=torch.int32,
+            device=device,
+        )
+
+        actual = torch.ops.fbgemm.pack_segments(
+            t_in=t_input, lengths=lengths, max_length=3
+        )
+
+        self.assertTrue(torch.equal(actual, expected))
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_pack_segments_empty_input_writes_padding(self) -> None:
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        lengths = torch.zeros(3, dtype=torch.int32, device=device)
+        t_input = torch.empty((0, 4), dtype=torch.int32, device=device)
+
+        actual = torch.ops.fbgemm.pack_segments(
+            t_in=t_input, lengths=lengths, max_length=5
+        )
+
+        self.assertEqual(tuple(actual.shape), (3, 5, 4))
+        self.assertTrue(torch.equal(actual, torch.zeros_like(actual)))
+
     @given(
         n=st.integers(2, 10),
         k=st.integers(2, 10),


### PR DESCRIPTION
Summary: The `pack_segments` packing kernel writes every output element, so zero-initializing the output is redundant for non-empty inputs. Allocate with `empty()` on that path while retaining `zeros()` for empty inputs where no kernel runs. MI350X microbenchmarks improved 16.8-28.3%; an MTS trace removed exactly 180 fill kernels across 180 calls. Authored with assistance from an AI coding assistant.

Differential Revision: D118384043


