### PR TITLE
Resolve generated backward optimizer warnings (#6264)

### DIFF
--- a/fbgemm_gpu/codegen/genscript/jinja_environment.py
+++ b/fbgemm_gpu/codegen/genscript/jinja_environment.py
@@ -15,9 +15,13 @@ import re
 import jinja2
 
 try:
+    from .optimizer_args import maybe_unused_args
     from .scripts_argsparse import args
     from .torch_type_utils import TensorType
 except Exception:
+    # pyre-ignore[21]
+    from optimizer_args import maybe_unused_args
+
     # pyre-ignore[21]
     from scripts_argsparse import args
 
@@ -472,3 +476,4 @@ env.filters["make_pta_acc_builder_format"] = make_pta_acc_builder_format
 env.filters["replace_pta_namespace"] = replace_pta_namespace
 env.filters["replace_placeholder_types"] = replace_placeholder_types
 env.filters["to_upper_placeholder_types"] = to_upper_placeholder_types
+env.filters["maybe_unused_args"] = maybe_unused_args

--- a/fbgemm_gpu/codegen/genscript/optimizer_args.py
+++ b/fbgemm_gpu/codegen/genscript/optimizer_args.py
@@ -82,6 +82,19 @@ def annotate_unused_declaration(
     return f"[[maybe_unused]] {declaration}" if surface in unused_on else declaration
 
 
+def maybe_unused_args(args_str: str, apply: bool = True) -> str:
+    """Prefix every parameter of an already-rendered argument list.
+
+    The V1 optimizer argument lists reach the templates as one pre-joined
+    string, so a declaration that reads none of them -- a deprecation stub --
+    cannot annotate them individually. `apply` is the generated variant's
+    predicate, so a variant that does read the arguments renders unchanged.
+    """
+    if not apply:
+        return args_str
+    return ", ".join(f"[[maybe_unused]] {arg.strip()}" for arg in args_str.split(","))
+
+
 ######################################################################
 # Optimizer Args Set Item
 ######################################################################
@@ -1213,7 +1226,11 @@ class OptimizerArgsSet:
                 f"{name}_placements",
                 default,
                 is_optional=is_optional,
-                unused_on=unused_on,
+                # A placements tensor tells the CUDA path which of the device,
+                # UVM, or cache copies to read. The CPU kernel only ever has
+                # the host copy, so it forwards the tensor to keep the
+                # signature uniform and never dereferences it.
+                unused_on=unused_on | {DeclSurface.CPU_KERNEL},
             ),
             # pyre-fixme[19]: Expected 1 positional argument.
             OptimItem(

--- a/fbgemm_gpu/codegen/genscript/optimizers.py
+++ b/fbgemm_gpu/codegen/genscript/optimizers.py
@@ -12,14 +12,22 @@ from typing import Any
 
 try:
     from .jinja_environment import generate_optimized_grad_sum_loop_access
-    from .optimizer_args import OptimizerArgsSet, OptimizerArgsSetItem as OptimItem
+    from .optimizer_args import (
+        DeclSurface,
+        OptimizerArgsSet,
+        OptimizerArgsSetItem as OptimItem,
+    )
     from .torch_type_utils import ArgType
 except Exception:
     # pyre-ignore[21]
     from jinja_environment import generate_optimized_grad_sum_loop_access
 
     # pyre-ignore[21]
-    from optimizer_args import OptimizerArgsSet, OptimizerArgsSetItem as OptimItem
+    from optimizer_args import (
+        DeclSurface,
+        OptimizerArgsSet,
+        OptimizerArgsSetItem as OptimItem,
+    )
 
     # pyre-ignore[21]
     from torch_type_utils import ArgType
@@ -35,7 +43,16 @@ def dense() -> dict[str, Any]:
         "dense": True,
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(ArgType.FLOAT, "unused"),
+                # The dense backward has no optimizer state; this placeholder
+                # exists so the shared TBE templates have an argument list to
+                # render. No CPU declaration reads it.
+                OptimItem(
+                    ArgType.FLOAT,
+                    "unused",
+                    unused_on=frozenset(
+                        {DeclSurface.CPU_KERNEL, DeclSurface.HOST_FUNCTION}
+                    ),
+                ),
             ],
             {
                 "v1": "float unused = 0",
@@ -277,7 +294,14 @@ def rowwise_adagrad() -> dict[str, Any]:
                 OptimItem(ArgType.FLOAT, "eps"),
                 OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
                 OptimItem(ArgType.INT, "weight_decay_mode", 0),
-                OptimItem(ArgType.FLOAT, "max_norm", 0.0),
+                # Max-norm clipping is implemented in the CUDA weight update
+                # only; the CPU kernel never reads it.
+                OptimItem(
+                    ArgType.FLOAT,
+                    "max_norm",
+                    0.0,
+                    unused_on=frozenset({DeclSurface.CPU_KERNEL}),
+                ),
             ],
             {
                 "v1": "Tensor momentum1, float eps = 0, float learning_rate = 0, float weight_decay = 0.0, int weight_decay_mode = 0.0, float max_norm = 0.0"
@@ -721,7 +745,14 @@ def rowwise_adagrad_with_counter() -> dict[str, Any]:
                 OptimItem(ArgType.FLOAT, "adjustment_ub", 1.0),
                 OptimItem(ArgType.INT, "learning_rate_mode", -1),
                 OptimItem(ArgType.INT, "weight_decay_mode", 1),
-                OptimItem(ArgType.INT, "grad_sum_decay", -1),
+                # The gradient-sum decay schedule is applied in the CUDA
+                # counter update only; the CPU kernel never reads it.
+                OptimItem(
+                    ArgType.INT,
+                    "grad_sum_decay",
+                    -1,
+                    unused_on=frozenset({DeclSurface.CPU_KERNEL}),
+                ),
                 OptimItem(ArgType.FLOAT, "max_counter"),
                 OptimItem(ArgType.FLOAT, "tail_id_threshold", 0.0),
                 OptimItem(ArgType.INT, "is_tail_id_thresh_ratio", 0),

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_cpu_template.cpp
@@ -33,6 +33,10 @@
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
 
+{#- /* Only this optimizer has an fbgemm fast path on CPU, and it is the
+      sole reader of the raw momentum1 offsets accessor. */ #}
+{%- set uses_fbgemm_rowwise_adagrad = optimizer == "rowwise_adagrad" %}
+
 namespace internal {
 template <typename T>
 struct half2float16 {
@@ -61,7 +65,7 @@ void split_embedding_backward_exact_cpu_kernel(
     int B,
     const int* table_to_feature_offset,
     {% if "momentum1_offsets" in args.split_function_arg_names %}
-    const at::TensorAccessor<int64_t, 1> momentum1_offsets_data,
+    {{ "" if uses_fbgemm_rowwise_adagrad else "[[maybe_unused]] " }}const at::TensorAccessor<int64_t, 1> momentum1_offsets_data,
     {% endif %}
     {% if "momentum2_offsets" in args.split_function_arg_names %}
     const at::TensorAccessor<int64_t, 1> momentum2_offsets_data,
@@ -252,11 +256,9 @@ void split_embedding_nobag_backward_exact_cpu_kernel(
     const Tensor& hash_size_cumsum,
     const Tensor& indices,
     const Tensor& offsets,
-    int num_tables,
     int B,
-    const int* table_to_feature_offset,
     {% if "momentum1_offsets" in args.split_function_arg_names %}
-    const at::TensorAccessor<int64_t, 1> momentum1_offsets_data,
+    {{ "" if uses_fbgemm_rowwise_adagrad else "[[maybe_unused]] " }}const at::TensorAccessor<int64_t, 1> momentum1_offsets_data,
     {% endif %}
     {% if "momentum2_offsets" in args.split_function_arg_names %}
     const at::TensorAccessor<int64_t, 1> momentum2_offsets_data,
@@ -410,17 +412,17 @@ for (const auto d : c10::irange(D)) {
     Tensor grad_output,
     Tensor host_weights,
     {% if not dense %}
-    Tensor weights_placements,
+    [[maybe_unused]] Tensor weights_placements,
     {% endif %}
     Tensor weights_offsets,
     {% if nobag %}
     int64_t D,
     {% else %}
     Tensor D_offsets,
-    int64_t max_D,
+    [[maybe_unused]] int64_t max_D,
     {% endif %}
     Tensor hash_size_cumsum,
-    int64_t total_hash_size_bits,
+    [[maybe_unused]] int64_t total_hash_size_bits,
     Tensor indices,
     Tensor offsets,
     {% if not nobag %}
@@ -428,10 +430,10 @@ for (const auto d : c10::irange(D)) {
     Tensor indice_weights,
     {% endif %}
     {% if not dense %}
-    bool stochastic_rounding,
+    [[maybe_unused]] bool stochastic_rounding,
     {{ args.split_function_args | join(", ") }}
     {%- if not nobag %}
-    , int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)
+    , [[maybe_unused]] int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)
     {%- endif %}
     {% else %}
     {{ args.split_function_args | join(", ") }}
@@ -512,10 +514,12 @@ for (const auto d : c10::irange(D)) {
               {% if not nobag %}
               pooling_mode,
               indice_weights,
-              {% endif %}
               num_tables,
+              {% endif %}
               B,
+              {% if not nobag %}
               table_to_feature_offset,
+              {% endif %}
               {% if "momentum1_offsets" in args.split_function_arg_names %}
               momentum1_offsets_data,
               {% endif %}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
@@ -18,6 +18,10 @@
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
 
+{#- /* Without CPU support the V1 lookup function keeps its registered schema
+      but its body is only a deprecation TORCH_CHECK, so no argument is read. */ #}
+{%- set mu_stub = "" if has_cpu_support else "[[maybe_unused]] " %}
+
 {% if has_cpu_support %}
 /// @defgroup embedding-cpu Embedding CPU Operators
 
@@ -201,24 +205,24 @@ class SplitLookupFunction_{{ optimizer }}_Op : public torch::autograd::Function<
 {%- if args.split_function_args_v1 is not none %}
 ///@ingroup embedding-cpu
 Tensor split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(
-    Tensor host_weights,
-    Tensor weights_placements,
-    Tensor weights_offsets,
-    Tensor D_offsets,
-    c10::SymInt total_D,
-    c10::SymInt max_D,
-    Tensor hash_size_cumsum,
-    int64_t total_hash_size_bits,
-    Tensor indices,
-    Tensor offsets,
-    int64_t pooling_mode,
-    std::optional<Tensor> indice_weights,
-    std::optional<Tensor> feature_requires_grad,
-    bool gradient_clipping,
-    double max_gradient,
-    bool stochastic_rounding,
-    {{ args.split_function_args_v1 }},
-    int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)) {
+    {{ mu_stub }}Tensor host_weights,
+    {{ mu_stub }}Tensor weights_placements,
+    {{ mu_stub }}Tensor weights_offsets,
+    {{ mu_stub }}Tensor D_offsets,
+    {{ mu_stub }}c10::SymInt total_D,
+    {{ mu_stub }}c10::SymInt max_D,
+    {{ mu_stub }}Tensor hash_size_cumsum,
+    {{ mu_stub }}int64_t total_hash_size_bits,
+    {{ mu_stub }}Tensor indices,
+    {{ mu_stub }}Tensor offsets,
+    {{ mu_stub }}int64_t pooling_mode,
+    {{ mu_stub }}std::optional<Tensor> indice_weights,
+    {{ mu_stub }}std::optional<Tensor> feature_requires_grad,
+    {{ mu_stub }}bool gradient_clipping,
+    {{ mu_stub }}double max_gradient,
+    {{ mu_stub }}bool stochastic_rounding,
+    {{ args.split_function_args_v1 | maybe_unused_args(not has_cpu_support) }},
+    {{ mu_stub }}int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)) {
   {% if has_cpu_support %}
   {%- if "learning_rate_tensor" in args.split_function_arg_names %}
   // `learning rate` is changed to tensor to prevent recompilation.

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -27,6 +27,14 @@ namespace profiler = torch::autograd::profiler;
 {%- set fwd_mdesc = "ssd" if ssd else ("dense" if dense else "split") %}
 {%- set bwd_mdesc = "ssd" if ssd else "split" %}
 
+{#- /* An optimizer without GPU support still registers the full V1 schema, but
+      its lookup function body is only a deprecation TORCH_CHECK, so none of
+      its arguments is read. VBE and global-weight-decay arguments are likewise
+      always declared and only read by optimizers that support them. */ #}
+{%- set mu_stub = "" if has_gpu_support else "[[maybe_unused]] " %}
+{%- set mu_vbe = "" if (has_gpu_support and has_vbe_support) else "[[maybe_unused]] " %}
+{%- set mu_gwd = "" if (has_gpu_support and has_global_weight_decay_support and not ssd) else "[[maybe_unused]] " %}
+
 
 {%- if ssd %}
 enum SSDTensor {
@@ -572,10 +580,16 @@ class {{ autograd_func }} :
  public:
   static constexpr bool is_traceable = true;
 
+  {#- /* `is_experimental` selects the TBE v2 forward, which exists only for
+        the bagged, non-VBE, non-SSD, non-GWD configuration. The placeholder
+        tensor exists only to give autograd a differentiable input. */ #}
+  {%- set mu_experimental = "" if (has_experimental_support(
+        dense, nobag, vbe, is_index_select=False, ssd=ssd
+      ) and not is_gwd) else "[[maybe_unused]] " %}
   static torch::autograd::variable_list forward(
     torch::autograd::AutogradContext* ctx,
     {%- if not dense %}
-    const Tensor& placeholder_autograd_tensor,
+    [[maybe_unused]] const Tensor& placeholder_autograd_tensor,
     {%- endif %}
     const int64_t output_dtype,
     const Tensor& dev_weights,
@@ -626,7 +640,7 @@ class {{ autograd_func }} :
     const c10::SymInt max_B_feature_rank,
     const c10::SymInt vbe_output_size,
     {%- endif %}
-    const bool is_experimental,
+    {{ mu_experimental }}const bool is_experimental,
     const bool use_uniq_cache_locations_bwd,
     const bool use_homogeneous_placements,
     {%- if ssd %}
@@ -1076,64 +1090,64 @@ class {{ autograd_func }} :
 ///@ingroup embedding-cuda
 Tensor {{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function(
     {%- if dense %}
-    const Tensor& dev_weights,
+    {{ mu_stub }}const Tensor& dev_weights,
     {%- else %}
-    const Tensor& placeholder_autograd_tensor,
-    const Tensor& dev_weights,
-    const Tensor& uvm_weights,
-    const Tensor& lxu_cache_weights,
-    const Tensor& weights_placements,
+    {{ mu_stub }}const Tensor& placeholder_autograd_tensor,
+    {{ mu_stub }}const Tensor& dev_weights,
+    {{ mu_stub }}const Tensor& uvm_weights,
+    {{ mu_stub }}const Tensor& lxu_cache_weights,
+    {{ mu_stub }}const Tensor& weights_placements,
     {%- endif %}
-    const Tensor& weights_offsets,
-    const Tensor& D_offsets,
-    const c10::SymInt total_D,
-    const c10::SymInt max_D,
-    const Tensor& hash_size_cumsum,
-    const int64_t total_hash_size_bits,
-    const Tensor& indices,
-    const Tensor& offsets,
-    const int64_t pooling_mode,
-    const std::optional<Tensor>& indice_weights,
-    const std::optional<Tensor>& feature_requires_grad,
+    {{ mu_stub }}const Tensor& weights_offsets,
+    {{ mu_stub }}const Tensor& D_offsets,
+    {{ mu_stub }}const c10::SymInt total_D,
+    {{ mu_stub }}const c10::SymInt max_D,
+    {{ mu_stub }}const Tensor& hash_size_cumsum,
+    {{ mu_stub }}const int64_t total_hash_size_bits,
+    {{ mu_stub }}const Tensor& indices,
+    {{ mu_stub }}const Tensor& offsets,
+    {{ mu_stub }}const int64_t pooling_mode,
+    {{ mu_stub }}const std::optional<Tensor>& indice_weights,
+    {{ mu_stub }}const std::optional<Tensor>& feature_requires_grad,
     {%- if not dense %}
-    const Tensor& lxu_cache_locations,
+    {{ mu_stub }}const Tensor& lxu_cache_locations,
     {%- if optimizer != "none"%}
-    const bool gradient_clipping,
-    const double max_gradient,
-    const bool stochastic_rounding,
+    {{ mu_stub }}const bool gradient_clipping,
+    {{ mu_stub }}const double max_gradient,
+    {{ mu_stub }}const bool stochastic_rounding,
     {%- endif %}
-    {{ args.split_function_args_v1 }},
+    {{ args.split_function_args_v1 | maybe_unused_args(not has_gpu_support) }},
     {%- endif %}
-    const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32),
-    const std::optional<Tensor>& B_offsets = std::nullopt,
-    const std::optional<Tensor>& vbe_output_offsets_feature_rank = std::nullopt,
-    const std::optional<Tensor>& vbe_B_offsets_rank_per_feature = std::nullopt,
-    const c10::SymInt max_B = -1,
-    const c10::SymInt max_B_feature_rank = -1,
+    {{ mu_stub }}const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32),
+    {{ mu_vbe }}const std::optional<Tensor>& B_offsets = std::nullopt,
+    {{ mu_vbe }}const std::optional<Tensor>& vbe_output_offsets_feature_rank = std::nullopt,
+    {{ mu_vbe }}const std::optional<Tensor>& vbe_B_offsets_rank_per_feature = std::nullopt,
+    {{ mu_vbe }}const c10::SymInt max_B = -1,
+    {{ mu_vbe }}const c10::SymInt max_B_feature_rank = -1,
     {%- if not dense %}
-    const c10::SymInt vbe_output_size = -1,
-    const bool is_experimental_tbe = false, // formerly named is_experimental
-    const bool use_uniq_cache_locations_bwd = false,
-    const bool use_homogeneous_placements = false,
+    {{ mu_vbe }}const c10::SymInt vbe_output_size = -1,
+    {{ mu_stub }}const bool is_experimental_tbe = false, // formerly named is_experimental
+    {{ mu_stub }}const bool use_uniq_cache_locations_bwd = false,
+    {{ mu_stub }}const bool use_homogeneous_placements = false,
     {%- if ssd %}
-    const bool enable_optimizer_offloading = false,
+    {{ mu_stub }}const bool enable_optimizer_offloading = false,
     {%- endif %}
-    const std::optional<Tensor>& uvm_cache_stats = std::nullopt,
+    {{ mu_stub }}const std::optional<Tensor>& uvm_cache_stats = std::nullopt,
     {%- if "prev_iter_dev" not in args.split_function_arg_names %}
-    const std::optional<Tensor>& prev_iter_dev = std::nullopt,
+    {{ mu_gwd }}const std::optional<Tensor>& prev_iter_dev = std::nullopt,
     {%- endif %}
     {%- if "iter" not in args.split_function_arg_names %}
-    const int64_t iter = 0,
+    {{ mu_gwd }}const int64_t iter = 0,
     {%- endif %}
-    const bool apply_global_weight_decay = false,
+    {{ mu_gwd }}const bool apply_global_weight_decay = false,
     {%- if ssd %}
-    const std::optional<at::TensorList>& ssd_tensors = std::nullopt,
+    {{ mu_stub }}const std::optional<at::TensorList>& ssd_tensors = std::nullopt,
     {%- endif %}
-    const double gwd_lower_bound = 0,
+    {{ mu_gwd }}const double gwd_lower_bound = 0,
     {%- else %}
-    const c10::SymInt vbe_output_size = -1,
+    {{ mu_vbe }}const c10::SymInt vbe_output_size = -1,
     {%- endif %}
-    const bool mixed_D = false
+    {{ mu_stub }}const bool mixed_D = false
 ) {
   // TODO: refactor into macro
   {%- if has_gpu_support %}
@@ -1200,6 +1214,7 @@ Tensor {{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function(
 }
 {%- endif %} {#-/* if args.split_function_args_v1 is not none */#}
 
+{%- if dense or args.split_function_args_v1 is not none %}
 // Deprecated for fb namespace! Please use fbgemm namespace instead!
 {%- for lib_name in ["fb", "fbgemm"] %}
 TORCH_LIBRARY_FRAGMENT({{ lib_name }}, m) {
@@ -1302,4 +1317,5 @@ TORCH_LIBRARY_FRAGMENT({{ lib_name }}, m) {
     {%- endif %} {#-/* if dense or args.split_function_args_v1 is not none */#}
 }
 {%- endfor %} {#-/* for lib_name */#}
+{%- endif %} {#-/* if dense or args.split_function_args_v1 is not none */#}
     // clang-format on

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_indice_weights_template.cu
@@ -607,30 +607,33 @@ Tensor {{ mdesc }}_embedding_codegen_grad_indice_weights{{ vdesc }}_cuda(
 }
 
 
+{#- /* The meta shadow mirrors the CUDA op's schema but only needs the shapes
+      that determine the output, so the weight, cache, and VBE metadata
+      arguments below are declared for the contract and never read. */ #}
 Tensor {{ mdesc }}_embedding_codegen_grad_indice_weights{{ vdesc }}_meta(
     const Tensor& grad_output,
-    const Tensor& dev_weights,
+    [[maybe_unused]] const Tensor& dev_weights,
     {%- if not dense %}
-    const Tensor& uvm_weights,
-    const Tensor& lxu_cache_weights,
-    const Tensor& weights_placements,
+    [[maybe_unused]] const Tensor& uvm_weights,
+    [[maybe_unused]] const Tensor& lxu_cache_weights,
+    [[maybe_unused]] const Tensor& weights_placements,
     {%- endif %}
-    const Tensor& weights_offsets,
+    [[maybe_unused]] const Tensor& weights_offsets,
     const Tensor& D_offsets,
     const c10::SymInt max_D,
     const Tensor& indices,
     const Tensor& offsets,
     {%- if not dense %}
-    const Tensor& {{ locs_or_addrs_tensor }},
+    [[maybe_unused]] const Tensor& {{ locs_or_addrs_tensor }},
     {%- endif %}
     {%- if vbe %}
-    const Tensor& feature_requires_grad,
-    const Tensor& vbe_row_output_offsets,
-    const Tensor& vbe_b_t_map,
-    const int64_t info_B_num_bits, // int32_t
-    const int64_t info_B_mask_int64 // uint32_t
+    [[maybe_unused]] const Tensor& feature_requires_grad,
+    [[maybe_unused]] const Tensor& vbe_row_output_offsets,
+    [[maybe_unused]] const Tensor& vbe_b_t_map,
+    [[maybe_unused]] const int64_t info_B_num_bits, // int32_t
+    [[maybe_unused]] const int64_t info_B_mask_int64 // uint32_t
     {%- else %}
-    const Tensor& feature_requires_grad
+    [[maybe_unused]] const Tensor& feature_requires_grad
     {%- endif %}
 ) {
 

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -618,7 +618,8 @@ Tensor {{ embedding_cuda_op }}(
     const c10::SymInt D_,
     {%- endif %}
     {%- if not nobag and not is_index_select %}
-    const bool mixed_D,
+    {#- /* Read only by the ROCm-optimized non-VBE warp kernel dispatch below. */ #}
+    {{ "" if has_hip_optimized_nonvbe_support else "[[maybe_unused]] " }}const bool mixed_D,
     {%- endif %}
     const Tensor& hash_size_cumsum,
     const int64_t total_hash_size_bits,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3147


NOTE: No linked task. Please associate a task with this diff.

Apply declaration-surface policy to generated backward CPU, host, and GPU declarations.

The change records optimizer-specific unused parameters, removes private helper parameters that are never consumed, and annotates legacy or specialization-only arguments without altering dispatcher schemas or public argument ordering.

Reviewed By: gchalump

Differential Revision: D117024945


