### PR TITLE
Add -Wextra-qualification

### DIFF
--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -104,6 +104,10 @@ function(fbgemm_get_warning_flags)
     # This flag finds code that only clang accepts. It protects the gcc
     # builds.
     -Wgcc-compat
+    # clang has this on by default, so naming it does not change the
+    # behaviour. g++ does not know the flag, and g++ treats the construct as
+    # an error in any case.
+    -Wextra-qualification
     -Wstring-conversion
     -Wimplicitly-unsigned-literal
     -Wuninitialized-const-reference


### PR DESCRIPTION
Summary:
NOTE: No linked task. Please associate a task with this diff.

Adds `-Wextra-qualification`. This warning finds a member declaration that
carries the name of its own class, for example `void A::f();` inside
`struct A`.

Clang accepts the flag. g++ does not know it, so the flag goes in the
clang-only list.

Keep the `-Wno-error=` form in the clang-only list too, if a later change
needs one. g++ stops with an error if it gets
`-Wno-error=extra-qualification`, because g++ does not know the warning.

Clang has this warning on by default. A test file with the bad construct
gives the same warning with `-Wall -Wextra` alone and with the flag present.
The name is now explicit, but the behaviour does not change. A clean test file
gives no warning.

g++ does not need the flag. g++ treats the construct as an error in all cases.

This flag completes the set: every flag that the internal build enables for
all directories now has a name in this list.

Differential Revision: D117143986


