### PR TITLE
Symbolize fbgemm asmjit embedding kernels via a perf map (#6273)

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -66,6 +66,7 @@ def get_fbgemm_generic_srcs(with_base = False, msvc = False, buck = False):
         "src/GroupwiseConv.cc",
         "src/GroupwiseConvAcc32Avx2.cc",
         "src/GroupwiseConvAcc32Avx512.cc",
+        "src/JitPerfMap.cc",
         "src/PackAMatrix.cc",
         "src/PackAWithIm2Col.cc",
         "src/PackAWithQuantRowOffset.cc",

--- a/fbgemm_gpu/cmake/Fbgemm.cmake
+++ b/fbgemm_gpu/cmake/Fbgemm.cmake
@@ -14,6 +14,7 @@ set(fbgemm_sources_normal
   "${FBGEMM}/src/EmbeddingSpMDMNBit.cc"
   "${FBGEMM}/src/FbgemmBfloat16Convert.cc"
   "${FBGEMM}/src/FbgemmFloat16Convert.cc"
+  "${FBGEMM}/src/JitPerfMap.cc"
   "${FBGEMM}/src/QuantUtils.cc"
   "${FBGEMM}/src/RefImplementations.cc"
   "${FBGEMM}/src/RowWiseSparseAdagradFused.cc"

--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -20,6 +20,7 @@
 #include "./CodeCache.h" // @manual
 #include "./EmbeddingSpMDMAutovec.h" // @manual
 #include "./EmbeddingSpMDMSve.h"
+#include "./JitPerfMap.h" // @manual
 #include "./MaskAvx2.h" // @manual
 #include "./RefImplementations.h" // @manual
 #include "fbgemm/FbgemmEmbedding.h"
@@ -962,6 +963,31 @@ GenEmbeddingSpMDMLookup<
           std::cout << "Error: in fn add" << '\n';
           return nullptr;
         }
+
+        registerJitKernel(code, reinterpret_cast<const void*>(fn), [&] {
+          const char* inTypeName = is_8bit_in ? "u8"
+              : is_16bit_in                   ? (is_bf16_in ? "bf16" : "fp16")
+                                              : "fp32";
+          return embeddingKernelSymbol(
+              "EmbeddingSpMDM",
+              "in-" + std::string(inTypeName) + "_D-" +
+                  std::to_string(block_size),
+              {.indices64 = areIndices64b,
+               .offsets64 = std::is_same_v<offsetType, int64_t>,
+               .thread_local_cache = THREAD_LOCAL,
+               .avx512 = instSet == inst_set_t::avx512,
+               .prefetch = prefetch,
+               .output_stride = output_stride,
+               .input_stride = input_stride,
+               .weighted = has_weight,
+               .positional = is_weight_positional,
+               .normalize = normalize_by_lengths,
+               .lengths = !use_offsets,
+               .rowwise_sparse = ROWWISE_SPARSE,
+               .scale_bias_first = !scale_bias_last,
+               .fp16_out = is_fp16_out,
+               .bf16_out = is_bf16_out});
+        });
 
         return fn;
       });

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -18,6 +18,7 @@
 #include "./CodeCache.h" // @manual
 #include "./EmbeddingSpMDMAutovec.h" // @manual
 #include "./EmbeddingSpMDMSve.h" // @manual
+#include "./JitPerfMap.h" // @manual
 #include "./MaskAvx2.h" // @manual
 #include "./RefImplementations.h" // @manual
 #include "fbgemm/SimdUtils.h"
@@ -961,6 +962,29 @@ GenEmbeddingSpMDMNBitLookup<
           cout << "Error: in fn add" << '\n';
           return nullptr;
         }
+
+        registerJitKernel(code, reinterpret_cast<const void*>(fn), [&] {
+          return embeddingKernelSymbol(
+              "EmbeddingSpMDMNBit",
+              std::to_string(bit_rate) + "bit_D-" + std::to_string(block_size),
+              {.indices64 = areIndices64b,
+               .offsets64 = std::is_same_v<offsetType, int64_t>,
+               .thread_local_cache = THREAD_LOCAL,
+               .avx512 = instSet == inst_set_t::avx512,
+               .prefetch = prefetch,
+               .output_stride = output_stride,
+               .input_stride = input_stride,
+               .weighted = has_weight,
+               .positional = is_weight_positional,
+               .normalize = normalize_by_lengths,
+               .lengths = !use_offsets,
+               .rowwise_sparse = ROWWISE_SPARSE,
+               .scale_bias_first = !scale_bias_last,
+               // outType selects the instantiation, so a float-output kernel
+               // and a float16-output one of the same shape are distinct code.
+               .fp16_out = is_16bit_storage_v<outType> && !is_bf16_out,
+               .bf16_out = is_bf16_out});
+        });
 
 #if defined(FBGEMM_LOG_CODE)
         fclose(codeLogFile);

--- a/src/JitPerfMap.cc
+++ b/src/JitPerfMap.cc
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#define FBGEMM_EXPORTS
+
+#include "./JitPerfMap.h" // @manual
+
+#include <atomic>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <string_view>
+#include <thread>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#ifdef _MSC_VER
+#include <io.h>
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace fbgemm {
+
+namespace {
+
+// This file deliberately takes no userspace lock. fbgemm JITs from worker
+// threads, and a multithreaded process may fork at any point -- PyTorch's
+// DataLoader does exactly that. fork() clones only the calling thread, so a
+// mutex held by any other thread at that moment is inherited permanently
+// locked and the child deadlocks on its first registration. Instead the
+// descriptor is published through atomics and each record is handed to the
+// kernel as one O_APPEND write(), which is what serialises concurrent writers.
+// The one place threads do wait on each other -- electing which of them opens
+// the map -- is keyed on the pid, so a child never waits on a claim its parent
+// still holds.
+
+int currentPid() {
+#ifdef _MSC_VER
+  return _getpid();
+#else
+  return static_cast<int>(getpid());
+#endif
+}
+
+#ifndef _MSC_VER
+// Seconds since the epoch at which this process started, or 0 when that cannot
+// be determined. On Linux the mtime of /proc/self is exactly the process start
+// time, which is what distinguishes a map this process wrote from one left by
+// an earlier process that happened to hold the same pid.
+//
+// POSIX-only: the Windows path below has no staleness check, so defining this
+// unconditionally leaves an unused static function that -Werror rejects.
+std::time_t processStartTime() {
+#ifdef __linux__
+  struct stat st = {};
+  if (::stat("/proc/self", &st) == 0) {
+    return st.st_mtime;
+  }
+#endif
+  return 0;
+}
+#endif // _MSC_VER
+
+bool writeAll(int fd, const char* data, size_t len) {
+  while (len > 0) {
+#ifdef _MSC_VER
+    const int written = _write(fd, data, static_cast<unsigned int>(len));
+#else
+    const ssize_t written = ::write(fd, data, len);
+#endif
+    if (written <= 0) {
+      if (written < 0 && errno == EINTR) {
+        continue;
+      }
+      return false;
+    }
+    data += written;
+    len -= static_cast<size_t>(written);
+  }
+  return true;
+}
+
+// -1 before the first open. Written only by openPerfMap().
+std::atomic<int> perfMapFd{-1};
+std::atomic<int> perfMapPid{-1};
+// Claimed by the single thread that opens the map for a given pid, so no
+// descriptor is published while that thread may still be truncating.
+std::atomic<int> perfMapOpeningPid{-1};
+
+int openPerfMap(int pid) {
+  char path[64];
+  std::snprintf(path, sizeof(path), "/tmp/perf-%d.map", pid);
+
+#ifdef _MSC_VER
+  const int fd =
+      _open(path, _O_WRONLY | _O_CREAT | _O_APPEND, _S_IREAD | _S_IWRITE);
+  if (fd < 0) {
+    return -1;
+  }
+#else
+  // The path is predictable, so anyone able to create files in /tmp could
+  // pre-place a symlink and capture what a more privileged process writes.
+  // O_NOFOLLOW rejects a symlink at the final component; the fstat() below
+  // then rejects anything that is not a regular file we own and that only we
+  // can write, which covers a pre-created file or FIFO that O_NOFOLLOW allows.
+  // O_CLOEXEC because the map belongs to this process and a child that execs
+  // should not inherit the descriptor.
+  const int fd = ::open(
+      path,
+      O_WRONLY | O_CREAT | O_APPEND | O_NOFOLLOW | O_CLOEXEC,
+      S_IRUSR | S_IWUSR);
+  if (fd < 0) {
+    return -1;
+  }
+  struct stat st = {};
+  if (::fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) ||
+      st.st_uid != ::geteuid() || (st.st_mode & (S_IWGRP | S_IWOTH)) != 0) {
+    ::close(fd);
+    return -1;
+  }
+
+  // Pids are recycled and /tmp entries outlive the process that made them, so
+  // an existing map may describe a dead process's address ranges. Appending to
+  // it would attribute our samples to its symbols. Content older than this
+  // process is therefore discarded; anything written since we started belongs
+  // to another JIT writer in this same process and is left alone.
+  const std::time_t startTime = processStartTime();
+  if (st.st_size > 0 && startTime != 0 && st.st_mtime < startTime) {
+    if (::ftruncate(fd, 0) != 0) {
+      ::close(fd);
+      return -1;
+    }
+  }
+#endif
+  return fd;
+}
+
+// The descriptor for this process's map, or -1 if it is unavailable.
+//
+// Reopened when the pid changes: a fork inherits both the descriptor and the
+// parent's file name, so a child that JITs would otherwise append its symbols
+// to /tmp/perf-<parent>.map and leave its own map empty. O_CLOEXEC covers
+// exec but not fork, so the pid is rechecked on every record.
+int perfMapDescriptor() {
+  const int pid = currentPid();
+  if (perfMapPid.load(std::memory_order_acquire) == pid) {
+    // May be -1: a failed open is remembered rather than retried on every
+    // kernel, so a hostile or unwritable /tmp costs one syscall, not one per
+    // registration.
+    return perfMapFd.load(std::memory_order_acquire);
+  }
+
+  // Exactly one thread opens. A stale map is discarded with ftruncate(), and
+  // if a second thread had already been handed an O_APPEND descriptor it could
+  // write a record that the truncation then threw away. Electing an opener
+  // means no descriptor exists until truncation is done.
+  int opening = perfMapOpeningPid.load(std::memory_order_acquire);
+  if (opening != pid &&
+      perfMapOpeningPid.compare_exchange_strong(
+          opening, pid, std::memory_order_acq_rel)) {
+    const int fd = openPerfMap(pid);
+    perfMapFd.store(fd, std::memory_order_release);
+    perfMapPid.store(pid, std::memory_order_release);
+    // Any descriptor installed by a previous pid is deliberately not closed. A
+    // concurrent writer may still be inside write() on it, and closing would
+    // let the number be recycled under them. It is at most one descriptor per
+    // fork that JITs, and O_CLOEXEC plus process exit reclaim it.
+    return fd;
+  }
+
+  // Another thread is opening. Wait for it to publish rather than opening a
+  // second descriptor onto the same file. This cannot be inherited stuck
+  // across a fork: the child's pid differs, so it wins the election above
+  // instead of waiting on a claim its parent still holds.
+  while (perfMapPid.load(std::memory_order_acquire) != pid) {
+    if (currentPid() != pid) {
+      return -1;
+    }
+    std::this_thread::yield();
+  }
+  return perfMapFd.load(std::memory_order_acquire);
+}
+
+} // namespace
+
+bool jitPerfMapEnabled() {
+  // Cached in a constant-initialised atomic rather than a function-local
+  // static: magic-static initialisation takes a guard lock, which is exactly
+  // the kind of inherited lock a forked child can deadlock on. Racing threads
+  // may both compute it, which is harmless -- they compute the same value.
+  static std::atomic<int> cached{-1};
+  int enabled = cached.load(std::memory_order_acquire);
+  if (enabled < 0) {
+    const char* value = std::getenv("FBGEMM_JIT_PERF_MAP");
+    enabled =
+        (value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0)
+        ? 1
+        : 0;
+    cached.store(enabled, std::memory_order_release);
+  }
+  return enabled != 0;
+}
+
+void registerJitCodeForProfiling(
+    const void* addr,
+    size_t size,
+    const std::string& name) {
+  if (!jitPerfMapEnabled() || addr == nullptr || size == 0) {
+    return;
+  }
+
+  const int fd = perfMapDescriptor();
+  if (fd < 0) {
+    return;
+  }
+
+  char header[64];
+  const int headerLen = std::snprintf(
+      header,
+      sizeof(header),
+      "%llx %llx ",
+      static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(addr)),
+      static_cast<unsigned long long>(size));
+  if (headerLen <= 0) {
+    return;
+  }
+
+  // Assembled first and written once: an O_APPEND write is what keeps records
+  // from other threads whole, and a record split across two writes could
+  // interleave with theirs.
+  std::string record;
+  record.reserve(static_cast<size_t>(headerLen) + name.size() + 1);
+  record.assign(header, static_cast<size_t>(headerLen));
+  record += name;
+  record += '\n';
+  writeAll(fd, record.data(), record.size());
+}
+
+std::string embeddingKernelSymbol(
+    std::string_view kernel,
+    std::string_view shape,
+    const EmbeddingKernelOptions& options) {
+  std::string sym;
+  sym.reserve(96);
+  sym += "fbgemm::";
+  sym += kernel;
+  sym += "_";
+  sym += shape;
+  const auto append = [&sym](bool on, std::string_view flag) {
+    if (on) {
+      sym += "_";
+      sym += flag;
+    }
+  };
+  append(true, options.indices64 ? "idx64" : "idx32");
+  append(true, options.offsets64 ? "off64" : "off32");
+  append(options.thread_local_cache, "tls");
+  append(true, options.avx512 ? "avx512" : "avx2");
+  if (options.prefetch != 0) {
+    sym += "_prefetch-";
+    sym += std::to_string(options.prefetch);
+  }
+  append(options.weighted, "weighted");
+  append(options.positional, "positional");
+  append(options.normalize, "normalize");
+  append(options.lengths, "lengths");
+  append(options.rowwise_sparse, "rowwise_sparse");
+  append(options.scale_bias_first, "scale_bias_first");
+  append(options.fp16_out, "fp16_out");
+  append(options.bf16_out, "bf16_out");
+  sym += "_ostride-";
+  sym += std::to_string(options.output_stride);
+  sym += "_istride-";
+  sym += std::to_string(options.input_stride);
+  return sym;
+}
+
+} // namespace fbgemm

--- a/src/JitPerfMap.h
+++ b/src/JitPerfMap.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#include "fbgemm/Utils.h" // inst_set_t
+
+namespace fbgemm {
+
+// Returns true when perf-map emission is enabled, i.e. the environment
+// variable FBGEMM_JIT_PERF_MAP is set to something other than "" or "0".
+// Callers should gate on this before building a symbol name so that the
+// default path costs nothing.
+bool jitPerfMapEnabled();
+
+// Publishes a JIT-generated code region to /tmp/perf-<pid>.map in the format
+// sampling profilers expect: one record per line, "<hex addr> <hex size>
+// <name>". Without this, asmjit output lives in anonymous executable pages
+// with no symbol table, and profiles attribute every sample inside a
+// generated kernel to "[unknown]".
+//
+// `name` must not contain a newline: the reader takes everything after the
+// size field to end-of-line as the symbol.
+void registerJitCodeForProfiling(
+    const void* addr,
+    size_t size,
+    const std::string& name);
+
+// The options the EmbeddingSpMDM and EmbeddingSpMDMNBit generators share.
+// Kept in one place so both keep the same flag spelling and ordering as
+// options are added.
+struct EmbeddingKernelOptions {
+  // The generators keep one code cache per template instantiation, so every
+  // template parameter that selects an instantiation has to appear here too:
+  // two kernels from different caches are distinct code, and a shared name
+  // would misattribute one to the other.
+  bool indices64 = false;
+  bool offsets64 = false;
+  bool thread_local_cache = false;
+  bool avx512 = false;
+  // Numeric members are part of the generators' code-cache keys, so they have
+  // to appear in the symbol or distinct kernels collide under one name.
+  int prefetch = 0;
+  int output_stride = -1;
+  int input_stride = -1;
+  bool weighted = false;
+  bool positional = false;
+  bool normalize = false;
+  bool lengths = false; // i.e. !use_offsets
+  bool rowwise_sparse = false;
+  bool scale_bias_first = false; // i.e. !scale_bias_last
+  bool fp16_out = false;
+  bool bf16_out = false;
+};
+
+// Builds `fbgemm::<kernel>_<shape>_<flags...>`, e.g.
+// `fbgemm::EmbeddingSpMDMNBit_2bit_D-128_idx64_off32_avx512_weighted`. `shape`
+// is the part that differs between the two generators (bit rate vs input type).
+//
+// Underscore-separated rather than `<...>` on purpose: profilers demangle and
+// normalize symbols, and Strobelight drops template arguments outright, which
+// silently discards everything inside the brackets. This also matches the
+// naming `CodeGenBase::getKernelName` already uses for the GEMM kernels.
+std::string embeddingKernelSymbol(
+    std::string_view kernel,
+    std::string_view shape,
+    const EmbeddingKernelOptions& options);
+
+// Canonical spelling of an instruction set in a JIT symbol. The generators are
+// templated on inst_set_t and each instantiation keeps its own code cache, so
+// the ISA has to appear in the name or same-shape variants collide.
+template <inst_set_t instSet>
+constexpr const char* instSetName() {
+  if constexpr (instSet == inst_set_t::avx512_vnni) {
+    return "avx512vnni";
+  } else if constexpr (instSet == inst_set_t::avx512_vnni_ymm) {
+    return "avx512vnni_ymm";
+  } else if constexpr (instSet == inst_set_t::avx512_ymm) {
+    return "avx512_ymm";
+  } else if constexpr (instSet == inst_set_t::avx512) {
+    return "avx512";
+  } else if constexpr (instSet == inst_set_t::avx2) {
+    return "avx2";
+  } else if constexpr (instSet == inst_set_t::sve) {
+    return "sve";
+  } else {
+    return "anyarch";
+  }
+}
+
+// "idx64"/"idx32" for a generator's index type, matching the spelling
+// embeddingKernelSymbol() uses.
+template <typename IndexType>
+constexpr const char* indexWidthName() {
+  return sizeof(IndexType) == 8 ? "idx64" : "idx32";
+}
+
+// Registers a freshly JIT-ed kernel with the perf map. `makeName` is invoked
+// only when emission is enabled, so building the symbol costs nothing on the
+// default path.
+//
+// The size comes from `code` AFTER asmjit's add(): relocation there can shrink
+// the code, so a pre-add size is only an upper bound and would publish a range
+// that overlaps the next kernel. Keeping that contract here means the call
+// sites cannot drift from it.
+//
+// Templated on the holder so this header needs no asmjit include.
+template <typename CodeHolderT, typename MakeName>
+void registerJitKernel(
+    const CodeHolderT& code,
+    const void* fn,
+    MakeName&& makeName) {
+  if (!jitPerfMapEnabled()) {
+    return;
+  }
+  registerJitCodeForProfiling(fn, code.codeSize(), makeName());
+}
+
+} // namespace fbgemm

--- a/test/JitPerfMapTest.cc
+++ b/test/JitPerfMapTest.cc
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "src/JitPerfMap.h" // @manual
+
+#ifndef _MSC_VER
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <atomic>
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+#endif
+
+using namespace fbgemm;
+
+#ifdef _MSC_VER
+
+TEST(JitPerfMapTest, PosixOnly) {
+  GTEST_SKIP() << "perf maps are a Linux profiling convention";
+}
+
+#else
+
+namespace {
+
+// A plausible code address and size; the map only records them, so any
+// non-null address works.
+const void* const kAddr = reinterpret_cast<const void*>(0x400000);
+constexpr size_t kSize = 0x40;
+constexpr const char* kSymbol = "fbgemm::test_kernel";
+
+std::string mapPathFor(pid_t pid) {
+  return "/tmp/perf-" + std::to_string(pid) + ".map";
+}
+
+std::string readFile(const std::string& path) {
+  std::ifstream in(path);
+  std::ostringstream buf;
+  buf << in.rdbuf();
+  return buf.str();
+}
+
+// Runs `body` in a forked child and returns the child's pid once it has
+// exited. Each scenario needs its own process: the descriptor is opened once
+// per pid, so a single process can only exercise the open path once.
+pid_t runInChild(void (*body)()) {
+  const pid_t pid = fork();
+  if (pid == 0) {
+    body();
+    _exit(0);
+  }
+  EXPECT_GT(pid, 0);
+  int status = 0;
+  EXPECT_EQ(waitpid(pid, &status, 0), pid);
+  return pid;
+}
+
+void enablePerfMap() {
+  // Must happen before the first registration in this process; the flag is
+  // read once and cached.
+  setenv("FBGEMM_JIT_PERF_MAP", "1", 1);
+}
+
+} // namespace
+
+// A map left behind by a dead process that happened to hold this pid must not
+// be appended to: its address ranges describe code that no longer exists, so a
+// profiler would attribute our samples to its symbols.
+TEST(JitPerfMapTest, StaleMapFromRecycledPidIsDiscarded) {
+  enablePerfMap();
+  const pid_t child = runInChild([] {
+    const std::string path = mapPathFor(getpid());
+    {
+      std::ofstream out(path);
+      out << "deadbeef 10 stale::kernel_from_previous_process\n";
+    }
+    // Backdate it an hour so it clearly predates this process.
+    struct timeval times[2];
+    gettimeofday(&times[0], nullptr);
+    times[0].tv_sec -= 3600;
+    times[1] = times[0];
+    utimes(path.c_str(), times);
+
+    registerJitCodeForProfiling(kAddr, kSize, kSymbol);
+  });
+
+  const std::string path = mapPathFor(child);
+  const std::string contents = readFile(path);
+  EXPECT_EQ(
+      contents.find("stale::kernel_from_previous_process"), std::string::npos)
+      << "stale content survived:\n"
+      << contents;
+  EXPECT_NE(contents.find(kSymbol), std::string::npos)
+      << "own record missing:\n"
+      << contents;
+  unlink(path.c_str());
+}
+
+// Discarding a stale map and writing records race each other: if a thread is
+// handed an O_APPEND descriptor before another finishes truncating, its record
+// is thrown away and the kernel reads as [unknown] in the profile.
+TEST(JitPerfMapTest, StaleMapTruncationDoesNotDropConcurrentRecords) {
+  enablePerfMap();
+  constexpr int kThreads = 32;
+
+  const pid_t child = runInChild([] {
+    const std::string path = mapPathFor(getpid());
+    {
+      std::ofstream out(path);
+      out << "deadbeef 10 stale::kernel_from_previous_process\n";
+    }
+    struct timeval times[2];
+    gettimeofday(&times[0], nullptr);
+    times[0].tv_sec -= 3600;
+    times[1] = times[0];
+    utimes(path.c_str(), times);
+
+    // Released together so several threads reach their first registration --
+    // and therefore the open that truncates -- at the same moment.
+    std::atomic<int> ready{0};
+    std::atomic<bool> go{false};
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+      threads.emplace_back([&ready, &go] {
+        ready.fetch_add(1, std::memory_order_relaxed);
+        while (!go.load(std::memory_order_acquire)) {
+          std::this_thread::yield();
+        }
+        registerJitCodeForProfiling(kAddr, kSize, "fbgemm::race_kernel");
+      });
+    }
+    while (ready.load(std::memory_order_relaxed) < kThreads) {
+      std::this_thread::yield();
+    }
+    go.store(true, std::memory_order_release);
+    for (auto& thread : threads) {
+      thread.join();
+    }
+  });
+
+  const std::string path = mapPathFor(child);
+  const std::string contents = readFile(path);
+  int records = 0;
+  for (size_t i = contents.find("fbgemm::race_kernel"); i != std::string::npos;
+       i = contents.find("fbgemm::race_kernel", i + 1)) {
+    ++records;
+  }
+  EXPECT_EQ(records, kThreads)
+      << "records were discarded by the stale-map truncation";
+  EXPECT_EQ(
+      contents.find("stale::kernel_from_previous_process"), std::string::npos)
+      << "stale content survived";
+  unlink(path.c_str());
+}
+
+// Content written during this process's lifetime belongs to another JIT writer
+// sharing the map, and must survive.
+TEST(JitPerfMapTest, ContentFromThisProcessIsPreserved) {
+  enablePerfMap();
+  const pid_t child = runInChild([] {
+    const std::string path = mapPathFor(getpid());
+    std::ofstream out(path);
+    out << "cafe1000 20 other_jit::kernel\n";
+    out.close();
+
+    registerJitCodeForProfiling(kAddr, kSize, kSymbol);
+  });
+
+  const std::string path = mapPathFor(child);
+  const std::string contents = readFile(path);
+  EXPECT_NE(contents.find("other_jit::kernel"), std::string::npos)
+      << "co-writer's record was discarded:\n"
+      << contents;
+  EXPECT_NE(contents.find(kSymbol), std::string::npos)
+      << "own record missing:\n"
+      << contents;
+  unlink(path.c_str());
+}
+
+// The path is predictable, so a symlink planted there must not redirect the
+// write into someone else's file.
+TEST(JitPerfMapTest, SymlinkAtMapPathIsRefused) {
+  enablePerfMap();
+  const std::string victim = "/tmp/fbgemm_perf_map_victim.txt";
+  unlink(victim.c_str());
+  {
+    std::ofstream create(victim);
+  }
+
+  const pid_t child = runInChild([] {
+    const std::string path = mapPathFor(getpid());
+    unlink(path.c_str());
+    symlink("/tmp/fbgemm_perf_map_victim.txt", path.c_str());
+    registerJitCodeForProfiling(kAddr, kSize, kSymbol);
+  });
+
+  EXPECT_EQ(readFile(victim), "") << "write followed the symlink";
+  unlink(victim.c_str());
+  unlink(mapPathFor(child).c_str());
+}
+
+// Nothing serialises writers in userspace, so the guarantee that a record
+// arrives whole comes from handing each one to the kernel as a single
+// O_APPEND write. Concurrent writers must not tear or interleave records.
+TEST(JitPerfMapTest, ConcurrentWritesProduceWellFormedRecords) {
+  enablePerfMap();
+  constexpr int kThreads = 16;
+  constexpr int kPerThread = 200;
+
+  const pid_t child = runInChild([] {
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+      threads.emplace_back([t] {
+        for (int i = 0; i < kPerThread; ++i) {
+          registerJitCodeForProfiling(
+              kAddr, kSize, "fbgemm::thread" + std::to_string(t));
+        }
+      });
+    }
+    for (auto& thread : threads) {
+      thread.join();
+    }
+  });
+
+  const std::string path = mapPathFor(child);
+  std::ifstream in(path);
+  std::string line;
+  int lines = 0;
+  int malformed = 0;
+  while (std::getline(in, line)) {
+    ++lines;
+    unsigned long long addr = 0;
+    unsigned long long size = 0;
+    char symbol[128] = {};
+    // Exactly three fields, and the symbol must be one of the ones written.
+    if (sscanf(line.c_str(), "%llx %llx %127s", &addr, &size, symbol) != 3 ||
+        !std::string(symbol).starts_with("fbgemm::thread")) {
+      ++malformed;
+    }
+  }
+  EXPECT_EQ(lines, kThreads * kPerThread);
+  EXPECT_EQ(malformed, 0) << malformed << " of " << lines
+                          << " records were torn or interleaved";
+  unlink(path.c_str());
+}
+
+// fork() clones only the calling thread. A lock held by any other thread at
+// that instant would be inherited permanently locked, and the child would hang
+// on its first registration -- the PyTorch DataLoader pattern.
+TEST(JitPerfMapTest, ForkDuringConcurrentRegistrationDoesNotDeadlock) {
+  enablePerfMap();
+  constexpr int kForks = 100;
+  // A healthy child exits in about a millisecond. The loop stops at the first
+  // hang, so a regression fails in seconds instead of kForks * kTimeoutMs.
+  constexpr int kTimeoutMs = 2000;
+
+  std::atomic<bool> stop{false};
+  std::thread writer([&stop] {
+    while (!stop.load(std::memory_order_relaxed)) {
+      registerJitCodeForProfiling(kAddr, kSize, "fbgemm::concurrent_kernel");
+    }
+  });
+
+  int hung = 0;
+  for (int i = 0; i < kForks; ++i) {
+    const pid_t pid = fork();
+    if (pid == 0) {
+      registerJitCodeForProfiling(kAddr, kSize, kSymbol);
+      _exit(0);
+    }
+    ASSERT_GT(pid, 0);
+
+    bool exited = false;
+    for (int waited = 0; waited < kTimeoutMs; ++waited) {
+      int status = 0;
+      if (waitpid(pid, &status, WNOHANG) == pid) {
+        exited = true;
+        break;
+      }
+      usleep(1000);
+    }
+    if (!exited) {
+      ++hung;
+      kill(pid, SIGKILL);
+      waitpid(pid, nullptr, 0);
+    }
+    unlink(mapPathFor(pid).c_str());
+    if (hung > 0) {
+      break;
+    }
+  }
+
+  stop.store(true, std::memory_order_relaxed);
+  writer.join();
+  unlink(mapPathFor(getpid()).c_str());
+
+  EXPECT_EQ(hung, 0)
+      << "a child deadlocked on its first registration after forking while "
+         "another thread was registering";
+}
+
+#endif // _MSC_VER


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3155

fbgemm JITs its embedding-lookup microkernels with asmjit into anonymous executable pages that carry no symbols. Profilers attribute every cycle spent there to `[unknown] ([Anon Map])` — on the IPNext recsys predictor fleet this is the single largest unattributable bucket (up to 30 % unsymbolized leaf, nearly all from asmjit TBE kernels).

This adds `src/JitPerfMap.{h,cc}`, which writes `/tmp/perf-<pid>.map` entries that Strobelight's `PerfMapSymbolizer` already knows how to resolve. The two embedding JIT sites (`EmbeddingSpMDMNBit.cc`, `EmbeddingSpMDM.cc`) now register their kernels with shape-descriptive names, e.g. `fbgemm::EmbeddingSpMDMNBit<2bit,D=128,idx64,avx512,weighted,normalize>`.

Opt-in via `FBGEMM_JIT_PERF_MAP`; unset or `"0"` is a no-op (one `static bool` load). Both `fbcode/` and `xplat/` mirrors are updated. 11 remaining asmjit sites (GEMM, conv, SparseAdagrad, depthwise) are left to a follow-up.

Reviewed By: q10

Differential Revision: D118894440


