### PR TITLE
[ROCm] Make the Python NFP8 dtype selection architecture-aware

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -23,25 +23,18 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
 @torch.jit.ignore
 def _nfp8_is_fnuz() -> bool:
     """
-    Whether the current runtime device uses the FP8 "fnuz" e4m3 encoding.
+    Whether the runtime device uses the FP8 "fnuz" e4m3 encoding.
 
-    The FP8 e4m3 encoding is hardware specific on AMD GPUs: the gfx94x family
-    (gfx940/941/942, MI300) and gfx90a use the "fnuz" encoding, while gfx950 and
-    CUDA use the OCP "fn" encoding. A single ROCm build can be a fat binary
-    spanning multiple archs, so this must be resolved at runtime from the actual
-    device in use, mirroring the C++ getNFP8ScalarType() helper in
-    embedding_common.h. Keep the arch to encoding mapping identical between the
-    two.
-
-    Marked @torch.jit.ignore because the arch query is not TorchScript-able;
-    scripted callers get the eager result at runtime.
+    gfx94x (MI300) and gfx90a use "fnuz"; gfx950 and CUDA use OCP "fn". A ROCm
+    build can be a fat binary spanning both, so resolve it per-device at runtime.
+    Mirrors getNFP8ScalarType() in embedding_common.h - keep the two arch
+    mappings in sync. @torch.jit.ignore because the query is not scriptable.
     """
-    if torch.version.hip is not None and torch.cuda.is_available():
-        arch = torch.cuda.get_device_properties(torch.cuda.current_device()).gcnArchName
-        # fnuz archs: the gfx94x family (gfx940/941/942, MI300) and gfx90a.
-        if "gfx94" in arch or "gfx90a" in arch:
-            return True
-    return False
+    # Non-ROCm is always OCP "fn"; return before touching the device.
+    if torch.version.hip is None or not torch.cuda.is_available():
+        return False
+    arch = torch.cuda.get_device_properties(torch.cuda.current_device()).gcnArchName
+    return "gfx94" in arch or "gfx90a" in arch
 
 
 def nfp8_dtype() -> torch.dtype:
@@ -467,9 +460,8 @@ class SparseType(enum.Enum):
             raise ValueError(f"Unsupported sparse dtype: {dtype}")
 
     def as_dtype(self) -> torch.dtype:
-        # Resolved ahead of the table below: the NFP8 encoding is arch-dependent,
-        # and the table is rebuilt on every call, so leaving it inline would run
-        # a device query for every lookup - including the non-FP8 ones.
+        # Resolved before the table: the table is rebuilt per call, so an inline
+        # nfp8_dtype() would run a device query for every lookup.
         if self == SparseType.NFP8:
             return nfp8_dtype()
         return {

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -388,7 +388,7 @@ def sparse_type_int_to_dtype(ty: int) -> torch.dtype:
     elif ty == 7:  # mx4
         return torch.uint8
     elif ty == 9:
-        return torch.float8_e4m3fnuz if _nfp8_is_fnuz() else torch.float8_e4m3fn
+        return nfp8_dtype()
     else:  # Invalid is 7 or non enumerated.
         raise ValueError(f"Unsupported sparse type: {ty}")
 

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -20,6 +20,38 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
 )
 
 
+@torch.jit.ignore
+def _nfp8_is_fnuz() -> bool:
+    """
+    Whether the current runtime device uses the FP8 "fnuz" e4m3 encoding.
+
+    The FP8 e4m3 encoding is hardware specific on AMD GPUs: the gfx94x family
+    (gfx940/941/942, MI300) and gfx90a use the "fnuz" encoding, while gfx950 and
+    CUDA use the OCP "fn" encoding. A single ROCm build can be a fat binary
+    spanning multiple archs, so this must be resolved at runtime from the actual
+    device in use, mirroring the C++ getNFP8ScalarType() helper in
+    embedding_common.h. Keep the arch to encoding mapping identical between the
+    two.
+
+    Marked @torch.jit.ignore because the arch query is not TorchScript-able;
+    scripted callers get the eager result at runtime.
+    """
+    if torch.version.hip is not None and torch.cuda.is_available():
+        arch = torch.cuda.get_device_properties(torch.cuda.current_device()).gcnArchName
+        # fnuz archs: the gfx94x family (gfx940/941/942, MI300) and gfx90a.
+        if "gfx94" in arch or "gfx90a" in arch:
+            return True
+    return False
+
+
+def nfp8_dtype() -> torch.dtype:
+    """
+    Return the native FP8 (e4m3) torch dtype for the current runtime device.
+    See _nfp8_is_fnuz() for the arch to encoding mapping.
+    """
+    return torch.float8_e4m3fnuz if _nfp8_is_fnuz() else torch.float8_e4m3fn
+
+
 def pad4(value: int) -> int:
     """
     Compute the smallest multiple of 4 that is greater than or equal to the given value.
@@ -363,11 +395,7 @@ def sparse_type_int_to_dtype(ty: int) -> torch.dtype:
     elif ty == 7:  # mx4
         return torch.uint8
     elif ty == 9:
-        return (
-            torch.float8_e4m3fnuz
-            if torch.version.hip is not None
-            else torch.float8_e4m3fn
-        )
+        return torch.float8_e4m3fnuz if _nfp8_is_fnuz() else torch.float8_e4m3fn
     else:  # Invalid is 7 or non enumerated.
         raise ValueError(f"Unsupported sparse type: {ty}")
 
@@ -439,6 +467,11 @@ class SparseType(enum.Enum):
             raise ValueError(f"Unsupported sparse dtype: {dtype}")
 
     def as_dtype(self) -> torch.dtype:
+        # Resolved ahead of the table below: the NFP8 encoding is arch-dependent,
+        # and the table is rebuilt on every call, so leaving it inline would run
+        # a device query for every lookup - including the non-FP8 ones.
+        if self == SparseType.NFP8:
+            return nfp8_dtype()
         return {
             SparseType.FP32.value: torch.float32,
             SparseType.FP16.value: torch.float16,
@@ -448,11 +481,6 @@ class SparseType(enum.Enum):
             SparseType.INT2.value: torch.quint2x4,
             SparseType.BF16.value: torch.bfloat16,
             SparseType.MX4.value: torch.uint8,
-            SparseType.NFP8.value: (
-                torch.float8_e4m3fnuz
-                if torch.version.hip is not None
-                else torch.float8_e4m3fn
-            ),
         }[self.value]
 
     def bit_rate(self) -> int:

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -28,7 +28,11 @@ from torch.autograd.profiler import record_function  # usort:skip
 # @manual=//deeplearning/fbgemm/fbgemm_gpu/codegen:split_embedding_codegen_lookup_invokers
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers as invokers
 from fbgemm_gpu.config import FeatureGate, FeatureGateName
-from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
+from fbgemm_gpu.split_embedding_configs import (
+    EmbOptimType as OptimType,
+    nfp8_dtype,
+    SparseType,
+)
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     BoundsCheckMode,
     CacheAlgorithm,
@@ -3720,11 +3724,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             for param in splits:
                 tmp_param = torch.zeros(param.shape, device=self.current_device)
                 # Create initialized weights and cast to fp8.
-                fp8_dtype = (
-                    torch.float8_e4m3fnuz
-                    if torch.version.hip is not None
-                    else torch.float8_e4m3fn
-                )
+                fp8_dtype = nfp8_dtype()
                 tmp_param.uniform_(min_val, max_val).to(fp8_dtype)
                 param.data.copy_(tmp_param)
         else:

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
@@ -12,7 +12,11 @@ from typing import Any
 import hypothesis.strategies as st
 import numpy as np
 import torch
-from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
+from fbgemm_gpu.split_embedding_configs import (
+    EmbOptimType as OptimType,
+    nfp8_dtype,
+    SparseType,
+)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     SplitTableBatchedEmbeddingBagsCodegen,
@@ -94,9 +98,7 @@ common_settings: dict[str, Any] = {
     "deadline": None,
 }
 
-fp8_dtype: torch.dtype = (
-    torch.float8_e4m3fnuz if torch.version.hip is not None else torch.float8_e4m3fn
-)
+fp8_dtype: torch.dtype = nfp8_dtype()
 
 
 def execute_backward_adagrad(  # noqa C901

--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -883,11 +883,6 @@ class ForwardTest(unittest.TestCase):
 
     @optests.dontGenerateOpCheckTests("FP8 compute requires custom op support.")
     @unittest.skipIf(*gpu_unavailable)
-    @unittest.skip(
-        "Known failure on the MI350 runner: the device decodes NFP8 with the "
-        "arch-native OCP encoding while Python labels the tensor fnuz, so the "
-        "two disagree by one exponent bias"
-    )
     @skipIfNotRocm("NFP8 format-selection corner case is ROCm-specific")
     def test_forward_gpu_nfp8_format_matches_host_decode(self) -> None:
         # Pins that the device NFP8 decode matches a host decode through the same

--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -17,7 +17,11 @@ from unittest.mock import MagicMock, patch
 import hypothesis.strategies as st
 import numpy as np
 import torch
-from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
+from fbgemm_gpu.split_embedding_configs import (
+    EmbOptimType as OptimType,
+    nfp8_dtype,
+    SparseType,
+)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     RESParams,
@@ -69,9 +73,7 @@ else:
 
 VERBOSITY: Verbosity = Verbosity.verbose
 
-fp8_dtype: torch.dtype = (
-    torch.float8_e4m3fnuz if torch.version.hip is not None else torch.float8_e4m3fn
-)
+fp8_dtype: torch.dtype = nfp8_dtype()
 
 # pyre-ignore
 additional_decorators.update(


### PR DESCRIPTION
### Problem

FP8 e4m3 has two encodings: `fnuz` on gfx90a/gfx94x (MI300), and OCP `fn` on gfx950 and CUDA.

The C++ side already selects per-arch via `getNFP8ScalarType()`, but Python selected on *"is this a ROCm build"* and always returned `fnuz`. On gfx950 that labels the weight tensor `fnuz` while the device decodes OCP `fn`, so every PyTorch-native read of those bytes (casting, printing, serialization) is off by one exponent bias — a factor of two.

### Fix

Add `_nfp8_is_fnuz()` / `nfp8_dtype()`, mirroring the C++ arch check, and use them at the dtype-selection sites.

**No new kernel instantiations.** `relabel_nfp8_for_dispatch()` already views an `fn`-labelled tensor as `fnuz` at the host boundary, so the single `fnuz` kernel instantiation still serves both archs. An earlier attempt at this problem emitted both FP8 kernel variants on ROCm and was rolled back over build time; this approach avoids that entirely.

`as_dtype()` resolves NFP8 ahead of its lookup table rather than inside it, because the table is rebuilt on every call and would otherwise run a device query for every dtype lookup.

### Testing (MI350X / gfx950, ROCm 7.1)

- `test_forward_gpu_nfp8_format_matches_host_decode`: **fails (max abs err 26) → passes**
- `forward_test.py`: 14 passed, 0 failed
- Additionally ran the NFP8 tests currently skipped on ROCm (`no_cache_fp8`, `uvm_cache_fp8`, `backward_adagrad_fp8_pmSUM`) — all pass, which exercises the forward, cache, backward and optimizer relabel paths. Those skips are left untouched in this PR.

### Re-enabled test

Removes the ROCm skip on `test_forward_gpu_nfp8_format_matches_host_decode`. It was disabled in da743f0a to unblock the MI350 CI migration, and is the failure this fix addresses.

