### PR TITLE
Fix flaky forward-tolerance in backward adagrad ROCm test (#6267)

### DIFF
--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
@@ -378,9 +378,18 @@ def execute_backward_adagrad(  # noqa C901
         )
     )
 
+    fp32_io = weights_precision == SparseType.FP32 and output_dtype == SparseType.FP32
+    # FBGEMM uses fused FP32 multiply-add on ROCm, while the EmbeddingBag
+    # reference rounds multiply and add separately. At a BF16 midpoint, their
+    # one-FP32-ULP difference can therefore round to adjacent BF16 values.
+    rocm_fp32_bf16_output = (
+        TEST_WITH_ROCM
+        and weights_precision == SparseType.FP32
+        and output_dtype == SparseType.BF16
+    )
     tolerance = (
         1.0e-4
-        if weights_precision == SparseType.FP32 and output_dtype == SparseType.FP32
+        if fp32_io
         else 1.0e-2 if weights_precision != SparseType.NFP8 else 1.0e-1
     )
 
@@ -396,7 +405,11 @@ def execute_backward_adagrad(  # noqa C901
         fc2,
         ref_output,
         atol=tolerance,
-        rtol=1.0e-2 if weights_precision != SparseType.FP32 else 1.0e-4,
+        rtol=(
+            1.0e-2
+            if weights_precision != SparseType.FP32 or rocm_fp32_bf16_output
+            else 1.0e-4
+        ),
         msg=f"Forward output mismatch: VBE={mixed_B} pooling_mode={pooling_mode}, weight_precision={weights_precision} output_dtype={output_dtype} output_shape={fc2.shape}",
     )
     if do_pooling:


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3150

ROCm FP32/BF16 forward comparisons can differ by one BF16 ULP even when the FP32 accumulations differ by only one FP32 ULP: FBGEMM uses fused multiply-add, while the PyTorch EmbeddingBag reference rounds multiply and add separately. A 1,000-seed census found strict failures only for MI350 FP32/BF16 (25/1,000); MI350 FP32/FP16, NVIDIA FP32/BF16, and NVIDIA FP32/FP16 each had 0/1,000 failures.

Relax `rtol` to `1e-2` only for ROCm with FP32 weights and BF16 output. Keep `rtol=1e-4` for FP32/FP32, FP32/FP16, and non-ROCm FP32/BF16. Existing non-FP32-weight cases retain their pre-existing `1e-2` tolerance.

Reviewed By: spcyppt

Differential Revision: D118491985
