### PR TITLE
Backward kernel atomic add optimizations (#6272)

### DIFF
--- a/fbgemm_gpu/FbgemmGpu.cmake
+++ b/fbgemm_gpu/FbgemmGpu.cmake
@@ -116,6 +116,7 @@ if(NOT FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_CPU)
       src/sparse_ops/sparse_compute_frequency_sequence.cu
       src/sparse_ops/sparse_expand_into_jagged_permute.cu
       src/sparse_ops/sparse_group_index.cu
+      src/sparse_ops/sparse_group_index_segment_reduce.cu
       src/sparse_ops/sparse_index_add.cu
       src/sparse_ops/sparse_index_select.cu
       src/sparse_ops/sparse_invert_permute.cu

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -1150,6 +1150,24 @@ void group_index_select_or_add_cuda(
     const bool use_cache,
     const bool use_packed_rows);
 
+#ifdef USE_ROCM
+// Reduces sorted grouped index-add inputs in bounded chunks. Single-chunk rows
+// have one writer; longer rows use one atomic add per chunk and column.
+void group_index_add_2d_segment_cuda(
+    const int64_t* grad_output_ptrs,
+    const int64_t* grad_input_ptrs,
+    const int64_t* sorted_indices_ptrs,
+    const int64_t* reverse_indices_ptrs,
+    const int64_t* row_offsets_group,
+    const int32_t* num_cols_group,
+    const c10::ScalarType& input_scalar_type,
+    const c10::ScalarType& indices_scalar_type,
+    const c10::DeviceIndex& device,
+    const int64_t num_work_rows,
+    const int64_t total_num_rows,
+    const int64_t group_size);
+#endif
+
 int get_group_index_select_cols_per_warp();
 
 int get_group_index_select_unroll_factor();

--- a/fbgemm_gpu/src/sparse_ops/sparse_group_index_segment_reduce.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_group_index_segment_reduce.cu
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef USE_ROCM
+
+#include <algorithm>
+#include <limits>
+
+#include <ATen/AccumulateType.h>
+
+#include "common.cuh"
+
+namespace fbgemm_gpu {
+namespace {
+
+constexpr int64_t kSegmentReduceChunkSize = 512;
+
+template <typename value_t>
+__device__ __forceinline__ int64_t
+lower_bound(const value_t* values, const int64_t size, const int64_t target) {
+  int64_t first = 0;
+  int64_t count = size;
+  while (count > 0) {
+    const int64_t step = count / 2;
+    const int64_t current = first + step;
+    if (static_cast<int64_t>(values[current]) < target) {
+      first = current + 1;
+      count -= step + 1;
+    } else {
+      count = step;
+    }
+  }
+  return first;
+}
+
+__device__ __forceinline__ int64_t find_segment(
+    const int64_t* offsets,
+    const int64_t num_segments,
+    const int64_t position) {
+  int64_t first = 0;
+  int64_t count = num_segments + 1;
+  while (count > 0) {
+    const int64_t step = count / 2;
+    const int64_t current = first + step;
+    if (offsets[current] <= position) {
+      first = current + 1;
+      count -= step + 1;
+    } else {
+      count = step;
+    }
+  }
+  return first - 1;
+}
+
+template <typename index_t>
+__global__ void compute_segment_metadata_kernel(
+    const int64_t* sorted_indices_ptrs,
+    const int64_t* row_offsets_group,
+    int64_t* row_starts,
+    int64_t* row_lengths,
+    int64_t* chunks_per_row,
+    const int64_t num_work_rows,
+    const int64_t total_num_rows,
+    const int64_t group_size) {
+  for (int64_t global_row =
+           static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       global_row < total_num_rows;
+       global_row += static_cast<int64_t>(gridDim.x) * blockDim.x) {
+    const int64_t group =
+        find_segment(row_offsets_group, group_size, global_row);
+    const int64_t local_row = global_row - row_offsets_group[group];
+    const auto* sorted_indices =
+        reinterpret_cast<const index_t*>(sorted_indices_ptrs[group]);
+    const int64_t begin = lower_bound(sorted_indices, num_work_rows, local_row);
+    const int64_t end =
+        lower_bound(sorted_indices, num_work_rows, local_row + 1);
+    const int64_t length = end - begin;
+
+    row_starts[global_row] = begin;
+    row_lengths[global_row] = length;
+    chunks_per_row[global_row] =
+        (length + kSegmentReduceChunkSize - 1) / kSegmentReduceChunkSize;
+  }
+}
+
+template <typename scalar_t, typename acc_t>
+__global__ void group_index_add_segment_reduce_kernel(
+    const int64_t* grad_output_ptrs,
+    const int64_t* grad_input_ptrs,
+    const int64_t* reverse_indices_ptrs,
+    const int64_t* row_offsets_group,
+    const int32_t* num_cols_group,
+    const int64_t* row_starts,
+    const int64_t* row_lengths,
+    const int64_t* chunk_offsets,
+    const int64_t total_num_rows,
+    const int64_t group_size,
+    const int64_t max_chunks) {
+  const int64_t actual_chunks = chunk_offsets[total_num_rows];
+  for (int64_t chunk = blockIdx.x; chunk < max_chunks; chunk += gridDim.x) {
+    if (chunk >= actual_chunks) {
+      break;
+    }
+
+    const int64_t global_row =
+        find_segment(chunk_offsets, total_num_rows, chunk);
+    const int64_t group =
+        find_segment(row_offsets_group, group_size, global_row);
+    const int64_t local_row = global_row - row_offsets_group[group];
+    const int64_t row_chunk = chunk - chunk_offsets[global_row];
+    const int64_t begin =
+        row_starts[global_row] + row_chunk * kSegmentReduceChunkSize;
+    const int64_t row_end = row_starts[global_row] + row_lengths[global_row];
+    const int64_t chunk_end = begin + kSegmentReduceChunkSize;
+    const int64_t end = chunk_end < row_end ? chunk_end : row_end;
+    const bool single_chunk =
+        chunk_offsets[global_row + 1] - chunk_offsets[global_row] == 1;
+    const int64_t num_cols = num_cols_group[group];
+    const auto* grad_output =
+        reinterpret_cast<const scalar_t*>(grad_output_ptrs[group]);
+    auto* grad_input = reinterpret_cast<acc_t*>(grad_input_ptrs[group]);
+    const auto* reverse_indices =
+        reinterpret_cast<const int64_t*>(reverse_indices_ptrs[group]);
+
+    for (int64_t col = threadIdx.x; col < num_cols; col += blockDim.x) {
+      acc_t sum = 0;
+      for (int64_t sorted_pos = begin; sorted_pos < end; ++sorted_pos) {
+        const int64_t source_row = reverse_indices[sorted_pos];
+        sum += static_cast<acc_t>(grad_output[source_row * num_cols + col]);
+      }
+
+      auto* output = grad_input + local_row * num_cols + col;
+      if (single_chunk) {
+        *output = sum;
+      } else {
+        gpuAtomicAddNoReturn(output, sum);
+      }
+    }
+  }
+}
+
+} // namespace
+
+DLL_PUBLIC void group_index_add_2d_segment_cuda(
+    const int64_t* grad_output_ptrs,
+    const int64_t* grad_input_ptrs,
+    const int64_t* sorted_indices_ptrs,
+    const int64_t* reverse_indices_ptrs,
+    const int64_t* row_offsets_group,
+    const int32_t* num_cols_group,
+    const c10::ScalarType& input_scalar_type,
+    const c10::ScalarType& indices_scalar_type,
+    const c10::DeviceIndex& device,
+    const int64_t num_work_rows,
+    const int64_t total_num_rows,
+    const int64_t group_size) {
+  if (num_work_rows == 0 || total_num_rows == 0 || group_size == 0) {
+    return;
+  }
+
+  TORCH_CHECK(
+      total_num_rows < std::numeric_limits<int32_t>::max(),
+      "group_index_add_2d_segment_cuda supports fewer than INT_MAX output rows");
+  TORCH_CHECK(
+      num_work_rows <= std::numeric_limits<int32_t>::max(),
+      "group_index_add_2d_segment_cuda supports at most INT_MAX input rows");
+  TORCH_CHECK(
+      group_size <= std::numeric_limits<int64_t>::max() / num_work_rows,
+      "group_index_add_2d_segment_cuda work size overflow");
+
+  at::cuda::OptionalCUDAGuard device_guard(device);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+  const auto metadata_options =
+      at::TensorOptions().device(at::kCUDA, device).dtype(at::kLong);
+  auto row_starts = at::empty({total_num_rows}, metadata_options);
+  auto row_lengths = at::empty({total_num_rows}, metadata_options);
+  auto chunks_per_row = at::empty({total_num_rows}, metadata_options);
+
+  constexpr uint32_t metadata_threads = 256;
+  const uint32_t metadata_blocks =
+      utils::cuda::cap_grid_dim_x(total_num_rows, metadata_threads, stream);
+  AT_DISPATCH_INDEX_TYPES(
+      indices_scalar_type, "group_index_add_2d_segment_metadata", [&] {
+        FBGEMM_LAUNCH_KERNEL(
+            (compute_segment_metadata_kernel<index_t>),
+            metadata_blocks,
+            metadata_threads,
+            0,
+            stream,
+            sorted_indices_ptrs,
+            row_offsets_group,
+            row_starts.data_ptr<int64_t>(),
+            row_lengths.data_ptr<int64_t>(),
+            chunks_per_row.data_ptr<int64_t>(),
+            num_work_rows,
+            total_num_rows,
+            group_size);
+      });
+
+  const auto chunk_offsets = asynchronous_complete_cumsum_gpu(chunks_per_row);
+  const int64_t total_num_indices = group_size * num_work_rows;
+  const int64_t max_chunks = total_num_rows +
+      (total_num_indices + kSegmentReduceChunkSize - 1) /
+          kSegmentReduceChunkSize;
+  const int64_t max_blocks =
+      static_cast<int64_t>(
+          at::cuda::getCurrentDeviceProperties()->multiProcessorCount) *
+      8;
+  const uint32_t reduce_blocks =
+      static_cast<uint32_t>(std::min(max_chunks, max_blocks));
+  constexpr uint32_t reduce_threads = 256;
+
+  FBGEMM_DISPATCH_FLOATING_TYPES(
+      input_scalar_type, "group_index_add_2d_segment_reduce", [&] {
+        using acc_t = at::acc_type<scalar_t, true>;
+        FBGEMM_LAUNCH_KERNEL(
+            (group_index_add_segment_reduce_kernel<scalar_t, acc_t>),
+            reduce_blocks,
+            reduce_threads,
+            0,
+            stream,
+            grad_output_ptrs,
+            grad_input_ptrs,
+            reverse_indices_ptrs,
+            row_offsets_group,
+            num_cols_group,
+            row_starts.const_data_ptr<int64_t>(),
+            row_lengths.const_data_ptr<int64_t>(),
+            chunk_offsets.const_data_ptr<int64_t>(),
+            total_num_rows,
+            group_size,
+            max_chunks);
+      });
+}
+
+} // namespace fbgemm_gpu
+
+#endif // USE_ROCM

--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_gpu.cpp
@@ -23,6 +23,7 @@
 #include <torch/library.h>
 #include <torch/script.h>
 #include <cstdint>
+#include <limits>
 #include <stdexcept> // for logic_error
 #include <utility>
 
@@ -601,9 +602,17 @@ static torch::autograd::variable_list group_index_select_dim0_backward_impl_gpu(
   }
 
   // Allocate Tensor for ptrs of grad output and input, and indices
+#ifdef USE_ROCM
+  // The segment-reduction path also needs device-visible destination-row
+  // offsets. Keep them in the existing packed argument transfer.
+  Tensor args_tensor = at::empty(
+      {group_size * 6 + 1},
+      at::TensorOptions().dtype(at::kLong).pinned_memory(true));
+#else
   Tensor args_tensor = at::empty(
       {group_size * 5},
       at::TensorOptions().dtype(at::kLong).pinned_memory(true));
+#endif
   // Ensure that args_tensor is contiguous
   TORCH_CHECK(
       args_tensor.is_contiguous(), "Tensor args_tensor must be contiguous.");
@@ -616,6 +625,19 @@ static torch::autograd::variable_list group_index_select_dim0_backward_impl_gpu(
       args_tensor.data_ptr<int64_t>() + 3 * group_size;
   int64_t* reverse_indices_ptrs =
       args_tensor.data_ptr<int64_t>() + 4 * group_size;
+#ifdef USE_ROCM
+  int64_t* row_offsets_group =
+      args_tensor.mutable_data_ptr<int64_t>() + 5 * group_size;
+  row_offsets_group[0] = 0;
+
+  constexpr int64_t kMinSegmentReduceDupFactor = 32;
+  constexpr int64_t kMinSegmentReduceCols = 32;
+  const auto input_scalar_type = fwd_input.scalar_type();
+  bool use_segment_reduce = group_size > 0 && num_input_rows > 0 &&
+      (input_scalar_type == at::kHalf || input_scalar_type == at::kBFloat16 ||
+       input_scalar_type == at::kFloat);
+  int64_t total_num_rows = 0;
+#endif
 
   int64_t group_grad_input_numel = 0;
   std::vector<int64_t> grad_input_numels;
@@ -634,10 +656,32 @@ static torch::autograd::variable_list group_index_select_dim0_backward_impl_gpu(
     grad_output_contigs.push_back(grad.expect_contiguous());
 
     // Compute the total number of elements for all grad_inputs
+#ifdef USE_ROCM
+    const int64_t num_destination_rows = output_shape_group[i * output_dim];
+    int64_t grad_input_numel = num_destination_rows;
+#else
     int64_t grad_input_numel = output_shape_group[i * output_dim];
+#endif
     for (auto j = (i * output_dim) + 1; j < (i + 1) * output_dim; j++) {
       grad_input_numel *= output_shape_group[j];
     }
+#ifdef USE_ROCM
+    const auto& indices = indices_group[i];
+    use_segment_reduce = use_segment_reduce &&
+        grad.scalar_type() == input_scalar_type &&
+        indices.numel() == num_input_rows &&
+        indices.scalar_type() == first_indices.scalar_type() &&
+        (indices.scalar_type() == at::kInt ||
+         indices.scalar_type() == at::kLong) &&
+        grad.numel() / num_input_rows >= kMinSegmentReduceCols &&
+        num_destination_rows > 0 &&
+        num_input_rows / num_destination_rows >= kMinSegmentReduceDupFactor;
+    use_segment_reduce = use_segment_reduce &&
+        total_num_rows <
+            std::numeric_limits<int32_t>::max() - num_destination_rows;
+    total_num_rows += num_destination_rows;
+    row_offsets_group[i + 1] = total_num_rows;
+#endif
     grad_input_numels.push_back(grad_input_numel);
     group_grad_input_numel += grad_input_numel;
 
@@ -646,12 +690,24 @@ static torch::autograd::variable_list group_index_select_dim0_backward_impl_gpu(
         reinterpret_cast<int64_t>(grad_output_contigs[i]->const_data_ptr());
   }
 
-  // Allocate a big tensor to avoid calling many small elementwise kernels
+  // Allocate a big tensor to avoid calling many small elementwise kernels.
   const auto group_grad_input =
       at::zeros({group_grad_input_numel}, fwd_input.options());
   TORCH_CHECK(
       group_grad_input.is_contiguous(),
       "Tensor group_grad_input must be contiguous.");
+#ifdef USE_ROCM
+  // Multi-chunk Half/BFloat16 rows must accumulate atomically in FP32. Native
+  // 16-bit atomics can lose concurrent updates, and casting every chunk before
+  // the atomic also discards the accuracy gained by register accumulation.
+  const bool use_fp32_segment_accum = use_segment_reduce &&
+      (input_scalar_type == at::kHalf || input_scalar_type == at::kBFloat16);
+  const auto segment_grad_input = use_fp32_segment_accum
+      ? at::zeros(
+            {group_grad_input_numel}, fwd_input.options().dtype(at::kFloat))
+      : group_grad_input;
+  auto segment_output_group = segment_grad_input.split(grad_input_numels, 0);
+#endif
 
   // Split to output_group
   auto output_group = group_grad_input.split(grad_input_numels, 0);
@@ -675,8 +731,13 @@ static torch::autograd::variable_list group_index_select_dim0_backward_impl_gpu(
         " of ",
         group_size,
         " must be contiguous.");
+#ifdef USE_ROCM
+    grad_input_ptrs[i] =
+        reinterpret_cast<int64_t>(segment_output_group[i].const_data_ptr());
+#else
     grad_input_ptrs[i] =
         reinterpret_cast<int64_t>(output_group[i].const_data_ptr());
+#endif
 
     // 2) Add group_size gradients for inputs
     outputs.push_back(output_group[i]);
@@ -693,7 +754,7 @@ static torch::autograd::variable_list group_index_select_dim0_backward_impl_gpu(
   at::Tensor sort_original_positions;
   at::Tensor all_sorted_indices;
   at::Tensor all_reverse_indices;
-  int64_t sort_num_items = static_cast<int64_t>(indices_group[0].numel());
+  const int64_t sort_num_items = static_cast<int64_t>(indices_group[0].numel());
   // Choose the sort backend by per-segment size:
   //   * LARGE segments (num_items > k_sort_merge_threshold): per-group batch
   //     path (radix_sort_pairs<sort_config>, which rocprim runs as onesweep
@@ -703,7 +764,8 @@ static torch::autograd::variable_list group_index_select_dim0_backward_impl_gpu(
   //     launches.
   const bool use_segmented_sort =
       static_cast<size_t>(sort_num_items) <= rocm::k_sort_merge_threshold;
-  if (use_sorted_indices) {
+  const bool sort_indices_for_bwd = use_sorted_indices || use_segment_reduce;
+  if (sort_indices_for_bwd) {
     const auto stream = at::cuda::getCurrentCUDAStream();
     const size_t temp_bytes = use_segmented_sort
         ? rocm::get_segmented_sort_temp_storage_bytes(
@@ -747,7 +809,7 @@ static torch::autograd::variable_list group_index_select_dim0_backward_impl_gpu(
     reverse_indices_ptrs[i] = 0;
   }
 #ifdef USE_ROCM
-  if (use_sorted_indices) {
+  if (sort_indices_for_bwd) {
     // Fill sorted/reverse ptr tables via direct pointer arithmetic.
     const int64_t idx_elem_bytes = first_indices.element_size();
     auto* sorted_base = static_cast<char*>(all_sorted_indices.data_ptr());
@@ -807,6 +869,7 @@ static torch::autograd::variable_list group_index_select_dim0_backward_impl_gpu(
   args_tensor = args_tensor.to(first_indices.device(), /*non_blocking=*/true);
 
 #ifdef USE_ROCM
+  row_offsets_group = args_tensor.data_ptr<int64_t>() + 5 * group_size;
   // enable_cache_and_contig is computed in the forward (see the heuristic
   // there)
   const bool use_contiguous_warps = enable_cache_and_contig;
@@ -816,27 +879,47 @@ static torch::autograd::variable_list group_index_select_dim0_backward_impl_gpu(
   constexpr bool use_cache = false;
 #endif
 
-  group_index_select_or_add_cuda(
-      args_tensor.const_data_ptr<int64_t>(),
-      args_tensor.const_data_ptr<int64_t>() + group_size,
-      args_tensor.const_data_ptr<int64_t>() + 2 * group_size,
-      use_sorted_indices ? args_tensor.data_ptr<int64_t>() + 3 * group_size
-                         : nullptr,
-      use_sorted_indices ? args_tensor.data_ptr<int64_t>() + 4 * group_size
-                         : nullptr,
-      warp_offsets_group,
-      num_cols_group,
-      fwd_input.scalar_type(),
-      first_indices.scalar_type(),
-      fwd_input.device().index(),
-      num_input_rows,
-      total_num_warps,
-      group_size,
-      /*use_index_select=*/false,
-      use_var_cols,
-      use_contiguous_warps,
-      use_cache,
-      use_packed_rows);
+#ifdef USE_ROCM
+  if (use_segment_reduce) {
+    group_index_add_2d_segment_cuda(
+        args_tensor.const_data_ptr<int64_t>(),
+        args_tensor.const_data_ptr<int64_t>() + group_size,
+        args_tensor.const_data_ptr<int64_t>() + 3 * group_size,
+        args_tensor.const_data_ptr<int64_t>() + 4 * group_size,
+        row_offsets_group,
+        num_cols_group,
+        fwd_input.scalar_type(),
+        first_indices.scalar_type(),
+        fwd_input.device().index(),
+        num_input_rows,
+        total_num_rows,
+        group_size);
+    if (use_fp32_segment_accum) {
+      group_grad_input.copy_(segment_grad_input);
+    }
+  } else
+#endif
+    group_index_select_or_add_cuda(
+        args_tensor.const_data_ptr<int64_t>(),
+        args_tensor.const_data_ptr<int64_t>() + group_size,
+        args_tensor.const_data_ptr<int64_t>() + 2 * group_size,
+        use_sorted_indices ? args_tensor.data_ptr<int64_t>() + 3 * group_size
+                           : nullptr,
+        use_sorted_indices ? args_tensor.data_ptr<int64_t>() + 4 * group_size
+                           : nullptr,
+        warp_offsets_group,
+        num_cols_group,
+        fwd_input.scalar_type(),
+        first_indices.scalar_type(),
+        fwd_input.device().index(),
+        num_input_rows,
+        total_num_warps,
+        group_size,
+        /*use_index_select=*/false,
+        use_var_cols,
+        use_contiguous_warps,
+        use_cache,
+        use_packed_rows);
 
   return outputs;
 }

--- a/fbgemm_gpu/test/sparse/amd/index_select_amd_test.py
+++ b/fbgemm_gpu/test/sparse/amd/index_select_amd_test.py
@@ -7,10 +7,86 @@
 
 # pyre-strict
 
+import math
 import unittest
 
 import fbgemm_gpu.sparse_ops  # noqa: F401
 import torch
+
+# Smallest embedding-row count the filler indices below are valid for.
+MIN_EMBEDDING_ROWS = 6
+
+
+def _make_unsorted_indices(
+    duplicate_run_length: int,
+    group_id: int,
+    index_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Build unsorted indices with a known duplicate run after sorting.
+
+    The filler values deliberately skip rows so that, once sorted, at least one
+    zero-length row sits BETWEEN two populated rows. That is the interior case
+    for find_segment(): it returns first - 1 from an upper-bound scan, so a
+    chunk boundary landing on a duplicate offset (chunk_offsets[r] ==
+    chunk_offsets[r + 1]) must still resolve to the right row. Skipped rows only
+    at the tail never own a chunk and would leave that branch uncovered.
+
+    Requires num_embedding_rows >= MIN_EMBEDDING_ROWS.
+    """
+    num_fillers = 4
+    indices = torch.zeros(duplicate_run_length + num_fillers, dtype=index_dtype)
+    filler_positions = [
+        0,
+        indices.numel() // 3,
+        indices.numel() // 2,
+        indices.numel() - 1,
+    ]
+    filler_values = [
+        2 + group_id % 2,
+        1,
+        5,
+        1,
+    ]
+    indices[filler_positions] = torch.tensor(filler_values, dtype=index_dtype)
+    return indices
+
+
+def _make_grad_output(
+    num_indices: int,
+    num_cols: int,
+    dtype: torch.dtype,
+    group_id: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return target-dtype gradients and their exact FP64 values."""
+    grad = torch.full((num_indices, num_cols), 0.125, dtype=dtype)
+    filler_positions = [0, num_indices // 3, num_indices // 2, num_indices - 1]
+    cols = torch.arange(num_cols, dtype=dtype)
+    for filler_id, position in enumerate(filler_positions):
+        grad[position] = (
+            0.25 + (group_id * 0.125) + (filler_id * 0.125) + cols.remainder(4)
+        )
+    return grad, grad.to(torch.float64)
+
+
+def _grad_tolerance(dtype: torch.dtype, num_indices: int) -> float:
+    """Relative tolerance derived from `dtype`, not from a flat constant.
+
+    The kernel accumulates in FP32 (at::acc_type) and rounds once into `dtype`,
+    so a correct result lands within a ULP of an FP64 reference plus whatever the
+    FP32 accumulation order costs over the duplicate run. Deriving the bound from
+    the format matters most for BF16, whose own resolution is ~0.4%: a flat 1e-2
+    is over two ULPs and can absorb several dropped contributions.
+    """
+    return (
+        torch.finfo(dtype).eps + math.sqrt(num_indices) * torch.finfo(torch.float32).eps
+    )
+
+
+def _unselected_rows_mask(indices: torch.Tensor, num_rows: int) -> torch.Tensor:
+    """Rows that no index selects, derived from the indices themselves."""
+    selected = torch.zeros(num_rows, dtype=torch.bool)
+    selected[indices.long()] = True
+    return ~selected
 
 
 @unittest.skipUnless(
@@ -46,3 +122,274 @@ class IndexSelectAmdTest(unittest.TestCase):
             rtol=0,
             msg="grad_input mismatch at the ROCm column-tile cache boundary",
         )
+
+    def _assert_grad_matches_reference(
+        self,
+        grad: torch.Tensor,
+        expected_fp64: torch.Tensor,
+        indices_cpu: torch.Tensor,
+        dtype: torch.dtype,
+    ) -> None:
+        """Compare a flattened grad against an FP64 reference, then check zeros.
+
+        expected_fp64 is NOT downcast to `dtype`: rounding the reference first
+        throws away the precision the comparison is supposed to be measuring.
+        """
+        num_rows, _ = expected_fp64.shape
+        tolerance = _grad_tolerance(dtype, indices_cpu.numel())
+        torch.testing.assert_close(
+            grad.double(),
+            expected_fp64,
+            atol=tolerance * float(expected_fp64.abs().max()),
+            rtol=tolerance,
+        )
+        unselected = _unselected_rows_mask(indices_cpu, num_rows)
+        if bool(unselected.any()):
+            torch.testing.assert_close(
+                grad[unselected].double(),
+                torch.zeros_like(expected_fp64[unselected]),
+                atol=0,
+                rtol=0,
+                msg="rows selected by no index must have exactly zero gradient",
+            )
+
+    def _assert_group_index_select_backward(
+        self,
+        duplicate_run_length: int,
+        widths: list[int],
+        dtype: torch.dtype,
+        num_embedding_rows_group: list[int] | None = None,
+        index_dtype: torch.dtype = torch.long,
+        trailing_shapes: list[tuple[int, ...]] | None = None,
+    ) -> None:
+        """Run one grouped backward and check every group's gradient.
+
+        `widths` are FLATTENED column counts. `trailing_shapes` optionally gives
+        the N-D trailing dims behind each width, exercising the kernel's
+        reliance on input.reshape({input.size(0), -1}) to flatten them.
+        """
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        if num_embedding_rows_group is None:
+            num_embedding_rows_group = [8] * len(widths)
+        self.assertEqual(len(widths), len(num_embedding_rows_group))
+        if trailing_shapes is None:
+            trailing_shapes = [(width,) for width in widths]
+        self.assertEqual(len(widths), len(trailing_shapes))
+        input_group: list[torch.Tensor] = []
+        indices_group: list[torch.Tensor] = []
+        grad_group: list[torch.Tensor] = []
+        expected_group: list[torch.Tensor] = []
+        indices_cpu_group: list[torch.Tensor] = []
+
+        for group_id, (num_cols, num_embedding_rows, trailing) in enumerate(
+            zip(widths, num_embedding_rows_group, trailing_shapes)
+        ):
+            self.assertGreaterEqual(num_embedding_rows, MIN_EMBEDDING_ROWS)
+            self.assertEqual(math.prod(trailing), num_cols)
+            indices_cpu = _make_unsorted_indices(
+                duplicate_run_length,
+                group_id,
+                index_dtype,
+            )
+            num_indices = indices_cpu.numel()
+            grad_cpu, grad_fp64 = _make_grad_output(
+                num_indices, num_cols, dtype, group_id
+            )
+            expected = torch.zeros(
+                num_embedding_rows, num_cols, dtype=torch.float64
+            ).index_add_(0, indices_cpu.long(), grad_fp64)
+
+            input_group.append(
+                torch.randn(
+                    num_embedding_rows,
+                    *trailing,
+                    device=device,
+                    dtype=dtype,
+                ).requires_grad_(True)
+            )
+            indices_group.append(indices_cpu.to(device))
+            grad_group.append(grad_cpu.reshape(num_indices, *trailing).to(device))
+            expected_group.append(expected)
+            indices_cpu_group.append(indices_cpu)
+
+        output_group = torch.ops.fbgemm.group_index_select_dim0(
+            input_group, indices_group
+        )
+        torch.autograd.backward(output_group, grad_group)
+
+        for group_id, (input_tensor, expected, indices_cpu) in enumerate(
+            zip(input_group, expected_group, indices_cpu_group)
+        ):
+            with self.subTest(group_id=group_id, num_cols=widths[group_id]):
+                self.assertIsNotNone(input_tensor.grad)
+                assert input_tensor.grad is not None
+                self._assert_grad_matches_reference(
+                    input_tensor.grad.cpu().reshape(expected.shape),
+                    expected,
+                    indices_cpu,
+                    dtype,
+                )
+
+    def test_group_index_select_backward_segment_chunk_boundaries(self) -> None:
+        """Sweep ONLY the duplicate run length across the 512-wide chunk bound.
+
+        Width and dtype are held fixed so a failure here localises to the chunk
+        arithmetic; dtype and width get their own sweeps below.
+        """
+        for duplicate_run_length in [511, 512, 513, 1025]:
+            with self.subTest(duplicate_run_length=duplicate_run_length):
+                self._assert_group_index_select_backward(
+                    duplicate_run_length, [64], torch.float
+                )
+
+    def test_group_index_select_backward_dtypes(self) -> None:
+        """Sweep ONLY dtype, at a fixed multi-chunk run length and width."""
+        for dtype in [torch.float, torch.float16, torch.bfloat16]:
+            with self.subTest(dtype=dtype):
+                self._assert_group_index_select_backward(513, [64], dtype)
+
+    def test_group_index_select_backward_widths(self) -> None:
+        """Sweep ONLY the column width, including non-powers of two."""
+        for num_cols in [32, 64, 65, 127, 128]:
+            with self.subTest(num_cols=num_cols):
+                self._assert_group_index_select_backward(513, [num_cols], torch.float)
+
+    def test_group_index_select_backward_segment_branch_boundary(self) -> None:
+        """kMinSegmentReduceDupFactor = 32: 31 falls back, 32 is eligible."""
+        num_embedding_rows = 8
+        num_fillers = 4
+        for duplicate_factor in [31, 32]:
+            with self.subTest(duplicate_factor=duplicate_factor):
+                self._assert_group_index_select_backward(
+                    duplicate_run_length=(duplicate_factor * num_embedding_rows)
+                    - num_fillers,
+                    widths=[64],
+                    dtype=torch.float,
+                    num_embedding_rows_group=[num_embedding_rows],
+                )
+
+    def test_group_index_select_backward_segment_cols_boundary(self) -> None:
+        """kMinSegmentReduceCols = 32: 31 falls back, 32 is eligible.
+
+        Mirrors the duplication-factor boundary above for the other gate term.
+        The duplication factor is held well above its own threshold so that the
+        column width is the only thing deciding which path runs.
+        """
+        for num_cols in [31, 32]:
+            with self.subTest(num_cols=num_cols):
+                self._assert_group_index_select_backward(513, [num_cols], torch.float)
+
+    def test_group_index_select_backward_nd_input(self) -> None:
+        """N-D inputs: trailing dims are flattened into num_cols_group.
+
+        The kernel reads grad_output[source_row * num_cols + col] with num_cols
+        from input.reshape({input.size(0), -1}).size(1), so an (8, 8, 16) input
+        must behave exactly like a flattened 128-wide one.
+        """
+        self._assert_group_index_select_backward(
+            duplicate_run_length=513,
+            widths=[128],
+            dtype=torch.float,
+            trailing_shapes=[(8, 16)],
+        )
+
+    def test_group_index_select_backward_multiple_groups(self) -> None:
+        self._assert_group_index_select_backward(
+            duplicate_run_length=513,
+            widths=[32, 65, 128],
+            dtype=torch.bfloat16,
+            num_embedding_rows_group=[8, 9, 10],
+            index_dtype=torch.int32,
+        )
+
+    def test_group_index_select_backward_non_contiguous_inputs(self) -> None:
+        """Non-contiguous grad and indices must still produce exact gradients.
+
+        The ROCm segment-reduce gate deliberately does not test the caller's
+        layout: expect_contiguous() runs unconditionally, and the kernel consumes
+        grad_output_contigs and the sort outputs, never the tensors passed in
+        here. The grad shape below is the one that motivated dropping those
+        guards -- the backward of a torch.cat(..., dim=1) hands each input a
+        column slice whose row stride is the full concatenated width.
+
+        Sized to land in the segment path: 1029 indices over 8 rows is a
+        duplication factor of 128 (gate needs >= 32), 64 cols (needs >= 32), and
+        1029 spans three 512-wide chunks so the multi-chunk atomic branch runs.
+        """
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        dtype = torch.float
+        num_cols = 64
+        num_embedding_rows = 8
+        indices_cpu = _make_unsorted_indices(1025, 0, torch.long)
+        num_indices = indices_cpu.numel()
+        grad_cpu, grad_fp64 = _make_grad_output(num_indices, num_cols, dtype, 0)
+        expected = torch.zeros(
+            num_embedding_rows, num_cols, dtype=torch.float64
+        ).index_add_(0, indices_cpu, grad_fp64)
+
+        for name, noncontig_grad, noncontig_indices in [
+            ("grad", True, False),
+            ("indices", False, True),
+            ("both", True, True),
+        ]:
+            with self.subTest(name=name):
+                if noncontig_grad:
+                    # Middle column slice of a 3x-wide parent: strides
+                    # (3 * num_cols, 1), so neither side of the slice is empty.
+                    grad_parent = torch.zeros(
+                        num_indices, num_cols * 3, device=device, dtype=dtype
+                    )
+                    grad = grad_parent[:, num_cols : num_cols * 2]
+                    grad.copy_(grad_cpu.to(device))
+                else:
+                    grad = grad_cpu.to(device)
+
+                if noncontig_indices:
+                    # Every other element of a 2x-long parent: stride 2.
+                    index_parent = torch.zeros(
+                        num_indices * 2, device=device, dtype=torch.long
+                    )
+                    index_parent[::2] = indices_cpu.to(device)
+                    indices = index_parent[::2]
+                else:
+                    indices = indices_cpu.to(device)
+
+                # Guard against the case under test quietly disappearing.
+                self.assertEqual(grad.is_contiguous(), not noncontig_grad)
+                self.assertEqual(indices.is_contiguous(), not noncontig_indices)
+                self.assertEqual(indices.numel(), grad.size(0))
+
+                input_tensor = torch.randn(
+                    num_embedding_rows, num_cols, device=device, dtype=dtype
+                ).requires_grad_(True)
+                output_group = torch.ops.fbgemm.group_index_select_dim0(
+                    [input_tensor], [indices]
+                )
+                torch.autograd.backward(output_group, [grad])
+
+                self.assertIsNotNone(input_tensor.grad)
+                assert input_tensor.grad is not None
+                self._assert_grad_matches_reference(
+                    input_tensor.grad.cpu(), expected, indices_cpu, dtype
+                )
+
+    def test_group_index_select_backward_hot_row_accumulates_in_fp32(self) -> None:
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        num_indices = 4096
+        for dtype in [torch.float16, torch.bfloat16]:
+            with self.subTest(dtype=dtype):
+                input_tensor = torch.zeros(
+                    2, 64, device=device, dtype=dtype, requires_grad=True
+                )
+                indices = torch.zeros(num_indices, device=device, dtype=torch.long)
+                contribution = torch.tensor(0.1, device=device, dtype=dtype)
+
+                output = torch.ops.fbgemm.group_index_select_dim0(
+                    [input_tensor], [indices]
+                )[0]
+                output.backward(contribution.expand_as(output).contiguous())
+
+                expected = torch.zeros_like(input_tensor)
+                expected[0] = contribution.float() * num_indices
+                assert input_tensor.grad is not None
+                torch.testing.assert_close(input_tensor.grad, expected, atol=0, rtol=0)


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3163


# Summary
This optimizes the ROCm `group_index_select_dim0` backward path for highly duplicated/skewed indices. The existing grouped index-add kernel performs an atomic update for every selected row and column, which serializes heavily when many indices target the same embedding row.

The new path reuses the sorted indices and reverse positions, finds the sorted range for each destination row, and reduces that range in bounded 512-index chunks. Rows that fit in one chunk have a single writer and are stored directly; longer rows issue one atomic add per chunk and column instead of one per index and column. FP16/BF16 inputs accumulate through an FP32 temporary buffer before being cast back, avoiding lost concurrent 16-bit updates and preserving the accuracy of register accumulation. The existing segmented-vs-batched ROCm sort selection remains in place based on `k_sort_merge_threshold`.

# Eligibility gates

The segment-reduction path is compiled only for ROCm and is selected only when every group satisfies all of the following:

* The group and input are non-empty, with a positive destination-row count.
* Inputs/gradients use FP32, FP16, or BF16; every gradient matches the input dtype and is contiguous.
* Indices are contiguous INT32 or INT64 tensors, share the same dtype, and each contains `num_input_rows` entries.
* The row width is at least 32 columns.
* The average duplication factor is at least 32 (`num_input_rows / num_destination_rows >= 32`).
* The combined destination-row count fits the kernel's INT32 range; the kernel also validates input-row and work-size limits.

If any gate fails, backward falls back to the existing `group_index_select_or_add_cuda` implementation. This keeps NVIDIA behavior and lower-skew/smaller-width ROCm workloads unchanged.

# Performance
On the captured UFM-combo skewed shapes, the hottest backward cases **improve from 108.2 ms to 1.25 ms (~86x)** and **from 43.0 ms to 0.77 ms (~56x)**, while the non-targeted shapes remain stable.

Reviewed By: q10

Differential Revision: D118739790


