### PR TITLE
Relocate permute_pooled_embs_split index tensors instead of failing

### DIFF
--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split.cu
@@ -77,9 +77,10 @@ Tensor permute_pooled_embs_split_gpu_impl(
       "current shape is: ",
       torch_tensor_shape_str(pooled_embs));
 
-  // inv_permute_list is not being used so it's not checked here.
-  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
-      pooled_embs, offset_dim_list, permute_list, inv_offset_dim_list);
+  // Relocation below aligns the index tensors to pooled_embs' device, but it
+  // cannot make a CPU input valid for this GPU impl -- keep failing loudly
+  // for that, which TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL used to cover.
+  TENSOR_ON_CUDA_GPU(pooled_embs);
 
   CUDA_DEVICE_GUARD(pooled_embs);
 
@@ -87,13 +88,39 @@ Tensor permute_pooled_embs_split_gpu_impl(
   // passs after D22767058. TODO: optimize and make sure pooled_embs is
   // contiguous.
   auto pooled_embs_contiguous = pooled_embs.contiguous();
+
+  // `offset_dim_list`, `permute_list` and `inv_offset_dim_list` are small
+  // constant index tensors describing how to slice `pooled_embs` -- on the
+  // order of a few KiB, against pooled embeddings that are typically hundreds
+  // of MiB. Requiring the caller to place them on the same device is not
+  // always satisfiable: in a statically exported graph they are buffers,
+  // resolved to a device once when the weights are materialized, while
+  // `pooled_embs` follows whichever device the runtime executing the request
+  // happens to be on. Relocate them rather than failing, matching
+  // permute_multi_embedding (D117957553).
+  // inv_permute_list is not being used so it's not relocated here.
+  const auto offset_dim_list_dev = torch_tensor_to_same_device(
+      offset_dim_list,
+      pooled_embs_contiguous,
+      "offset_dim_list",
+      "pooled_embs",
+      /*non_blocking=*/true);
+  const auto permute_list_dev = torch_tensor_to_same_device(
+      permute_list,
+      pooled_embs_contiguous,
+      "permute_list",
+      "pooled_embs",
+      /*non_blocking=*/true);
+  const auto inv_offset_dim_list_dev = torch_tensor_to_same_device(
+      inv_offset_dim_list,
+      pooled_embs_contiguous,
+      "inv_offset_dim_list",
+      "pooled_embs",
+      /*non_blocking=*/true);
+
   const int64_t B = pooled_embs_contiguous.size(0);
-  const int64_t T = permute_list.numel();
+  const int64_t T = permute_list_dev.numel();
   const int64_t dim_sum = pooled_embs_contiguous.size(1);
-  // inv_permute_list is not being used so it's not checked here.
-  TENSORS_ON_SAME_DEVICE(pooled_embs_contiguous, offset_dim_list);
-  TENSORS_ON_SAME_DEVICE(pooled_embs_contiguous, permute_list);
-  TENSORS_ON_SAME_DEVICE(pooled_embs_contiguous, inv_offset_dim_list);
 
   // Last index in inv_offset_dim_list contains the size of output.
   // This will cause a D->H sync.
@@ -136,9 +163,9 @@ Tensor permute_pooled_embs_split_gpu_impl(
             0,
             at::cuda::getCurrentCUDAStream(),
             pooled_embs_contiguous.data_ptr<scalar_t>(),
-            offset_dim_list.data_ptr<int64_t>(),
-            permute_list.data_ptr<int64_t>(),
-            inv_offset_dim_list.data_ptr<int64_t>(),
+            offset_dim_list_dev.data_ptr<int64_t>(),
+            permute_list_dev.data_ptr<int64_t>(),
+            inv_offset_dim_list_dev.data_ptr<int64_t>(),
             permuted_pooled_embs.data_ptr<scalar_t>(),
             B,
             T,

--- a/fbgemm_gpu/test/permute/permute_pooled_embedding_test.py
+++ b/fbgemm_gpu/test/permute/permute_pooled_embedding_test.py
@@ -263,6 +263,84 @@ class PooledEmbeddingModulesTest(unittest.TestCase):
         self.assertEqual(result.shape, pooled_embs.shape)
         self.assertTrue(torch.all(result == 0).item())
 
+    @unittest.skipIf(*typed_gpu_unavailable)
+    def test_permute_pooled_embedding_split_index_tensors_on_other_device(
+        self,
+    ) -> None:
+        """The index tensors are relocated to pooled_embs' device instead of
+        being required to already match it.
+
+        A statically exported graph resolves these buffers to one device when
+        the weights are materialized, while pooled_embs follows whichever device
+        the executing runtime is on, so the two legitimately disagree. Uses CPU
+        index tensors so the relocation path is covered on a single-GPU host;
+        the cross-GPU case takes the identical branch.
+        """
+        embs_dims = [4, 4, 8]
+        T = len(embs_dims)
+        B = 3
+        permute = [2, 0, 1]
+        inv_permute = [1, 2, 0]
+
+        offsets = torch.zeros(T + 1, dtype=torch.int64)
+        offsets[1:] = torch.cumsum(torch.tensor(embs_dims, dtype=torch.int64), dim=0)
+        permuted_dims = [embs_dims[i] for i in permute]
+        inv_offsets = torch.zeros(T + 1, dtype=torch.int64)
+        inv_offsets[1:] = torch.cumsum(
+            torch.tensor(permuted_dims, dtype=torch.int64), dim=0
+        )
+
+        # Deliberately left on CPU while pooled_embs are on the accelerator.
+        self.assertEqual(offsets.device.type, "cpu")
+        self.assertEqual(inv_offsets.device.type, "cpu")
+
+        pooled_embs = (
+            torch.arange(B * sum(embs_dims), dtype=torch.float32, device=self.device)
+            .view(B, sum(embs_dims))
+            .contiguous()
+        )
+
+        result = torch.ops.fbgemm.permute_pooled_embs_auto_grad_split(
+            pooled_embs,
+            offsets,
+            torch.tensor(permute, dtype=torch.int64),
+            inv_offsets,
+            torch.tensor(inv_permute, dtype=torch.int64),
+        )
+
+        self.assertEqual(result.device.type, pooled_embs.device.type)
+        self.assertEqual(result.shape, pooled_embs.shape)
+
+        # Values must match the permutation, not merely come back the right shape.
+        expected = torch.cat(
+            [pooled_embs[:, offsets[i] : offsets[i + 1]] for i in permute],
+            dim=1,
+        )
+        torch.testing.assert_close(result, expected)
+
+    @unittest.skipIf(*typed_gpu_unavailable)
+    @optests.dontGenerateOpCheckTests("negative test: the op is expected to raise")
+    def test_permute_pooled_embedding_split_rejects_cpu_pooled_embs(self) -> None:
+        """Relocation aligns the index tensors to pooled_embs' device; it must not
+        make a CPU pooled_embs acceptable to the GPU impl.
+        """
+        embs_dims = [4, 4]
+        T = len(embs_dims)
+        offsets = torch.zeros(T + 1, dtype=torch.int64)
+        offsets[1:] = torch.cumsum(torch.tensor(embs_dims, dtype=torch.int64), dim=0)
+        permute_t = torch.tensor([1, 0], dtype=torch.int64)
+
+        cpu_pooled_embs = torch.zeros(2, sum(embs_dims), dtype=torch.float32)
+
+        with self.assertRaises(RuntimeError):
+            torch.ops.fbgemm.permute_pooled_embs_split(
+                cpu_pooled_embs,
+                offsets.to(self.device),
+                permute_t.to(self.device),
+                offsets.to(self.device),
+                permute_t.to(self.device),
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3152

Follow-on to D117957553, which added this relocation for `permute_multi_embedding`.
The same hard failure existed in `permute_pooled_embs_split_gpu_impl`.

Uses the shared `torch_tensor_to_same_device` helper introduced in D118157970,
so both permute ops relocate through one code path and emit the same warning.

`offset_dim_list`, `permute_list` and `inv_offset_dim_list` are small constant
index tensors -- a few KiB, against pooled embeddings of hundreds of MiB. In a
statically exported graph they are buffers, resolved to a device once when the
weights are materialized, while `pooled_embs` follows whichever device the
runtime executing the request happens to be on. Requiring the caller to align
them is not always satisfiable.

On a sharded disagg-GPU `remote` net the pooled embeddings arrive from a
`cuda:3` TBE shard while the index buffers sit on `cuda:0`, and the op aborts:

```
Not all tensors were on the same GPU:
  pooled_embs(CUDA:3), offset_dim_list(CUDA:0), permute_list(CUDA:0), inv_offset_dim_list(CUDA:0)
Exception raised from permute_pooled_embs_split_gpu_impl
  at fbcode/deeplearning/fbgemm/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split.cu:82
```

This is reachable whenever the device allocation string carries an index-less
`cuda` entry (e.g. `remote.mpe_permute|cuda`), which means "relocate at runtime,
do not pin".

`inv_permute_list` is unused in this function and is left alone, matching the
existing comments.

Reviewed By: q10

Differential Revision: D119094849


