### PR TITLE
Add two warnings for unused functions and results (#6268)

### DIFF
--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -72,7 +72,9 @@ function(fbgemm_get_warning_flags)
     -Wzero-as-null-pointer-constant
     -Wunused-variable
     -Wunused-const-variable
-    -Wunused-but-set-variable)
+    -Wunused-but-set-variable
+    -Wunused-function
+    -Wunused-result)
 
   # Clang-only flags. g++ does not know these flags. g++ stops with an error
   # when it gets an unknown `-W` option. This error occurs even when `-Werror`


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3151

NOTE: No linked task. Please associate a task with this diff.

Adds two warnings:

  -Wunused-function
  -Wunused-result

g++ 11.5 and Clang 22 both accept the two flags and the matching `-Wno-error=`
forms. A test with each compiler shows this. The flags go in the portable
list.

`-Wall` already switches on both warnings. A test file gives one warning of
each type with `-Wall -Wextra` alone, and the same count with the two flags
present. The names are now explicit, but the behaviour does not change.

The list gives their names for the same reason as the other flags in this
group: a later version of `-Wall` can remove them.

Both warnings are already active in the internal build, and a measurement
across the GPU sources counted zero of each.

Differential Revision: D117143529


