### PR TITLE
[ROCm] Fix flaky forward-tolerance in backward adagrad ROCm test

### DIFF
--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
@@ -378,9 +378,7 @@ def execute_backward_adagrad(  # noqa C901
         )
     )
 
-    fp32_io = (
-        weights_precision == SparseType.FP32 and output_dtype == SparseType.FP32
-    )
+    fp32_io = weights_precision == SparseType.FP32 and output_dtype == SparseType.FP32
     tolerance = (
         1.0e-4
         if fp32_io

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
@@ -378,9 +378,12 @@ def execute_backward_adagrad(  # noqa C901
         )
     )
 
+    fp32_io = (
+        weights_precision == SparseType.FP32 and output_dtype == SparseType.FP32
+    )
     tolerance = (
         1.0e-4
-        if weights_precision == SparseType.FP32 and output_dtype == SparseType.FP32
+        if fp32_io
         else 1.0e-2 if weights_precision != SparseType.NFP8 else 1.0e-1
     )
 
@@ -396,7 +399,7 @@ def execute_backward_adagrad(  # noqa C901
         fc2,
         ref_output,
         atol=tolerance,
-        rtol=1.0e-2 if weights_precision != SparseType.FP32 else 1.0e-4,
+        rtol=1.0e-4 if fp32_io else 1.0e-2,
         msg=f"Forward output mismatch: VBE={mixed_B} pooling_mode={pooling_mode}, weight_precision={weights_precision} output_dtype={output_dtype} output_shape={fc2.shape}",
     )
     if do_pooling:


### PR DESCRIPTION
## Problem 
test_backward_adagrad_rocm_fallback_kernel flakily failed with a forward output mismatch (e.g. fp32 weights + bf16 output, [127, 960]). The forward-check tolerance derived rtol/atol from weights_precision only, so fp32 weights forced the tight rtol=1e-4,  tol=1e-2 even when the output was bf16 — below one bf16 ULP at the output magnitudes (~16–22). A correct kernel that bounded a single element the other way (exactly 1 ULP) tripped the assertion.

##  Fix
In backward_adagrad_common.py, only use the tight fp32 tolerance when both weights and output are fp32; otherwise use the relaxed 1e-2. Repro loop goes 16/40 -> 0/40 failures; the fp32/fp32 tight path is unchanged.