### PR TITLE
Separate block and grid-plane counts in launch caps

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
@@ -29,113 +29,205 @@ constexpr int32_t MAX_THREAD_BLOCKS_FACTOR = 64;
 /// with `gridDim.x` above this is rejected by the driver.
 constexpr int64_t kMaxGridDimX = std::numeric_limits<int32_t>::max();
 
-/// HIP additionally caps the *total* threads per launch at 2^32 (CUDA silently
-/// wraps). Used only as the `OverflowOnly` threshold, and is distinct from the
-/// grid-x dimension limit above. See: https://github.com/ROCm/hip/issues/2253
+/// The grid y-dimension is limited to 65,535 on both CUDA and HIP.
+constexpr int64_t kMaxGridDimY = std::numeric_limits<uint16_t>::max();
+
+/// HIP requires the total threads per launch to be less than 2^32 (CUDA
+/// silently wraps). This is the largest valid total thread count and is
+/// distinct from the grid-x dimension limit above.
+/// See: https://github.com/ROCm/hip/issues/2253
 constexpr int64_t kMaxThreadsPerLaunch = std::numeric_limits<uint32_t>::max();
 
-/// Selects how `cap_grid_dim_x{,_from_workload}` clamps the requested grid.
+/// Selects how the grid-cap helpers clamp the requested dimension.
 ///
 /// - `Always`: cap on both CUDA and ROCm at `MAX_THREAD_BLOCKS_FACTOR * #SMs`.
 ///   Mirrors the legacy platform-agnostic `get_max_thread_blocks` semantics
 ///   (D75543767, D65009966).
 /// - `OverflowOnly` (default): cap on ROCm only when the unguarded launch
-///   would exceed the HIP 2^32 thread-per-launch limit. No-op on CUDA.
+///   would reach the HIP 2^32 thread-per-launch limit. No-op on CUDA except
+///   for the driver limit.
 ///   Cheapest correct policy for kernels that already grid-stride.
-/// - `Never`: do not cap.
+/// - `Never`: skip optional performance and overflow caps. Still clamp
+///   the selected dimension to the driver range and reject a fixed grid plane
+///   that cannot fit on HIP.
 enum class BlockCapPolicy { Always, OverflowOnly, Never };
 
-/// Returns the grid-x dimension to launch with, optionally clamped per
-/// `policy`. The caller is expected to have already computed
-/// `blocks_uncapped` (e.g. via `cuda_calc_xblock_count(N, divisor)`) and to
-/// pass the full per-block thread count for the threshold check.
+namespace detail {
+
+/// Caps one grid dimension and leaves the other two dimensions unchanged.
 ///
-/// Use this form when the block-count divisor differs from the full block
-/// size (e.g. `dim3(a, b)` launches where `gridDim.x = ceil(N / b)` but the
-/// threshold check needs `a * b`). For the common case where divisor equals
-/// `threads_per_block`, prefer `cap_grid_dim_x_from_workload`.
+/// The launch has `blocks_uncapped * other_grid_blocks * threads_per_block`
+/// threads before capping. On ROCm, division-first arithmetic finds the
+/// largest valid value of the selected dimension under the launch thread
+/// limit. The function fails only when the fixed grid plane and one thread
+/// block exceed that limit. Nonpositive launch multipliers bypass the overflow
+/// cap so the kernel launcher retains responsibility for validating them.
 ///
-/// The caller MUST guarantee the kernel grid-strides over its saturating
-/// work dimension whenever the cap path is reachable.
-///
-/// References:
-/// - HIP 2^32 thread-per-launch limit: https://github.com/ROCm/hip/issues/2253
-/// - Pre-existing unconditional-cap pattern: D75543767, D65009966
-///
-/// @param blocks_uncapped     Pre-computed unclamped grid-x dimension. Taken
-///                            as 64-bit so callers whose uncapped block count
-///                            can exceed `uint32_t` (the exact overflow case
-///                            this cap guards against) do not have to narrow it
-///                            first; the returned dimension is always clamped
-///                            into the valid grid-x range `[1, 2^31 - 1]`.
-/// @param threads_per_block   Full per-block thread count
-///                            (`block.x * block.y * block.z`), used only by
-///                            the `OverflowOnly` threshold check.
-/// @param stream              Stream whose device supplies `#SMs` for the cap.
-/// @param policy              Cap policy; see `BlockCapPolicy`. Default
-///                            `OverflowOnly`.
-/// @return Grid-x dimension to pass to the kernel launch.
-inline uint32_t cap_grid_dim_x(
+/// @param blocks_uncapped Requested size of the selected grid dimension.
+/// @param threads_per_block Product of `block.x`, `block.y`, and `block.z`.
+/// @param other_grid_blocks Product of the two unchanged grid dimensions.
+/// @param stream Stream whose device supplies the performance cap.
+/// @param policy Optional cap policy.
+/// @param max_grid_dim Driver limit for the selected grid dimension.
+/// @param grid_dimension Name of the selected dimension for error messages.
+/// @param fixed_grid_plane Name of the unchanged plane for error messages.
+/// @return Valid size of the selected grid dimension.
+inline uint32_t cap_grid_dimension(
     int64_t blocks_uncapped,
     [[maybe_unused]] int64_t threads_per_block,
+    [[maybe_unused]] int64_t other_grid_blocks,
     const c10::cuda::CUDAStream& stream,
-    BlockCapPolicy policy = BlockCapPolicy::OverflowOnly) {
-  // Clamp into the valid launch range [1, kMaxGridDimX]. Every caller
-  // grid-strides over its saturating dimension, so a clamped grid still covers
-  // all work; this also prevents a bogus (negative, or int64-overflowed) count
-  // from wrapping into an out-of-range dimension.
-  const auto to_grid_dim = [](int64_t blocks) {
+    BlockCapPolicy policy,
+    int64_t max_grid_dim,
+    [[maybe_unused]] const char* grid_dimension,
+    [[maybe_unused]] const char* fixed_grid_plane) {
+  // Apply the selected dimension's driver range after all policy caps.
+  const auto to_grid_dim = [max_grid_dim](int64_t blocks) {
     return static_cast<uint32_t>(
-        std::clamp<int64_t>(blocks, int64_t{1}, kMaxGridDimX));
+        std::clamp<int64_t>(blocks, int64_t{1}, max_grid_dim));
   };
 
+#ifdef USE_ROCM
+  // Divide before multiplication because the uncapped product can overflow.
+  const auto has_positive_launch_multipliers =
+      threads_per_block > 0 && other_grid_blocks > 0;
+  const auto safe_dimension_cap = has_positive_launch_multipliers
+      ? (kMaxThreadsPerLaunch / threads_per_block) / other_grid_blocks
+      : std::numeric_limits<int64_t>::max();
+  TORCH_CHECK(
+      !has_positive_launch_multipliers || safe_dimension_cap > 0,
+      fixed_grid_plane,
+      " and threads_per_block exceed the ROCm maximum per-launch thread count ",
+      kMaxThreadsPerLaunch,
+      "; no positive ",
+      grid_dimension,
+      " value can make the launch valid");
+#endif
+
   if (policy == BlockCapPolicy::Never) {
+    // The fixed-plane validity check above still applies on ROCm.
     return to_grid_dim(blocks_uncapped);
   }
 
-  // Occupancy/perf heuristic (64 * #SMs), not a correctness bound: caps grid.x
-  // to a few waves per SM. Used directly by `Always` and as one of the caps in
-  // the ROCm overflow branch below.
-  const auto perf_block_cap = static_cast<int64_t>(
-      MAX_THREAD_BLOCKS_FACTOR *
-      at::cuda::getDeviceProperties(stream.device_index())
-          ->multiProcessorCount);
+  const int64_t performance_cap =
+      static_cast<int64_t>(MAX_THREAD_BLOCKS_FACTOR) *
+      at::cuda::getDeviceProperties(stream.device_index())->multiProcessorCount;
 
   if (policy == BlockCapPolicy::Always) {
-    return to_grid_dim(std::min(blocks_uncapped, perf_block_cap));
+    auto capped_blocks = blocks_uncapped;
+    if (capped_blocks > performance_cap) {
+      capped_blocks = performance_cap;
+    }
+#ifdef USE_ROCM
+    if (capped_blocks > safe_dimension_cap) {
+      capped_blocks = safe_dimension_cap;
+    }
+#endif
+    return to_grid_dim(capped_blocks);
   }
 
-  // policy == OverflowOnly
 #ifdef USE_ROCM
-  // Overflow-safe form of `blocks_uncapped * threads_per_block >
-  // kMaxThreadsPerLaunch` (the product can exceed int64 for large grids).
-  if (threads_per_block > 0 &&
-      blocks_uncapped > kMaxThreadsPerLaunch / threads_per_block) {
-    // Also clamp grid.x so the *total* launch stays within HIP's 2^32 thread
-    // limit (perf_block_cap alone can exceed it when threads_per_block folds in
-    // other grid dims, e.g. a large grid.y). Safe because callers grid-stride.
-    const auto overflow_block_cap =
-        static_cast<int64_t>(kMaxThreadsPerLaunch / threads_per_block);
+  if (blocks_uncapped > safe_dimension_cap) {
     return to_grid_dim(
         std::min(
-            blocks_uncapped, std::min(perf_block_cap, overflow_block_cap)));
+            blocks_uncapped, std::min(performance_cap, safe_dimension_cap)));
   }
-#endif
   return to_grid_dim(blocks_uncapped);
+#else
+  return to_grid_dim(blocks_uncapped);
+#endif
 }
 
-/// Sugar over `cap_grid_dim_x` for the common case where the block-count
-/// divisor equals `threads_per_block`. Computes `blocks_uncapped` via
-/// `cuda_calc_xblock_count(num_items, threads_per_block)` (which preserves
-/// its overflow-safe arithmetic, `threads <= 1024` guard, and CUDA grid-x
-/// cap of 2^31 - 1) and forwards to `cap_grid_dim_x`.
+} // namespace detail
+
+/// Caps `grid.x` without changing `grid.y` or `grid.z`.
 ///
-/// @param num_items           Total work items (saturating dimension size).
-/// @param threads_per_block   Per-block thread count, also used as the
-///                            block-count divisor.
-/// @param stream              See `cap_grid_dim_x`.
-/// @param policy              See `cap_grid_dim_x`. Default `OverflowOnly`.
-/// @return Grid-x dimension to pass to the kernel launch.
+/// On ROCm, the result keeps
+/// `grid.x * yz_blocks * threads_per_block <= kMaxThreadsPerLaunch` when the
+/// selected policy permits capping. The kernel must grid-stride over X.
+///
+/// @param blocks_x_uncapped Requested `grid.x` size before capping.
+/// @param threads_per_block Product of `block.x`, `block.y`, and `block.z`.
+/// @param yz_blocks Product of the unchanged `grid.y` and `grid.z`.
+/// @param stream Stream whose device supplies the performance cap.
+/// @param policy Optional cap policy.
+/// @return Valid `grid.x` size.
+inline uint32_t cap_grid_dim_x_with_yz_blocks(
+    int64_t blocks_x_uncapped,
+    int64_t threads_per_block,
+    int64_t yz_blocks,
+    const c10::cuda::CUDAStream& stream,
+    BlockCapPolicy policy = BlockCapPolicy::OverflowOnly) {
+  return detail::cap_grid_dimension(
+      blocks_x_uncapped,
+      threads_per_block,
+      yz_blocks,
+      stream,
+      policy,
+      kMaxGridDimX,
+      "grid.x",
+      "grid.y * grid.z");
+}
+
+/// Caps `grid.y` without changing `grid.x` or `grid.z`.
+///
+/// On ROCm, the result keeps
+/// `grid.y * xz_blocks * threads_per_block <= kMaxThreadsPerLaunch` when the
+/// selected policy permits capping. The kernel must grid-stride over Y.
+///
+/// @param blocks_y_uncapped Requested `grid.y` size before capping.
+/// @param threads_per_block Product of `block.x`, `block.y`, and `block.z`.
+/// @param xz_blocks Product of the unchanged `grid.x` and `grid.z`.
+/// @param stream Stream whose device supplies the performance cap.
+/// @param policy Optional cap policy.
+/// @return Valid `grid.y` size.
+inline uint32_t cap_grid_dim_y_with_xz_blocks(
+    int64_t blocks_y_uncapped,
+    int64_t threads_per_block,
+    int64_t xz_blocks,
+    const c10::cuda::CUDAStream& stream,
+    BlockCapPolicy policy = BlockCapPolicy::OverflowOnly) {
+  return detail::cap_grid_dimension(
+      blocks_y_uncapped,
+      threads_per_block,
+      xz_blocks,
+      stream,
+      policy,
+      kMaxGridDimY,
+      "grid.y",
+      "grid.x * grid.z");
+}
+
+/// Caps `grid.x` for a one-dimensional grid.
+///
+/// This function forwards `yz_blocks = 1`. Use
+/// `cap_grid_dim_x_with_yz_blocks` when `grid.y` or `grid.z` is greater than
+/// one. The kernel must grid-stride over X.
+///
+/// @param blocks_x_uncapped Requested `grid.x` size before capping.
+/// @param threads_per_block Product of `block.x`, `block.y`, and `block.z`.
+/// @param stream Stream whose device supplies the performance cap.
+/// @param policy Optional cap policy.
+/// @return Valid `grid.x` size.
+inline uint32_t cap_grid_dim_x(
+    int64_t blocks_x_uncapped,
+    int64_t threads_per_block,
+    const c10::cuda::CUDAStream& stream,
+    BlockCapPolicy policy = BlockCapPolicy::OverflowOnly) {
+  return cap_grid_dim_x_with_yz_blocks(
+      blocks_x_uncapped, threads_per_block, 1, stream, policy);
+}
+
+/// Derives and caps `grid.x` for a one-dimensional launch.
+///
+/// Computes `ceil(num_items / threads_per_block)`, then applies
+/// `cap_grid_dim_x`. The kernel must grid-stride over the work items.
+///
+/// @param num_items Number of work items.
+/// @param threads_per_block Product of `block.x`, `block.y`, and `block.z`.
+/// @param stream Stream whose device supplies the performance cap.
+/// @param policy Optional cap policy.
+/// @return Valid `grid.x` size.
 template <typename Integer1, typename Integer2>
 inline uint32_t cap_grid_dim_x_from_workload(
     Integer1 num_items,

--- a/fbgemm_gpu/test/utils/cap_grid_dim_x_test.cu
+++ b/fbgemm_gpu/test/utils/cap_grid_dim_x_test.cu
@@ -7,9 +7,9 @@
  */
 
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAStream.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <limits>
 
@@ -17,70 +17,196 @@
 
 namespace fbgemm_gpu::utils::cuda {
 
-// The grid x-dimension launch limit is 2^31 - 1 on both CUDA and HIP.
-static_assert(kMaxGridDimX == 2147483647, "grid.x max must be 2^31 - 1");
+static_assert(kMaxGridDimX == 2147483647);
+static_assert(kMaxGridDimY == 65535);
 
-// BlockCapPolicy::Never exercises the final clamp in isolation, without
-// touching device properties (#SMs) or the ROCm overflow threshold, so these
-// assertions hold identically on CUDA and ROCm.
-
-TEST(CapGridDimXTest, ClampsOutOfRangeCountsToGridXMax) {
+TEST(CapGridDimensionTest, AppliesDriverLimits) {
   const auto stream = at::cuda::getCurrentCUDAStream();
 
-  // Just past the grid.x limit (2^31) is clamped down instead of passing
-  // through as an invalid dimension.
   EXPECT_EQ(
-      cap_grid_dim_x(
-          int64_t{1} << 31,
-          /*threads_per_block=*/1024,
-          stream,
-          BlockCapPolicy::Never),
+      cap_grid_dim_x(int64_t{1} << 31, 1, stream, BlockCapPolicy::Never),
       static_cast<uint32_t>(kMaxGridDimX));
-
-  // uint32_t max (2^32 - 1): the exact value the launcher rejected before the
-  // fix ("grid.x value 4294967295 is not within the range (0, 2147483647]").
   EXPECT_EQ(
-      cap_grid_dim_x(
-          std::numeric_limits<uint32_t>::max(),
-          1024,
-          stream,
-          BlockCapPolicy::Never),
-      static_cast<uint32_t>(kMaxGridDimX));
-
-  // An arbitrarily large 64-bit count is still clamped into range (guards the
-  // int64-overflow path that produced the wrapped dimension).
+      cap_grid_dim_y_with_xz_blocks(
+          kMaxGridDimY + 1, 1, 1, stream, BlockCapPolicy::Never),
+      static_cast<uint32_t>(kMaxGridDimY));
   EXPECT_EQ(
       cap_grid_dim_x(
           std::numeric_limits<int64_t>::max(),
-          1024,
+          1,
           stream,
           BlockCapPolicy::Never),
       static_cast<uint32_t>(kMaxGridDimX));
 }
 
-TEST(CapGridDimXTest, PassesThroughValidCounts) {
+TEST(CapGridDimensionTest, FloorsNonpositiveBlockCounts) {
   const auto stream = at::cuda::getCurrentCUDAStream();
 
-  // Exactly at the limit is valid and returned unchanged.
-  EXPECT_EQ(
-      cap_grid_dim_x(kMaxGridDimX, 1024, stream, BlockCapPolicy::Never),
-      static_cast<uint32_t>(kMaxGridDimX));
+  EXPECT_EQ(cap_grid_dim_x(0, 1, stream, BlockCapPolicy::Never), uint32_t{1});
+  EXPECT_EQ(cap_grid_dim_x(-1, 1, stream, BlockCapPolicy::Never), uint32_t{1});
+}
 
-  // A normal small count is returned as-is.
+TEST(CapGridDimensionTest, PreservesLegacyHandlingForNonpositiveMultipliers) {
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
   EXPECT_EQ(
-      cap_grid_dim_x(1234, 1024, stream, BlockCapPolicy::Never),
+      cap_grid_dim_x(1234, 0, stream, BlockCapPolicy::OverflowOnly),
+      uint32_t{1234});
+  EXPECT_EQ(
+      cap_grid_dim_x(1234, -1, stream, BlockCapPolicy::OverflowOnly),
+      uint32_t{1234});
+  EXPECT_EQ(
+      cap_grid_dim_x_with_yz_blocks(
+          1234, 1, 0, stream, BlockCapPolicy::OverflowOnly),
+      uint32_t{1234});
+  EXPECT_EQ(
+      cap_grid_dim_x_with_yz_blocks(
+          1234, 1, -1, stream, BlockCapPolicy::OverflowOnly),
       uint32_t{1234});
 }
 
-TEST(CapGridDimXTest, FloorsNonPositiveCountsToOne) {
+TEST(CapGridDimensionTest, DerivesOneDimensionalGridX) {
   const auto stream = at::cuda::getCurrentCUDAStream();
 
-  // grid.x must be >= 1; a zero or negative (e.g. int-overflowed) count is
-  // floored to 1 rather than wrapping to a huge value via the uint32_t cast.
   EXPECT_EQ(
-      cap_grid_dim_x(0, 1024, stream, BlockCapPolicy::Never), uint32_t{1});
+      cap_grid_dim_x_from_workload(1025, 1024, stream, BlockCapPolicy::Never),
+      uint32_t{2});
+}
+
+TEST(CapGridDimensionTest, AccountsForFixedGridPlane) {
+  const auto stream = at::cuda::getCurrentCUDAStream();
+  constexpr int64_t kThreadsPerBlock = 1;
+  constexpr int64_t kFixedGridPlane = 65537;
+  constexpr int64_t kLastValidBlocks = 65535;
+  constexpr int64_t kFirstInvalidBlocks = 65536;
+  static_assert(
+      kLastValidBlocks * kFixedGridPlane * kThreadsPerBlock ==
+      kMaxThreadsPerLaunch);
+  static_assert(
+      kFirstInvalidBlocks * kFixedGridPlane * kThreadsPerBlock >
+      kMaxThreadsPerLaunch);
+
+#ifdef USE_ROCM
+  const auto expected_overflow_cap = static_cast<uint32_t>(std::min<int64_t>(
+      kLastValidBlocks,
+      static_cast<int64_t>(MAX_THREAD_BLOCKS_FACTOR) *
+          at::cuda::getDeviceProperties(stream.device_index())
+              ->multiProcessorCount));
   EXPECT_EQ(
-      cap_grid_dim_x(-1, 1024, stream, BlockCapPolicy::Never), uint32_t{1});
+      cap_grid_dim_x_with_yz_blocks(
+          kLastValidBlocks, kThreadsPerBlock, kFixedGridPlane, stream),
+      kLastValidBlocks);
+  EXPECT_EQ(
+      cap_grid_dim_x_with_yz_blocks(
+          kFirstInvalidBlocks, kThreadsPerBlock, kFixedGridPlane, stream),
+      expected_overflow_cap);
+  EXPECT_EQ(
+      cap_grid_dim_y_with_xz_blocks(
+          kFirstInvalidBlocks, kThreadsPerBlock, kFixedGridPlane, stream),
+      expected_overflow_cap);
+#else
+  EXPECT_EQ(
+      cap_grid_dim_x_with_yz_blocks(
+          kFirstInvalidBlocks, kThreadsPerBlock, kFixedGridPlane, stream),
+      kFirstInvalidBlocks);
+  EXPECT_EQ(
+      cap_grid_dim_y_with_xz_blocks(
+          kFirstInvalidBlocks, kThreadsPerBlock, kFixedGridPlane, stream),
+      static_cast<uint32_t>(kMaxGridDimY));
+#endif
+}
+
+TEST(CapGridDimensionTest, RejectsUnrepairableGridPlaneOnRocm) {
+  const auto stream = at::cuda::getCurrentCUDAStream();
+  constexpr int64_t kThreadsPerBlock = 1024;
+  constexpr int64_t kGridPlaneBlocks = 1LL << 22;
+
+#ifdef USE_ROCM
+  EXPECT_THROW(
+      cap_grid_dim_x_with_yz_blocks(
+          1, kThreadsPerBlock, kGridPlaneBlocks, stream),
+      c10::Error);
+  EXPECT_THROW(
+      cap_grid_dim_x_with_yz_blocks(
+          1, kThreadsPerBlock, kGridPlaneBlocks, stream, BlockCapPolicy::Never),
+      c10::Error);
+#else
+  EXPECT_EQ(
+      cap_grid_dim_x_with_yz_blocks(
+          1, kThreadsPerBlock, kGridPlaneBlocks, stream),
+      uint32_t{1});
+#endif
+}
+
+TEST(CapGridDimensionTest, NeverSkipsRepairableRocmCap) {
+  const auto stream = at::cuda::getCurrentCUDAStream();
+  constexpr int64_t kThreadsPerBlock = 1;
+  constexpr int64_t kFixedGridPlane = 65537;
+  constexpr int64_t kFirstInvalidBlocks = 65536;
+
+  EXPECT_EQ(
+      cap_grid_dim_x_with_yz_blocks(
+          kFirstInvalidBlocks,
+          kThreadsPerBlock,
+          kFixedGridPlane,
+          stream,
+          BlockCapPolicy::Never),
+      kFirstInvalidBlocks);
+}
+
+TEST(CapGridDimensionTest, OverflowOnlyPreservesPerformanceCapOnRocm) {
+  const auto stream = at::cuda::getCurrentCUDAStream();
+  const auto performance_cap = static_cast<uint32_t>(
+      MAX_THREAD_BLOCKS_FACTOR *
+      at::cuda::getDeviceProperties(stream.device_index())
+          ->multiProcessorCount);
+
+#ifdef USE_ROCM
+  EXPECT_EQ(cap_grid_dim_x(kMaxGridDimX, 1024, stream), performance_cap);
+#else
+  EXPECT_EQ(
+      cap_grid_dim_x(kMaxGridDimX, 1024, stream),
+      static_cast<uint32_t>(kMaxGridDimX));
+#endif
+}
+
+TEST(CapGridDimensionTest, AlwaysAppliesPerformanceCap) {
+  const auto stream = at::cuda::getCurrentCUDAStream();
+  const auto performance_cap = static_cast<uint32_t>(
+      MAX_THREAD_BLOCKS_FACTOR *
+      at::cuda::getDeviceProperties(stream.device_index())
+          ->multiProcessorCount);
+
+  EXPECT_EQ(
+      cap_grid_dim_x(kMaxGridDimX, 1, stream, BlockCapPolicy::Always),
+      performance_cap);
+}
+
+TEST(CapGridDimensionTest, AlwaysAppliesRocmSafetyCap) {
+  const auto stream = at::cuda::getCurrentCUDAStream();
+  constexpr int64_t kThreadsPerBlock = 1024;
+  constexpr int64_t kFixedGridPlane = int64_t{1} << 20;
+  constexpr int64_t kRequestedBlocks = 4;
+
+#ifdef USE_ROCM
+  EXPECT_EQ(
+      cap_grid_dim_x_with_yz_blocks(
+          kRequestedBlocks,
+          kThreadsPerBlock,
+          kFixedGridPlane,
+          stream,
+          BlockCapPolicy::Always),
+      uint32_t{3});
+#else
+  EXPECT_EQ(
+      cap_grid_dim_x_with_yz_blocks(
+          kRequestedBlocks,
+          kThreadsPerBlock,
+          kFixedGridPlane,
+          stream,
+          BlockCapPolicy::Always),
+      uint32_t{4});
+#endif
 }
 
 } // namespace fbgemm_gpu::utils::cuda


### PR DESCRIPTION
Summary:
NOTE: No linked task. Please associate a task with this diff.

Add multidimensional grid-cap helpers that separately account for the selected grid dimension, per-block threads, and unchanged grid plane. Preserve the inclusive ROCm `UINT32_MAX` thread boundary, legacy nonpositive-input handling, and the overflow-path occupancy cap.

Document and test all three `BlockCapPolicy` modes, including the intentional `Never` behavior and the ROCm safety cap applied by `Always`.

Reviewed By: jianyuh

Differential Revision: D116715214


