### PR TITLE
Fix INT4 no-bag output stride handling (#6266)

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
@@ -296,6 +296,10 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
       adjusted_D += kINT8QparamsBytes;
     } else if (o_dtype == SparseType::INT4) {
       adjusted_D += kINT4QparamsElems;
+      TORCH_CHECK(
+          adjusted_D % 2 == 0,
+          "INT4 no-bag output requires an even embedding dimension, got D=",
+          D);
     }
     output = at::empty({total_L, adjusted_D}, dev_weights.options().dtype(getScalarType(o_dtype)).pinned_memory(pinned_memory));
     if (!output_is_int8 && !output_is_int4) {
@@ -356,7 +360,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
                 const int32_t D_end = D_offsets_acc[t + 1];
                 const int32_t D = D_end - D_start;
                 {% else %}
-                const int32_t elems_D = (o_dtype == SparseType::INT4) ? at::divup(adjusted_D, 2) : adjusted_D;
+                const int32_t elems_D = (o_dtype == SparseType::INT4) ? adjusted_D / 2 : adjusted_D;
                 const int32_t D_start = offsets_acc[t * B] * elems_D;
                 {% endif %}
 
@@ -393,7 +397,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
                 const bool normalize_by_lengths = static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN;
 
                 const index_t index_size = offsets_acc[(t + 1) * B] - *offsets_begin_ptr;
-                const int32_t output_stride = {{ "total_D" if not nobag else "adjusted_D" }};
+                const int32_t output_stride = {{ "total_D" if not nobag else "elems_D" }};
 
                 {% if nobag %}
                 TORCH_CHECK(index_size >= 0, "offsets must be non-decreasing, got index_size ", index_size, " for table ", t);

--- a/fbgemm_gpu/test/tbe/inference/common.py
+++ b/fbgemm_gpu/test/tbe/inference/common.py
@@ -88,6 +88,7 @@ class NBitFowardTestCommon(unittest.TestCase):
         mixed_weights_ty: bool,
         indices_dtype: torch.dtype,
         output_dtype: SparseType,
+        row_alignment: int | None = None,
     ) -> None:
         # NOTE: weighted operation can be done only for SUM.
         assume(pooling_mode == PoolingMode.SUM or not weighted)
@@ -259,6 +260,7 @@ class NBitFowardTestCommon(unittest.TestCase):
                 fp8_config.get("exponent_bias") if has_fp8_weight else None
             ),
             indices_dtype=indices_dtype,
+            row_alignment=row_alignment,
         )
         # Initialize the random weights for int nbit table split embedding bag
         cc.fill_random_weights()

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -1459,6 +1459,28 @@ class NBitFowardTest(NBitFowardTestCommon):
             output_dtype=SparseType.INT4,
         )
 
+    def test_nbit_forward_cpu_seq_int4_unaligned_row(self) -> None:
+        self.execute_nbit_forward_(
+            T=2,
+            D=100,
+            B=2,
+            log_E=2,
+            L=2,
+            weighted=False,
+            mixed=False,
+            pooling_mode=PoolingMode.NONE,
+            weights_ty=SparseType.INT4,
+            use_cache=False,
+            cache_algorithm=CacheAlgorithm.LRU,
+            use_cpu=True,
+            use_array_for_index_remapping=True,
+            do_pruning=False,
+            mixed_weights_ty=False,
+            indices_dtype=torch.int32,
+            output_dtype=SparseType.INT4,
+            row_alignment=8,
+        )
+
     def test_nbit_forward_cpu_seq_rejects_index_at_row_count(self) -> None:
         """The sequence gather rejects an index equal to the table's row count.
 

--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -84,7 +84,7 @@ GenerateEmbeddingSpMDM(
     bool is_bf16_in = false);
 
 /**
- * @param output_stride If -1, output_stride is same as block_size
+ * @param output_stride If -1, output_stride is same as block_size.
  * @param input_stride If -1, input_stride is same as block_size
  * @param scale_bias_last if false, scale and bias appear at the beginning
  *        of each row and are in fp16 for table batched embedding (TBE)
@@ -140,7 +140,12 @@ GenerateEmbeddingSpMDMNBit(
     bool use_offsets = true);
 
 /**
- * @param output_stride If -1, output_stride is same as block_size
+ * @param output_stride If -1, output_stride is same as block_size. For no-bag
+ *        INT4 output, -1 uses the packed fused-row size in bytes:
+ *        ceil(block_size / 2) + 2 * sizeof(uint16_t).
+ *        The returned no-bag INT4 kernel writes output_stride bytes per row,
+ *        including zero-filled padding. The output buffer must contain at
+ *        least output_size * output_stride bytes.
  * @param input_stride in Bytes. If -1, input_stride is same as
  *                     block_size / num_elem_per_byte + 2 * sizeof(float16)
  * @param scale_bias_last if false, scale and bias appear at the beginning

--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -434,6 +434,38 @@ FBGEMM_API void set_autovec_disabled(bool val);
 FBGEMM_API void set_autovec_forced(bool val);
 FBGEMM_API void set_asmjit_disabled(bool val);
 
+#define WARN_ONCE(...)              \
+  do {                              \
+    static bool _warned = false;    \
+    if (!_warned) {                 \
+      _warned = true;               \
+      fprintf(stderr, __VA_ARGS__); \
+    }                               \
+  } while (0)
+
+constexpr int64_t nbit_embedding_int4_row_size_in_bytes(
+    const int64_t block_size) {
+  constexpr int64_t kScaleBiasSize = 2 * sizeof(uint16_t);
+  return (block_size + 1) / 2 + kScaleBiasSize;
+}
+
+inline bool nbit_embedding_int4_validate_strides(
+    const int64_t block_size,
+    const int64_t input_stride,
+    const int64_t output_stride) {
+  const auto row_size = nbit_embedding_int4_row_size_in_bytes(block_size);
+  if (input_stride >= row_size && output_stride >= row_size) {
+    return true;
+  }
+  WARN_ONCE(
+      "no_bag strides must be at least the packed INT4 row size: "
+      "input_stride=%ld output_stride=%ld packed_row_size=%ld\n",
+      static_cast<long>(input_stride),
+      static_cast<long>(output_stride),
+      static_cast<long>(row_size));
+  return false;
+}
+
 /**
  * @brief A function to check if the input parameter in the nbit CPU TBE kernel
  * is valid.
@@ -459,14 +491,5 @@ void nbit_embedding_sanity_check(
         "output_bit_rate should be equal to 8 * sizeof(OutType)");
   }
 }
-
-#define WARN_ONCE(...)              \
-  do {                              \
-    static bool _warned = false;    \
-    if (!_warned) {                 \
-      _warned = true;               \
-      fprintf(stderr, __VA_ARGS__); \
-    }                               \
-  } while (0)
 
 } // namespace fbgemm

--- a/src/EmbeddingSpMDMAutovec.cc
+++ b/src/EmbeddingSpMDMAutovec.cc
@@ -415,6 +415,12 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
       WARN_ONCE("no_bag is only supported for int4 to int4");
       return false;
     }
+    const int64_t no_bag_row_size =
+        nbit_embedding_int4_row_size_in_bytes(block_size);
+    if (!nbit_embedding_int4_validate_strides(
+            block_size, input_stride, output_stride)) {
+      return false;
+    }
 
     // The preamble above only warms indices [0, l1_prefetch_distance), so
     // without a rolling prefetch every row past that is a cold, dependent load:
@@ -441,8 +447,12 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
             l1_prefetch_distance);
       }
       const uint8_t* input_row = input + input_stride * idx;
-      memcpy(out, input_row, sizeof(uint8_t) * input_stride);
-      out += input_stride;
+      memcpy(out, input_row, sizeof(uint8_t) * no_bag_row_size);
+      memset(
+          out + no_bag_row_size,
+          0,
+          sizeof(uint8_t) * (output_stride - no_bag_row_size));
+      out += output_stride;
     }
 
     // Track every forward pass with the actual bag size (len)
@@ -1940,7 +1950,11 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
     output_bit_rate = 8 * sizeof(OutType);
   }
   if (output_stride == -1) {
-    output_stride = block_size;
+    if (no_bag && output_bit_rate == 4) {
+      output_stride = nbit_embedding_int4_row_size_in_bytes(block_size);
+    } else {
+      output_stride = block_size;
+    }
   }
 
   if (input_stride == -1) {

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -1006,7 +1006,9 @@ typename EmbeddingSpMDMKernelSignature<uint8_t, indxType, offsetType, outType>::
   }
 
   if (output_stride == -1) {
-    output_stride = block_size;
+    output_stride = no_bag && output_bit_rate == 4
+        ? nbit_embedding_int4_row_size_in_bytes(block_size)
+        : block_size;
   }
   if (input_stride == -1) {
     int64_t num_elem_per_byte = 8 / input_bit_rate;

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -1453,7 +1453,11 @@ bool EmbeddingSpMDMNBit_ref(
   int num_elem_per_byte = 8 / input_bit_rate;
 
   if (output_stride == -1) {
-    output_stride = block_size;
+    if (no_bag && output_bit_rate == 4) {
+      output_stride = nbit_embedding_int4_row_size_in_bytes(block_size);
+    } else {
+      output_stride = block_size;
+    }
   }
 
   // block_size is the number of elements and fused_block_size is the size of
@@ -1470,6 +1474,12 @@ bool EmbeddingSpMDMNBit_ref(
     // here to double check and also avoid "unused variable" warning
     if (input_bit_rate != 4 || output_bit_rate != 4) {
       WARN_ONCE("no_bag is only supported for int4 to int4");
+      return false;
+    }
+    const int64_t packed_row_size =
+        nbit_embedding_int4_row_size_in_bytes(block_size);
+    if (!nbit_embedding_int4_validate_strides(
+            block_size, input_stride, output_stride)) {
       return false;
     }
     // This loop is not reference-only on x86: the asmjit nbit generator is
@@ -1501,8 +1511,12 @@ bool EmbeddingSpMDMNBit_ref(
             prefetch_distance);
       }
       const uint8_t* input_row = input + input_stride * idx;
-      memcpy(out, input_row, sizeof(uint8_t) * input_stride);
-      out += input_stride;
+      memcpy(out, input_row, sizeof(uint8_t) * packed_row_size);
+      memset(
+          out + packed_row_size,
+          0,
+          sizeof(uint8_t) * (output_stride - packed_row_size));
+      out += output_stride;
     }
     return true;
   }

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -13,6 +13,7 @@
 #include "./EmbeddingSpMDMTestUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "fbgemm/FbgemmConvert.h"
+#include "src/EmbeddingSpMDMAutovec.h" // @manual
 #include "src/RefImplementations.h" // @manual
 
 using namespace std;
@@ -69,6 +70,37 @@ class FusedNBitRowwiseEmbeddingLookupTest : public testing::TestWithParam<tuple<
                                                 EmbeddingSpMDMCornerCase,
                                                 EmbeddingSpMDMDtypeChoice,
                                                 EmbeddingSpMDMKernelChoice>> {};
+
+using Int4NoBagKernel =
+    EmbeddingSpMDMKernelSignature<uint8_t, int64_t, int64_t, uint8_t>::Type;
+
+constexpr int64_t kInt4NoBagBlockSize = 100;
+constexpr int64_t kInt4NoBagPackedRowSize =
+    (kInt4NoBagBlockSize + 1) / 2 + 2 * sizeof(float16);
+constexpr int64_t kInt4NoBagStorageAlignment = 8;
+constexpr int64_t kInt4NoBagInputStride =
+    ((kInt4NoBagPackedRowSize + kInt4NoBagStorageAlignment - 1) /
+     kInt4NoBagStorageAlignment) *
+    kInt4NoBagStorageAlignment;
+
+Int4NoBagKernel makeInt4NoBagKernel(
+    const int64_t output_stride,
+    const int64_t input_stride) {
+  return GenerateEmbeddingSpMDMNBitWithStrides<int64_t, int64_t, uint8_t>(
+      /*input_bit_rate=*/4,
+      /*block_size=*/kInt4NoBagBlockSize,
+      /*has_weight=*/false,
+      /*normalize_by_lengths=*/false,
+      /*prefetch=*/16,
+      /*is_weight_positional=*/false,
+      /*use_offsets=*/true,
+      output_stride,
+      input_stride,
+      /*scale_bias_last=*/true,
+      /*is_bf16_out=*/false,
+      /*no_bag=*/true,
+      /*output_bit_rate=*/4);
+}
 }; // namespace
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1287,6 +1319,223 @@ TEST(
         << "row one past the end was accepted, kernel_choice=" << kernel_choice;
     EXPECT_FALSE(gather_with(-1))
         << "negative index was accepted, kernel_choice=" << kernel_choice;
+  }
+}
+
+TEST(FusedNBitRowwiseEmbeddingLookupTest, NoBagInt4DropsInputRowPadding) {
+  constexpr int64_t kNumRows = 2;
+  constexpr int64_t kOutputSize = 2;
+  constexpr int64_t kGuardSize = 16;
+  constexpr uint8_t kCanary = 0xa5;
+
+  vector<uint8_t> table(kNumRows * kInt4NoBagInputStride);
+  for (int64_t row = 0; row < kNumRows; ++row) {
+    for (int64_t col = 0; col < kInt4NoBagPackedRowSize; ++col) {
+      table[row * kInt4NoBagInputStride + col] =
+          static_cast<uint8_t>(row * kInt4NoBagInputStride + col);
+    }
+    fill(
+        table.begin() + row * kInt4NoBagInputStride + kInt4NoBagPackedRowSize,
+        table.begin() + (row + 1) * kInt4NoBagInputStride,
+        static_cast<uint8_t>(0xe0 + row));
+  }
+
+  const vector<int64_t> indices{1, 0};
+  const vector<int64_t> offsets{0, 1, 2};
+  vector<uint8_t> output(
+      kOutputSize * kInt4NoBagInputStride + kGuardSize, kCanary);
+  vector<uint8_t> expected;
+  expected.reserve(kOutputSize * kInt4NoBagPackedRowSize);
+  for (const auto idx : indices) {
+    expected.insert(
+        expected.end(),
+        table.begin() + idx * kInt4NoBagInputStride,
+        table.begin() + idx * kInt4NoBagInputStride + kInt4NoBagPackedRowSize);
+  }
+
+  for (const auto requested_output_stride :
+       {kInt4NoBagPackedRowSize, int64_t{-1}}) {
+    for (const auto kernel_choice : {DISPATCH_DEFAULT, DISPATCH_AUTOVEC}) {
+      ScopedKernelOverride kernel_override(kernel_choice);
+      fill(output.begin(), output.end(), kCanary);
+      const auto kernel =
+          makeInt4NoBagKernel(requested_output_stride, kInt4NoBagInputStride);
+
+      ASSERT_TRUE(kernel(
+          kOutputSize,
+          indices.size(),
+          kNumRows,
+          table.data(),
+          indices.data(),
+          offsets.data(),
+          nullptr,
+          output.data()));
+
+      const vector<uint8_t> actual(
+          output.begin(),
+          output.begin() + kOutputSize * kInt4NoBagPackedRowSize);
+      EXPECT_EQ(actual, expected)
+          << "kernel_choice=" << kernel_choice
+          << ", requested_output_stride=" << requested_output_stride;
+      EXPECT_TRUE(all_of(
+          output.begin() + kOutputSize * kInt4NoBagPackedRowSize,
+          output.end(),
+          [](uint8_t value) { return value == kCanary; }))
+          << "kernel_choice=" << kernel_choice
+          << ", requested_output_stride=" << requested_output_stride;
+    }
+  }
+}
+
+TEST(
+    FusedNBitRowwiseEmbeddingLookupTest,
+    NoBagInt4DirectEntryPointsUsePackedDefaultStride) {
+  constexpr int64_t kNumRows = 2;
+  constexpr int64_t kOutputSize = 2;
+  constexpr int64_t kOutputCapacity = kOutputSize * kInt4NoBagBlockSize;
+  constexpr uint8_t kCanary = 0xa5;
+  vector<uint8_t> table(kNumRows * kInt4NoBagInputStride, 0xe0);
+  for (int64_t row = 0; row < kNumRows; ++row) {
+    iota(
+        table.begin() + row * kInt4NoBagInputStride,
+        table.begin() + row * kInt4NoBagInputStride + kInt4NoBagPackedRowSize,
+        static_cast<uint8_t>(row));
+  }
+  const vector<int64_t> indices{1, 0};
+  const vector<int64_t> offsets{0, 1, 2};
+  vector<uint8_t> expected;
+  for (const auto idx : indices) {
+    expected.insert(
+        expected.end(),
+        table.begin() + idx * kInt4NoBagInputStride,
+        table.begin() + idx * kInt4NoBagInputStride + kInt4NoBagPackedRowSize);
+  }
+
+  const auto verify = [&](const auto& run, const char* path) {
+    vector<uint8_t> output(kOutputCapacity, kCanary);
+    ASSERT_TRUE(run(output.data())) << path;
+    EXPECT_TRUE(equal(expected.begin(), expected.end(), output.begin()))
+        << path;
+    EXPECT_TRUE(all_of(
+        output.begin() + expected.size(),
+        output.end(),
+        [](uint8_t value) { return value == kCanary; }))
+        << path;
+  };
+
+  verify(
+      [&](uint8_t* output) {
+        return EmbeddingSpMDMNBit_ref<int64_t, int64_t, uint8_t>(
+            /*input_bit_rate=*/4,
+            /*block_size=*/kInt4NoBagBlockSize,
+            kOutputSize,
+            indices.size(),
+            kNumRows,
+            table.data(),
+            indices.data(),
+            offsets.data(),
+            /*weights=*/nullptr,
+            /*normalize_by_lengths=*/false,
+            output,
+            /*is_weight_positional=*/false,
+            /*use_offsets=*/true,
+            /*output_stride=*/-1,
+            kInt4NoBagInputStride,
+            /*scale_bias_last=*/true,
+            /*is_bf16_out=*/false,
+            /*no_bag=*/true,
+            /*output_bit_rate=*/4);
+      },
+      "reference");
+
+  const auto autovec =
+      GenerateEmbeddingSpMDMNBitWithStrides_autovec<int64_t, int64_t, uint8_t>(
+          /*input_bit_rate=*/4,
+          /*block_size=*/kInt4NoBagBlockSize,
+          /*has_weight=*/false,
+          /*normalize_by_lengths=*/false,
+          /*prefetch=*/16,
+          /*is_weight_positional=*/false,
+          /*use_offsets=*/true,
+          /*output_stride=*/-1,
+          kInt4NoBagInputStride,
+          /*scale_bias_last=*/true,
+          /*is_bf16_out=*/false,
+          /*no_bag=*/true,
+          /*output_bit_rate=*/4);
+  verify(
+      [&](uint8_t* output) {
+        return autovec(
+            kOutputSize,
+            indices.size(),
+            kNumRows,
+            table.data(),
+            indices.data(),
+            offsets.data(),
+            /*weights=*/nullptr,
+            output);
+      },
+      "autovec");
+}
+
+TEST(FusedNBitRowwiseEmbeddingLookupTest, NoBagInt4ZerosOutputPadding) {
+  constexpr int64_t kOutputPadding = 6;
+  constexpr int64_t kOutputStride = kInt4NoBagPackedRowSize + kOutputPadding;
+  constexpr uint8_t kCanary = 0xa5;
+  const vector<int64_t> indices{0};
+  const vector<int64_t> offsets{0, 1};
+  vector<uint8_t> table(kInt4NoBagInputStride, 0xe0);
+  iota(table.begin(), table.begin() + kInt4NoBagPackedRowSize, uint8_t{0});
+  vector<uint8_t> expected(kOutputStride, 0);
+  iota(
+      expected.begin(), expected.begin() + kInt4NoBagPackedRowSize, uint8_t{0});
+
+  for (const auto kernel_choice : {DISPATCH_DEFAULT, DISPATCH_AUTOVEC}) {
+    ScopedKernelOverride kernel_override(kernel_choice);
+    vector<uint8_t> output(kOutputStride, kCanary);
+    const auto kernel =
+        makeInt4NoBagKernel(kOutputStride, kInt4NoBagInputStride);
+
+    ASSERT_TRUE(kernel(
+        /*output_size=*/1,
+        indices.size(),
+        /*data_size=*/1,
+        table.data(),
+        indices.data(),
+        offsets.data(),
+        nullptr,
+        output.data()));
+
+    EXPECT_EQ(output, expected) << "kernel_choice=" << kernel_choice;
+  }
+}
+
+TEST(FusedNBitRowwiseEmbeddingLookupTest, NoBagInt4RejectsShortRowStrides) {
+  const vector<int64_t> indices{0};
+  const vector<int64_t> offsets{0, 1};
+  vector<uint8_t> table(kInt4NoBagPackedRowSize);
+  vector<uint8_t> output(kInt4NoBagPackedRowSize);
+
+  for (const auto [output_stride, input_stride] :
+       {pair{kInt4NoBagPackedRowSize, kInt4NoBagPackedRowSize - 1},
+        pair{kInt4NoBagPackedRowSize - 1, kInt4NoBagPackedRowSize}}) {
+    for (const auto kernel_choice : {DISPATCH_DEFAULT, DISPATCH_AUTOVEC}) {
+      ScopedKernelOverride kernel_override(kernel_choice);
+      const auto kernel = makeInt4NoBagKernel(output_stride, input_stride);
+
+      EXPECT_FALSE(kernel(
+          /*output_size=*/1,
+          indices.size(),
+          /*data_size=*/1,
+          table.data(),
+          indices.data(),
+          offsets.data(),
+          nullptr,
+          output.data()))
+          << "kernel_choice=" << kernel_choice
+          << ", output_stride=" << output_stride
+          << ", input_stride=" << input_stride;
+    }
   }
 }
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3149


NOTE: No linked task. Please associate a task with this diff.

The KVZCH job linked below crashed in the FBGEMM CPU INT4 no-bag path. For D=100, the source stride is 56 bytes, but the logical fused row is 54 bytes. Copying source padding shifts later output rows.

This change passes the packed output size from the generated TBE caller, copies only the logical row, and clears output padding. All NBit entry points now use the packed INT4 size for a default no-bag output stride. Short-stride failures report their values. Tests share one generator helper and cover the direct reference and autovec entry points.

Reviewed By: emlin

Differential Revision: D118193255


