### PR TITLE
[ROCm] Fix packed-bag pooling truncation in nbit inference forward

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
@@ -145,10 +145,7 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
     // wave-collective (syncwarp, shfl_sync), so a per-lane bound would let the
     // short-bag lanes exit while the rest still shuffle against them.  Adds no
     // iterations: a divergent wave already runs the union of all lanes'.
-    #pragma unroll
-    for (uint32_t lane_mask = kWarpSize / 2; lane_mask > 0; lane_mask >>= 1) {
-      max_Ls = max(max_Ls, shfl_xor(max_Ls, lane_mask));
-    }
+    max_Ls = warp_reduce_max(max_Ls);
   }
 
   // Accumulate and store map lanes to bags at uint granularity, the load stage

--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
@@ -139,6 +139,28 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
     Ls[i] = indices_end - indices_start;
     max_Ls = max(max_Ls, Ls[i]);
   }
+
+  if constexpr (PackedMode) {
+    // Each lane's max_Ls covers only its own bags, but the L_start loop below is
+    // wave-collective (syncwarp, shfl_sync), so a per-lane bound would let the
+    // short-bag lanes exit while the rest still shuffle against them.  Adds no
+    // iterations: a divergent wave already runs the union of all lanes'.
+    #pragma unroll
+    for (uint32_t lane_mask = kWarpSize / 2; lane_mask > 0; lane_mask >>= 1) {
+      max_Ls = max(max_Ls, shfl_xor(max_Ls, lane_mask));
+    }
+  }
+
+  // Accumulate and store map lanes to bags at uint granularity, the load stage
+  // at uint4 granularity, so they need a different bag's pooling length.  Ls[]
+  // must stay intact for the load stage: overwriting it corrupts later loads
+  // and the shuffle sources themselves.  Loop-invariant, so broadcast once.
+  int32_t Ls_acc[OutputRowsPerThread];
+  #pragma unroll OutputRowsPerThread
+  for (uint32_t i = 0; i < OutputRowsPerThread; ++i) {
+    Ls_acc[i] = PackedMode ? shfl_sync(Ls[i], packed_bag_acc_idx * uint4_loads_per_row) : Ls[i];
+  }
+
   const index_t* indices_ = &indices[0];
 
   const uint8_t* __restrict__ weights;
@@ -325,19 +347,13 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
       // the permutation should be done after switching from uint4 processing during load stage
       // to uint processing during accumulate and store.
       input_rows_in_flight = shfl_sync(input_rows_in_flight, packed_bag_acc_idx * uint4_loads_per_row);
-
-      #pragma unroll OutputRowsPerThread
-      for(uint32_t i = 0; i < OutputRowsPerThread; ++i)
-      {
-        Ls[i] = shfl_sync(Ls[i], packed_bag_acc_idx * uint4_loads_per_row);
-      }
     }
 
     {% if not nobag %}
     for (uint32_t input_row_idx = 0; input_row_idx < input_rows_in_flight; ++input_row_idx) {
       #pragma unroll OutputRowsPerThread
       for (uint32_t i = 0; i < OutputRowsPerThread; ++i) {
-        bool valid = L_start + input_row_idx < Ls[i];
+        bool valid = L_start + input_row_idx < Ls_acc[i];
         if (!valid) {
           continue;
         }
@@ -375,7 +391,7 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
       for (uint32_t input_row_idx = 0; input_row_idx < input_rows_in_flight; ++input_row_idx) {
         #pragma unroll OutputRowsPerThread
         for (uint32_t i = 0; i < OutputRowsPerThread; ++i) {
-          bool valid = L_start + input_row_idx < Ls[i];
+          bool valid = L_start + input_row_idx < Ls_acc[i];
           if (!valid) {
             continue;
           }
@@ -426,7 +442,7 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
       for (uint32_t input_row_idx = 0; input_row_idx < input_rows_in_flight; ++input_row_idx) {
         #pragma unroll OutputRowsPerThread
         for (uint32_t i = 0; i < OutputRowsPerThread; ++i) {
-          bool valid = L_start + input_row_idx < Ls[i];
+          bool valid = L_start + input_row_idx < Ls_acc[i];
           if (!valid) {
             continue;
           }
@@ -505,7 +521,7 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
   #pragma unroll OutputRowsPerThread
   for (uint32_t i = 0; i < OutputRowsPerThread; ++i) {
     const uint32_t b = min(static_cast<uint32_t>(bb * num_packed_bags * OutputRowsPerThread + i * num_packed_bags + packed_bag_store_idx), static_cast<uint32_t>(B - 1));
-    const float inv_L = (mean_pooling && Ls[i] != 0) ? static_cast<float>(1.0) / Ls[i] : static_cast<float>(1.0);
+    const float inv_L = (mean_pooling && Ls_acc[i] != 0) ? static_cast<float>(1.0) / Ls_acc[i] : static_cast<float>(1.0);
 
     if constexpr (std::is_same_v<output_t, float> || std::is_same_v<output_t, at::Half> || std::is_same_v<output_t, at::BFloat16>) {
       #pragma unroll AccumulateStoreRequests

--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
@@ -342,13 +342,6 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
     cp_async_wait<0>();
     syncwarp();
 
-    if constexpr (PackedMode) {
-      // Since in PackedMode one warp/wave may contain different bags with different sizes,
-      // the permutation should be done after switching from uint4 processing during load stage
-      // to uint processing during accumulate and store.
-      input_rows_in_flight = shfl_sync(input_rows_in_flight, packed_bag_acc_idx * uint4_loads_per_row);
-    }
-
     {% if not nobag %}
     for (uint32_t input_row_idx = 0; input_row_idx < input_rows_in_flight; ++input_row_idx) {
       #pragma unroll OutputRowsPerThread

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -146,6 +146,9 @@ additional_decorators: dict[str, list[Callable[..., Any]]] = {
     "test_faketensor__test_nbit_forward_nan_zero_fill": [
         unittest.skip("Operator not implemented for fake tensors"),
     ],
+    "test_faketensor__test_nbit_forward_packed_bags_uneven_pooling": [
+        unittest.skip("Operator not implemented for fake tensors"),
+    ],
 }
 
 
@@ -582,6 +585,70 @@ class NBitFowardTest(NBitFowardTestCommon):
                         "NaNs in the output"
                     )
                 self._execute_nan_zero_fill(weights_ty, D, output_dtype, weighted)
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_nbit_forward_packed_bags_uneven_pooling(self) -> None:
+        """Verify pooling when bags packed into one warp/wave have unequal Ls.
+
+        Every embedding row is set to 1.0 and no index is pruned, so a SUM bag
+        has an analytic value independent of the kernel: its own pooling factor
+        L. The bag lengths alternate short/long so that bags sharing a
+        warp/wave never agree, and the long ones span several iterations of the
+        row-load loop.
+
+        This pattern is the point of the test: with uniform lengths, a kernel
+        that applies one bag's L to its neighbour still produces the right
+        answer, so the bug class is invisible.
+
+        NOTE (ROCm-specific): bag packing is gated on
+        TBE_ROCM_INFERENCE_PACKED_BAGS, and INT4 with D=160 is a shape small
+        enough for more than one bag to fit a wave. On CUDA, and on ROCm with
+        packing disabled, this degrades to an ordinary uneven-length pooled
+        forward, which is still a valid thing to check.
+        """
+        device = torch.cuda.current_device()
+        E = 100
+        D = 160
+
+        op = IntNBitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[("", E, D, SparseType.INT4, EmbeddingLocation.DEVICE)],
+            output_dtype=SparseType.FP16,
+            pooling_mode=PoolingMode.SUM,
+            device=device,
+        )
+        op.fill_random_weights()
+
+        # Overwrite every row with 1.0 (dequant of 1.0 is exact for INT4).
+        quant_weights, quant_scale_shift = quantize_embs(
+            torch.ones(E, D), SparseType.INT4
+        )
+        weights, scale_shift = op.split_embedding_weights()[0]
+        weights.copy_(quant_weights)
+        if quant_scale_shift is not None:
+            self.assertIsNotNone(scale_shift)
+            scale_shift.copy_(quant_scale_shift)
+
+        # Alternating lengths: adjacent bags, which are the ones packed
+        # together, differ by a wide margin.
+        Ls = [1, 64, 1, 64, 1, 64, 1, 64]
+        B = len(Ls)
+        total = sum(Ls)
+        offsets = torch.tensor([0, *np.cumsum(Ls)], dtype=torch.int, device=device)
+        indices = torch.randint(0, E, (total,), dtype=torch.int, device=device)
+
+        # Every row is 1.0 and nothing is pruned, so each bag sums to its own L.
+        expected = torch.zeros(B, D, dtype=torch.float)
+        for b, L in enumerate(Ls):
+            expected[b, :] = L
+
+        output = op(indices=indices, offsets=offsets)
+
+        torch.testing.assert_close(
+            output.float().cpu(),
+            expected,
+            atol=1.0e-2,
+            rtol=1.0e-2,
+        )
 
     def test_nbit_forward_cpu_multi_table_pooled_no_prezero(self) -> None:
         """Multi-table CPU SUM-pooled nbit forward writes every output column itself.

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -48,9 +48,14 @@ from .common import get_nbit_weights_ty, NBitFowardTestCommon
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_unavailable, optests, TEST_WITH_ROCM
+    from test_utils import gpu_unavailable, optests, skipIfNotRocm, TEST_WITH_ROCM
 else:
-    from fbgemm_gpu.test.test_utils import gpu_unavailable, optests, TEST_WITH_ROCM
+    from fbgemm_gpu.test.test_utils import (
+        gpu_unavailable,
+        optests,
+        skipIfNotRocm,
+        TEST_WITH_ROCM,
+    )
 
 
 VERBOSITY: Verbosity = Verbosity.verbose
@@ -587,6 +592,7 @@ class NBitFowardTest(NBitFowardTestCommon):
                 self._execute_nan_zero_fill(weights_ty, D, output_dtype, weighted)
 
     @unittest.skipIf(*gpu_unavailable)
+    @skipIfNotRocm("Bag packing is a ROCm-only kernel path")
     def test_nbit_forward_packed_bags_uneven_pooling(self) -> None:
         """Verify pooling when bags packed into one warp/wave have unequal Ls.
 
@@ -602,9 +608,9 @@ class NBitFowardTest(NBitFowardTestCommon):
 
         NOTE (ROCm-specific): bag packing is gated on
         TBE_ROCM_INFERENCE_PACKED_BAGS, and INT4 with D=160 is a shape small
-        enough for more than one bag to fit a wave. On CUDA, and on ROCm with
-        packing disabled, this degrades to an ordinary uneven-length pooled
-        forward, which is still a valid thing to check.
+        enough for more than one bag to fit a wave. Nothing packs elsewhere, so
+        the test is skipped there rather than silently checking something other
+        than what its name describes.
         """
         device = torch.cuda.current_device()
         E = 100

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -584,11 +584,6 @@ class NBitFowardTest(NBitFowardTestCommon):
         """
         for name, weights_ty, D, output_dtype, weighted in NAN_ZERO_FILL_CASES:
             with self.subTest(case=name):
-                if TEST_WITH_ROCM and name.startswith("int4_small"):
-                    self.skipTest(
-                        "Known failure on ROCm: the INT4 D=160 shape leaves "
-                        "NaNs in the output"
-                    )
                 self._execute_nan_zero_fill(weights_ty, D, output_dtype, weighted)
 
     @unittest.skipIf(*gpu_unavailable)


### PR DESCRIPTION
### Problem

On ROCm, `TBE_ROCM_INFERENCE_PACKED_BAGS` packs several bags into a single wave. When those bags have different pooling lengths, the longer one is silently truncated to its partner's length and the embedding output is wrong.

It only surfaces when a bag's length exceeds `InputRowsInFlight`, and it disappears entirely when packed bags happen to share a length — which is why it went unnoticed.

### Cause

The accumulate/store stages map lanes to bags differently from the load stage (uint vs uint4 granularity). The kernel translated `Ls[]` between the two by shuffling it in place **inside the `L_start` loop**. That corrupts the load stage, which keeps reading `Ls[]` on later passes, and also corrupts the shuffle source lanes themselves — so from the second pass onwards every lane broadcasts an already-permuted value.

### Fix

- Translate once into a separate `Ls_acc[]` before the loop, leaving `Ls[]` intact for the load stage. Being loop-invariant, this also removes shuffles from every pass.
- Make `max_Ls` wave-uniform under PackedMode. The loop is wave-collective (`syncwarp`, `shfl_sync`), so a per-lane bound let short-bag lanes exit while the remaining lanes still shuffled against them.

Both changes are required — either one alone still fails.

### Testing (MI350X / gfx950, ROCm 7.1)

- `nbit_forward_test.py`: **2 failed → 12 passed, 8 subtests passed**
- Also verified across a range of bag-length patterns and embedding dimensions
- Performance neutral: packed and non-packed configs all within run-to-run noise

CUDA and the `nobag` path are unaffected — PackedMode is ROCm-and-pooled-only.

### Re-enabled test

Removes the ROCm skip on the `int4_small_weighted` and `int4_small_unweighted` subcases of `test_nbit_forward_nan_zero_fill`. Those were disabled in da743f0a to unblock the MI350 CI migration, and are the two failures this fix addresses — the corrupted `Ls[]` breaks the `input_row_idx >= Ls[i]` predicate that drives the zero-fill, so NaNs survive into the output.

