### PR TITLE
Symbolize the remaining fbgemm asmjit kernels (#6274)

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -66,6 +66,7 @@ def get_fbgemm_generic_srcs(with_base = False, msvc = False, buck = False):
         "src/GroupwiseConv.cc",
         "src/GroupwiseConvAcc32Avx2.cc",
         "src/GroupwiseConvAcc32Avx512.cc",
+        "src/JitPerfMap.cc",
         "src/PackAMatrix.cc",
         "src/PackAWithIm2Col.cc",
         "src/PackAWithQuantRowOffset.cc",

--- a/defs.bzl
+++ b/defs.bzl
@@ -36,6 +36,7 @@ def default_compiler_flags():
 def get_fbgemm_base_srcs():
     return [
         "src/GenerateI8Depthwise.cc",
+        "src/JitPerfMap.cc",
         "src/RefImplementations.cc",
         "src/Utils.cc",
     ]
@@ -66,7 +67,6 @@ def get_fbgemm_generic_srcs(with_base = False, msvc = False, buck = False):
         "src/GroupwiseConv.cc",
         "src/GroupwiseConvAcc32Avx2.cc",
         "src/GroupwiseConvAcc32Avx512.cc",
-        "src/JitPerfMap.cc",
         "src/PackAMatrix.cc",
         "src/PackAWithIm2Col.cc",
         "src/PackAWithQuantRowOffset.cc",

--- a/fbgemm_gpu/cmake/Fbgemm.cmake
+++ b/fbgemm_gpu/cmake/Fbgemm.cmake
@@ -14,6 +14,7 @@ set(fbgemm_sources_normal
   "${FBGEMM}/src/EmbeddingSpMDMNBit.cc"
   "${FBGEMM}/src/FbgemmBfloat16Convert.cc"
   "${FBGEMM}/src/FbgemmFloat16Convert.cc"
+  "${FBGEMM}/src/JitPerfMap.cc"
   "${FBGEMM}/src/QuantUtils.cc"
   "${FBGEMM}/src/RefImplementations.cc"
   "${FBGEMM}/src/RowWiseSparseAdagradFused.cc"

--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -20,6 +20,7 @@
 #include "./CodeCache.h" // @manual
 #include "./EmbeddingSpMDMAutovec.h" // @manual
 #include "./EmbeddingSpMDMSve.h"
+#include "./JitPerfMap.h" // @manual
 #include "./MaskAvx2.h" // @manual
 #include "./RefImplementations.h" // @manual
 #include "fbgemm/FbgemmEmbedding.h"
@@ -962,6 +963,31 @@ GenEmbeddingSpMDMLookup<
           std::cout << "Error: in fn add" << '\n';
           return nullptr;
         }
+
+        registerJitKernel(code, reinterpret_cast<const void*>(fn), [&] {
+          const char* inTypeName = is_8bit_in ? "u8"
+              : is_16bit_in                   ? (is_bf16_in ? "bf16" : "fp16")
+                                              : "fp32";
+          return embeddingKernelSymbol(
+              "EmbeddingSpMDM",
+              "in-" + std::string(inTypeName) + "_D-" +
+                  std::to_string(block_size),
+              {.indices64 = areIndices64b,
+               .offsets64 = std::is_same_v<offsetType, int64_t>,
+               .thread_local_cache = THREAD_LOCAL,
+               .avx512 = instSet == inst_set_t::avx512,
+               .prefetch = prefetch,
+               .output_stride = output_stride,
+               .input_stride = input_stride,
+               .weighted = has_weight,
+               .positional = is_weight_positional,
+               .normalize = normalize_by_lengths,
+               .lengths = !use_offsets,
+               .rowwise_sparse = ROWWISE_SPARSE,
+               .scale_bias_first = !scale_bias_last,
+               .fp16_out = is_fp16_out,
+               .bf16_out = is_bf16_out});
+        });
 
         return fn;
       });

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -18,6 +18,7 @@
 #include "./CodeCache.h" // @manual
 #include "./EmbeddingSpMDMAutovec.h" // @manual
 #include "./EmbeddingSpMDMSve.h" // @manual
+#include "./JitPerfMap.h" // @manual
 #include "./MaskAvx2.h" // @manual
 #include "./RefImplementations.h" // @manual
 #include "fbgemm/SimdUtils.h"
@@ -961,6 +962,29 @@ GenEmbeddingSpMDMNBitLookup<
           cout << "Error: in fn add" << '\n';
           return nullptr;
         }
+
+        registerJitKernel(code, reinterpret_cast<const void*>(fn), [&] {
+          return embeddingKernelSymbol(
+              "EmbeddingSpMDMNBit",
+              std::to_string(bit_rate) + "bit_D-" + std::to_string(block_size),
+              {.indices64 = areIndices64b,
+               .offsets64 = std::is_same_v<offsetType, int64_t>,
+               .thread_local_cache = THREAD_LOCAL,
+               .avx512 = instSet == inst_set_t::avx512,
+               .prefetch = prefetch,
+               .output_stride = output_stride,
+               .input_stride = input_stride,
+               .weighted = has_weight,
+               .positional = is_weight_positional,
+               .normalize = normalize_by_lengths,
+               .lengths = !use_offsets,
+               .rowwise_sparse = ROWWISE_SPARSE,
+               .scale_bias_first = !scale_bias_last,
+               // outType selects the instantiation, so a float-output kernel
+               // and a float16-output one of the same shape are distinct code.
+               .fp16_out = is_16bit_storage_v<outType> && !is_bf16_out,
+               .bf16_out = is_bf16_out});
+        });
 
 #if defined(FBGEMM_LOG_CODE)
         fclose(codeLogFile);

--- a/src/FbgemmI64.cc
+++ b/src/FbgemmI64.cc
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "./GenerateKernel.h" // @manual
+#include "./JitPerfMap.h" // @manual
 #include "./RefImplementations.h" // @manual
 #include "fbgemm/PackingTraits-inl.h"
 
@@ -378,6 +379,11 @@ CodeGenBase<int64_t, int64_t, int64_t, int64_t>::getOrCreate(
       cout << "Error: in fn add" << '\n';
       return nullptr;
     }
+
+    registerJitKernel(code, reinterpret_cast<const void*>(fn), [&] {
+      return getKernelSymbol<instSet>(
+          accum, mc, nc, nBlock, kBlock, mRegBlockSize, nRegBlockSize);
+    });
 
 #ifdef FBGEMM_LOG_CODE
     fclose(codeLogfile);

--- a/src/GenerateI8Depthwise.cc
+++ b/src/GenerateI8Depthwise.cc
@@ -16,6 +16,7 @@
 
 #include "./CodeCache.h" // @manual
 #include "./CodeGenHelpers.h" // @manual
+#include "./JitPerfMap.h" // @manual
 #include "fbgemm/Utils.h"
 
 namespace fbgemm {
@@ -575,6 +576,24 @@ GenI8Depthwise::jit_kernel_signature GenI8Depthwise::getOrCreate(
           "kernel with the asmjit runtime (asmjit error " +
           std::to_string(err) + ")");
     }
+
+    registerJitKernel(code, reinterpret_cast<const void*>(fn), [&] {
+      return JitSymbolBuilder("i8_depthwise")
+          .field("D", D)
+          .field("F0", F[0])
+          .field("F1", F[1])
+          .field("F2", F[2])
+          .field("ocpg", oc_per_g)
+          .flag("asum", compute_a_sum)
+          .field("rem", remainder)
+          .field("prevskip", prev_skip)
+          .field("nextskip", next_skip)
+          .field("topskip", top_skip)
+          .field("bottomskip", bottom_skip)
+          .field("leftskip", left_skip)
+          .field("rightskip", right_skip)
+          .str();
+    });
 
 #ifdef FBGEMM_LOG_CODE
     fclose(codeLogFile);

--- a/src/GenerateKernel.h
+++ b/src/GenerateKernel.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <tuple>
 #include "./CodeCache.h" // @manual
+#include "./JitPerfMap.h" // @manual
 #include "fbgemm/Fbgemm.h"
 #include "fbgemm/SimdUtils.h"
 // #define FBGEMM_LOG_CODE 1
@@ -103,12 +104,44 @@ class CodeGenBase {
       int KCB,
       int MR,
       int NR) {
+    return getKernelName<instSet>(accum, mc, nc, NCB, KCB, MR, NR) + ".txt";
+  }
+
+  /**
+   * @brief The perf-map symbol for this kernel.
+   *
+   * Shares getKernelName() with the debug dump filename so the two cannot
+   * drift, and keeps the "fbgemm::" prefix here rather than repeating it in
+   * every generator.
+   */
+  template <inst_set_t instSet>
+  static std::string getKernelSymbol(
+      bool accum,
+      int mc,
+      int nc,
+      int NCB,
+      int KCB,
+      int MR,
+      int NR) {
+    return "fbgemm::" + getKernelName<instSet>(accum, mc, nc, NCB, KCB, MR, NR);
+  }
+
+  // The code-logging filename without its extension, so the same descriptive
+  // shape can be reused as a JIT symbol name. Deliberately unprefixed: this
+  // also feeds getCodeLoggingFile(), and a "fbgemm::" prefix would put a colon
+  // in the dump filename, which is not legal on Windows. Callers registering a
+  // perf-map symbol prepend the namespace themselves.
+  template <inst_set_t instSet>
+  static std::string
+  getKernelName(bool accum, int mc, int nc, int NCB, int KCB, int MR, int NR) {
     std::ostringstream oss;
     oss << "gemm_";
     if constexpr (std::is_same_v<accT, std::int16_t>) {
       oss << "acc16_";
     } else if constexpr (std::is_same_v<accT, std::int32_t>) {
       oss << "acc32_";
+    } else if constexpr (std::is_same_v<accT, std::int64_t>) {
+      oss << "acc64_";
     } else {
       oss << "unknown_";
     }
@@ -116,16 +149,11 @@ class CodeGenBase {
         << "_NC-" + std::to_string(nc) << "_NCB-" + std::to_string(NCB)
         << "_KCB-" + std::to_string(KCB) << "_MR-" + std::to_string(MR)
         << "_NR-" + std::to_string(NR);
-    if constexpr (instSet == inst_set_t::avx512_vnni) {
-      oss << "_avx512vnni";
-    } else if constexpr (instSet == inst_set_t::avx512) {
-      oss << "_avx512";
-    } else if constexpr (instSet == inst_set_t::avx512_ymm) {
-      oss << "_avx512_ymm";
-    } else if constexpr (instSet == inst_set_t::avx2) {
-      oss << "_avx2";
-    }
-    oss << ".txt";
+    // instSetName() rather than a local chain: it is the same spelling the
+    // embedding kernels use, and it has a fallback, so an instSet nobody
+    // thought to list here still names itself instead of silently producing a
+    // symbol with no ISA at all.
+    oss << "_" << instSetName<instSet>();
     return oss.str();
   }
 

--- a/src/GenerateKernelDirectConvU8S8S32ACC32.cc
+++ b/src/GenerateKernelDirectConvU8S8S32ACC32.cc
@@ -9,6 +9,7 @@
 #include <iostream>
 #include "./CodeGenHelpers.h" // @manual
 #include "./DirectConv.h" // @manual
+#include "./JitPerfMap.h" // @manual
 
 namespace fbgemm {
 
@@ -405,6 +406,18 @@ DirectConvCodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreateDirectConv(
       return nullptr;
     }
 
+    registerJitKernel(code, reinterpret_cast<const void*>(fn), [&] {
+      return JitSymbolBuilder("directconv_acc32")
+          .field("isa", instSetName<instSet>())
+          .flag("accum", accum)
+          .field("O1", O1)
+          .field("i1Xich", i1Xich)
+          .field("strideXich", strideXich)
+          .field("MR", mRegBlockSize)
+          .field("NR", nRegBlockSize)
+          .str();
+    });
+
 #if defined(FBGEMM_LOG_CODE)
     fclose(codeLogfile);
     delete codeLogger;
@@ -764,6 +777,16 @@ DirectConvCodeGenBase<uint8_t, int8_t, int32_t, int32_t>::
       std::cout << "Error: in fn add" << '\n';
       return nullptr;
     }
+
+    registerJitKernel(code, reinterpret_cast<const void*>(fn), [&] {
+      return JitSymbolBuilder("directconvT_acc32")
+          .field("isa", instSetName<instSet>())
+          .flag("accum", accum)
+          .field("stride", stride)
+          .field("MR", mRegBlockSize)
+          .field("NR", nRegBlockSize)
+          .str();
+    });
 
 #if defined(FBGEMM_LOG_CODE)
     fclose(codeLogfile);

--- a/src/GenerateKernelU8S8S32ACC16.cc
+++ b/src/GenerateKernelU8S8S32ACC16.cc
@@ -9,6 +9,7 @@
 #include <iostream>
 #include "./CodeGenHelpers.h" // @manual
 #include "./GenerateKernel.h" // @manual
+#include "./JitPerfMap.h" // @manual
 
 namespace fbgemm {
 
@@ -323,6 +324,11 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<inst_set_t::avx2>(
       std::cout << "Error: in fn add" << '\n';
       return nullptr;
     }
+
+    registerJitKernel(code, reinterpret_cast<const void*>(fn), [&] {
+      return getKernelSymbol<inst_set_t::avx2>(
+          accum, mc, nc, nBlock, kBlock, mRegBlockSize, nRegBlockSize);
+    });
 
 #if defined(FBGEMM_LOG_CODE)
     fclose(codeLogfile);

--- a/src/GenerateKernelU8S8S32ACC16Avx512.cc
+++ b/src/GenerateKernelU8S8S32ACC16Avx512.cc
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <iostream>
 #include "./GenerateKernel.h" // @manual
+#include "./JitPerfMap.h" // @manual
 
 namespace fbgemm {
 
@@ -347,6 +348,11 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate(
       std::cout << "Error: in fn add" << '\n';
       return nullptr;
     }
+
+    registerJitKernel(code, reinterpret_cast<const void*>(fn), [&] {
+      return getKernelSymbol<instSet>(
+          accum, mc, nc, nBlock, kBlock, mRegBlockSize, nRegBlockSize);
+    });
 
 #if defined(FBGEMM_LOG_CODE)
     fclose(codeLogfile);

--- a/src/GenerateKernelU8S8S32ACC32.cc
+++ b/src/GenerateKernelU8S8S32ACC32.cc
@@ -9,6 +9,7 @@
 #include <iostream>
 #include "./CodeGenHelpers.h" // @manual
 #include "./GenerateKernel.h" // @manual
+#include "./JitPerfMap.h" // @manual
 
 namespace fbgemm {
 
@@ -357,6 +358,11 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate(
       std::cout << "Error: in fn add" << '\n';
       return nullptr;
     }
+
+    registerJitKernel(code, reinterpret_cast<const void*>(fn), [&] {
+      return getKernelSymbol<instSet>(
+          accum, mc, nc, nBlock, kBlock, mRegBlockSize, nRegBlockSize);
+    });
 
 #if defined(FBGEMM_LOG_CODE)
     fclose(codeLogfile);

--- a/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
+++ b/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
@@ -8,6 +8,7 @@
 
 #include <iostream>
 #include "./GenerateKernel.h" // @manual
+#include "./JitPerfMap.h" // @manual
 
 namespace fbgemm {
 
@@ -352,6 +353,11 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate(
       std::cout << "Error: in fn add" << '\n';
       return nullptr;
     }
+
+    registerJitKernel(code, reinterpret_cast<const void*>(fn), [&] {
+      return getKernelSymbol<instSet>(
+          accum, mc, nc, nBlock, kBlock, mRegBlockSize, nRegBlockSize);
+    });
 
 #if defined(FBGEMM_LOG_CODE)
     fclose(codeLogfile);

--- a/src/GroupwiseConv.cc
+++ b/src/GroupwiseConv.cc
@@ -15,6 +15,7 @@
 #include <tuple>
 #include <type_traits>
 #include "./CodeGenHelpers.h" // @manual
+#include "./JitPerfMap.h" // @manual
 #include "fbgemm/Fbgemm.h"
 #include "fbgemm/QuantUtilsAvx512.h"
 #include "fbgemm/SimdUtils.h"
@@ -314,6 +315,25 @@ jit_conv_kernel_fp GenConvKernel<SPATIAL_DIM, INST_SET>::getOrCreate() {
     cout << "Error: in fn add" << '\n';
     return nullptr;
   }
+
+  registerJitKernel(code, reinterpret_cast<const void*>(fn), [&] {
+    return JitSymbolBuilder("groupwise_conv")
+        .field("G", this->G_)
+        .field("KpG", this->K_per_G_)
+        .field("CpG", this->C_per_G_)
+        .field("stride", this->STRIDE_)
+        .field("sdim", SPATIAL_DIM)
+        .field("isa", instSetName<INST_SET>())
+        .flag("azp0", this->isAZeroPointZero_)
+        .flag("rowoffset", this->needRowOffset_)
+        .flag("top", this->isTopEdgeIncluded_)
+        .flag("bottom", this->isBottomEdgeIncluded_)
+        .flag("same", this->isTopBottomEdgeSame_)
+        .flag("bpad", this->use_bottom_padding_)
+        .flag("rpad", this->use_right_padding_)
+        .flag("accum", this->accum_)
+        .str();
+  });
 
 #if defined(FBGEMM_LOG_CODE)
   fclose(codeLogfile);

--- a/src/JitPerfMap.cc
+++ b/src/JitPerfMap.cc
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#define FBGEMM_EXPORTS
+
+#include "./JitPerfMap.h" // @manual
+
+#include <atomic>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <string_view>
+#include <thread>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#ifdef _MSC_VER
+#include <io.h>
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace fbgemm {
+
+namespace {
+
+// This file deliberately takes no userspace lock. fbgemm JITs from worker
+// threads, and a multithreaded process may fork at any point -- PyTorch's
+// DataLoader does exactly that. fork() clones only the calling thread, so a
+// mutex held by any other thread at that moment is inherited permanently
+// locked and the child deadlocks on its first registration. Instead the
+// descriptor is published through atomics and each record is handed to the
+// kernel as one O_APPEND write(), which is what serialises concurrent writers.
+// The one place threads do wait on each other -- electing which of them opens
+// the map -- is keyed on the pid, so a child never waits on a claim its parent
+// still holds.
+
+int currentPid() {
+#ifdef _MSC_VER
+  return _getpid();
+#else
+  return static_cast<int>(getpid());
+#endif
+}
+
+#ifndef _MSC_VER
+// Seconds since the epoch at which this process started, or 0 when that cannot
+// be determined. On Linux the mtime of /proc/self is exactly the process start
+// time, which is what distinguishes a map this process wrote from one left by
+// an earlier process that happened to hold the same pid.
+//
+// POSIX-only: the Windows path below has no staleness check, so defining this
+// unconditionally leaves an unused static function that -Werror rejects.
+std::time_t processStartTime() {
+#ifdef __linux__
+  struct stat st = {};
+  if (::stat("/proc/self", &st) == 0) {
+    return st.st_mtime;
+  }
+#endif
+  return 0;
+}
+#endif // _MSC_VER
+
+bool writeAll(int fd, const char* data, size_t len) {
+  while (len > 0) {
+#ifdef _MSC_VER
+    const int written = _write(fd, data, static_cast<unsigned int>(len));
+#else
+    const ssize_t written = ::write(fd, data, len);
+#endif
+    if (written <= 0) {
+      if (written < 0 && errno == EINTR) {
+        continue;
+      }
+      return false;
+    }
+    data += written;
+    len -= static_cast<size_t>(written);
+  }
+  return true;
+}
+
+// -1 before the first open. Written only by openPerfMap().
+std::atomic<int> perfMapFd{-1};
+std::atomic<int> perfMapPid{-1};
+// Claimed by the single thread that opens the map for a given pid, so no
+// descriptor is published while that thread may still be truncating.
+std::atomic<int> perfMapOpeningPid{-1};
+
+int openPerfMap(int pid) {
+  char path[64];
+  std::snprintf(path, sizeof(path), "/tmp/perf-%d.map", pid);
+
+#ifdef _MSC_VER
+  const int fd =
+      _open(path, _O_WRONLY | _O_CREAT | _O_APPEND, _S_IREAD | _S_IWRITE);
+  if (fd < 0) {
+    return -1;
+  }
+#else
+  // The path is predictable, so anyone able to create files in /tmp could
+  // pre-place a symlink and capture what a more privileged process writes.
+  // O_NOFOLLOW rejects a symlink at the final component; the fstat() below
+  // then rejects anything that is not a regular file we own and that only we
+  // can write, which covers a pre-created file or FIFO that O_NOFOLLOW allows.
+  // O_CLOEXEC because the map belongs to this process and a child that execs
+  // should not inherit the descriptor.
+  const int fd = ::open(
+      path,
+      O_WRONLY | O_CREAT | O_APPEND | O_NOFOLLOW | O_CLOEXEC,
+      S_IRUSR | S_IWUSR);
+  if (fd < 0) {
+    return -1;
+  }
+  struct stat st = {};
+  if (::fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) ||
+      st.st_uid != ::geteuid() || (st.st_mode & (S_IWGRP | S_IWOTH)) != 0) {
+    ::close(fd);
+    return -1;
+  }
+
+  // Pids are recycled and /tmp entries outlive the process that made them, so
+  // an existing map may describe a dead process's address ranges. Appending to
+  // it would attribute our samples to its symbols. Content older than this
+  // process is therefore discarded; anything written since we started belongs
+  // to another JIT writer in this same process and is left alone.
+  const std::time_t startTime = processStartTime();
+  if (st.st_size > 0 && startTime != 0 && st.st_mtime < startTime) {
+    if (::ftruncate(fd, 0) != 0) {
+      ::close(fd);
+      return -1;
+    }
+  }
+#endif
+  return fd;
+}
+
+// The descriptor for this process's map, or -1 if it is unavailable.
+//
+// Reopened when the pid changes: a fork inherits both the descriptor and the
+// parent's file name, so a child that JITs would otherwise append its symbols
+// to /tmp/perf-<parent>.map and leave its own map empty. O_CLOEXEC covers
+// exec but not fork, so the pid is rechecked on every record.
+int perfMapDescriptor() {
+  const int pid = currentPid();
+  if (perfMapPid.load(std::memory_order_acquire) == pid) {
+    // May be -1: a failed open is remembered rather than retried on every
+    // kernel, so a hostile or unwritable /tmp costs one syscall, not one per
+    // registration.
+    return perfMapFd.load(std::memory_order_acquire);
+  }
+
+  // Exactly one thread opens. A stale map is discarded with ftruncate(), and
+  // if a second thread had already been handed an O_APPEND descriptor it could
+  // write a record that the truncation then threw away. Electing an opener
+  // means no descriptor exists until truncation is done.
+  int opening = perfMapOpeningPid.load(std::memory_order_acquire);
+  if (opening != pid &&
+      perfMapOpeningPid.compare_exchange_strong(
+          opening, pid, std::memory_order_acq_rel)) {
+    const int fd = openPerfMap(pid);
+    perfMapFd.store(fd, std::memory_order_release);
+    perfMapPid.store(pid, std::memory_order_release);
+    // Any descriptor installed by a previous pid is deliberately not closed. A
+    // concurrent writer may still be inside write() on it, and closing would
+    // let the number be recycled under them. It is at most one descriptor per
+    // fork that JITs, and O_CLOEXEC plus process exit reclaim it.
+    return fd;
+  }
+
+  // Another thread is opening. Wait for it to publish rather than opening a
+  // second descriptor onto the same file. This cannot be inherited stuck
+  // across a fork: the child's pid differs, so it wins the election above
+  // instead of waiting on a claim its parent still holds.
+  while (perfMapPid.load(std::memory_order_acquire) != pid) {
+    if (currentPid() != pid) {
+      return -1;
+    }
+    std::this_thread::yield();
+  }
+  return perfMapFd.load(std::memory_order_acquire);
+}
+
+} // namespace
+
+bool jitPerfMapEnabled() {
+  // Cached in a constant-initialised atomic rather than a function-local
+  // static: magic-static initialisation takes a guard lock, which is exactly
+  // the kind of inherited lock a forked child can deadlock on. Racing threads
+  // may both compute it, which is harmless -- they compute the same value.
+  static std::atomic<int> cached{-1};
+  int enabled = cached.load(std::memory_order_acquire);
+  if (enabled < 0) {
+    const char* value = std::getenv("FBGEMM_JIT_PERF_MAP");
+    enabled =
+        (value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0)
+        ? 1
+        : 0;
+    cached.store(enabled, std::memory_order_release);
+  }
+  return enabled != 0;
+}
+
+void registerJitCodeForProfiling(
+    const void* addr,
+    size_t size,
+    const std::string& name) {
+  if (!jitPerfMapEnabled() || addr == nullptr || size == 0) {
+    return;
+  }
+
+  const int fd = perfMapDescriptor();
+  if (fd < 0) {
+    return;
+  }
+
+  char header[64];
+  const int headerLen = std::snprintf(
+      header,
+      sizeof(header),
+      "%llx %llx ",
+      static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(addr)),
+      static_cast<unsigned long long>(size));
+  if (headerLen <= 0) {
+    return;
+  }
+
+  // Assembled first and written once: an O_APPEND write is what keeps records
+  // from other threads whole, and a record split across two writes could
+  // interleave with theirs.
+  std::string record;
+  record.reserve(static_cast<size_t>(headerLen) + name.size() + 1);
+  record.assign(header, static_cast<size_t>(headerLen));
+  record += name;
+  record += '\n';
+  writeAll(fd, record.data(), record.size());
+}
+
+std::string embeddingKernelSymbol(
+    std::string_view kernel,
+    std::string_view shape,
+    const EmbeddingKernelOptions& options) {
+  std::string sym;
+  sym.reserve(96);
+  sym += "fbgemm::";
+  sym += kernel;
+  sym += "_";
+  sym += shape;
+  const auto append = [&sym](bool on, std::string_view flag) {
+    if (on) {
+      sym += "_";
+      sym += flag;
+    }
+  };
+  append(true, options.indices64 ? "idx64" : "idx32");
+  append(true, options.offsets64 ? "off64" : "off32");
+  append(options.thread_local_cache, "tls");
+  append(true, options.avx512 ? "avx512" : "avx2");
+  if (options.prefetch != 0) {
+    sym += "_prefetch-";
+    sym += std::to_string(options.prefetch);
+  }
+  append(options.weighted, "weighted");
+  append(options.positional, "positional");
+  append(options.normalize, "normalize");
+  append(options.lengths, "lengths");
+  append(options.rowwise_sparse, "rowwise_sparse");
+  append(options.scale_bias_first, "scale_bias_first");
+  append(options.fp16_out, "fp16_out");
+  append(options.bf16_out, "bf16_out");
+  sym += "_ostride-";
+  sym += std::to_string(options.output_stride);
+  sym += "_istride-";
+  sym += std::to_string(options.input_stride);
+  return sym;
+}
+
+} // namespace fbgemm

--- a/src/JitPerfMap.h
+++ b/src/JitPerfMap.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#include "fbgemm/Utils.h" // inst_set_t
+
+namespace fbgemm {
+
+// Returns true when perf-map emission is enabled, i.e. the environment
+// variable FBGEMM_JIT_PERF_MAP is set to something other than "" or "0".
+// Callers should gate on this before building a symbol name so that the
+// default path costs nothing.
+bool jitPerfMapEnabled();
+
+// Publishes a JIT-generated code region to /tmp/perf-<pid>.map in the format
+// sampling profilers expect: one record per line, "<hex addr> <hex size>
+// <name>". Without this, asmjit output lives in anonymous executable pages
+// with no symbol table, and profiles attribute every sample inside a
+// generated kernel to "[unknown]".
+//
+// `name` must not contain a newline: the reader takes everything after the
+// size field to end-of-line as the symbol.
+void registerJitCodeForProfiling(
+    const void* addr,
+    size_t size,
+    const std::string& name);
+
+// The options the EmbeddingSpMDM and EmbeddingSpMDMNBit generators share.
+// Kept in one place so both keep the same flag spelling and ordering as
+// options are added.
+struct EmbeddingKernelOptions {
+  // The generators keep one code cache per template instantiation, so every
+  // template parameter that selects an instantiation has to appear here too:
+  // two kernels from different caches are distinct code, and a shared name
+  // would misattribute one to the other.
+  bool indices64 = false;
+  bool offsets64 = false;
+  bool thread_local_cache = false;
+  bool avx512 = false;
+  // Numeric members are part of the generators' code-cache keys, so they have
+  // to appear in the symbol or distinct kernels collide under one name.
+  int prefetch = 0;
+  int output_stride = -1;
+  int input_stride = -1;
+  bool weighted = false;
+  bool positional = false;
+  bool normalize = false;
+  bool lengths = false; // i.e. !use_offsets
+  bool rowwise_sparse = false;
+  bool scale_bias_first = false; // i.e. !scale_bias_last
+  bool fp16_out = false;
+  bool bf16_out = false;
+};
+
+// Builds `fbgemm::<kernel>_<shape>_<flags...>`, e.g.
+// `fbgemm::EmbeddingSpMDMNBit_2bit_D-128_idx64_off32_avx512_weighted`. `shape`
+// is the part that differs between the two generators (bit rate vs input type).
+//
+// Underscore-separated rather than `<...>` on purpose: profilers demangle and
+// normalize symbols, and Strobelight drops template arguments outright, which
+// silently discards everything inside the brackets. This also matches the
+// naming `CodeGenBase::getKernelName` already uses for the GEMM kernels.
+std::string embeddingKernelSymbol(
+    std::string_view kernel,
+    std::string_view shape,
+    const EmbeddingKernelOptions& options);
+
+// Canonical spelling of an instruction set in a JIT symbol. The generators are
+// templated on inst_set_t and each instantiation keeps its own code cache, so
+// the ISA has to appear in the name or same-shape variants collide.
+template <inst_set_t instSet>
+constexpr const char* instSetName() {
+  if constexpr (instSet == inst_set_t::avx512_vnni) {
+    return "avx512vnni";
+  } else if constexpr (instSet == inst_set_t::avx512_vnni_ymm) {
+    return "avx512vnni_ymm";
+  } else if constexpr (instSet == inst_set_t::avx512_ymm) {
+    return "avx512_ymm";
+  } else if constexpr (instSet == inst_set_t::avx512) {
+    return "avx512";
+  } else if constexpr (instSet == inst_set_t::avx2) {
+    return "avx2";
+  } else if constexpr (instSet == inst_set_t::sve) {
+    return "sve";
+  } else {
+    return "anyarch";
+  }
+}
+
+// "idx64"/"idx32" for a generator's index type, matching the spelling
+// embeddingKernelSymbol() uses.
+template <typename IndexType>
+constexpr const char* indexWidthName() {
+  return sizeof(IndexType) == 8 ? "idx64" : "idx32";
+}
+
+// Registers a freshly JIT-ed kernel with the perf map. `makeName` is invoked
+// only when emission is enabled, so building the symbol costs nothing on the
+// default path.
+//
+// The size comes from `code` AFTER asmjit's add(): relocation there can shrink
+// the code, so a pre-add size is only an upper bound and would publish a range
+// that overlaps the next kernel. Keeping that contract here means the call
+// sites cannot drift from it.
+//
+// Templated on the holder so this header needs no asmjit include.
+template <typename CodeHolderT, typename MakeName>
+void registerJitKernel(
+    const CodeHolderT& code,
+    const void* fn,
+    MakeName&& makeName) {
+  if (!jitPerfMapEnabled()) {
+    return;
+  }
+  registerJitCodeForProfiling(fn, code.codeSize(), makeName());
+}
+
+} // namespace fbgemm

--- a/src/JitPerfMap.h
+++ b/src/JitPerfMap.h
@@ -9,9 +9,11 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 
 #include "fbgemm/Utils.h" // inst_set_t
 
@@ -104,6 +106,53 @@ template <typename IndexType>
 constexpr const char* indexWidthName() {
   return sizeof(IndexType) == 8 ? "idx64" : "idx32";
 }
+
+// Builds a JIT symbol as `fbgemm::<kernel>_<name>-<value>...`, so every field
+// is labelled and the reading order in a profile matches the order written
+// here. Generators whose code-cache key is a plain tuple use this instead of
+// hand-rolled concatenation: a key that gains a member is then one `.field()`
+// away from being represented, rather than a silent mismatch.
+class JitSymbolBuilder {
+ public:
+  explicit JitSymbolBuilder(std::string_view kernel) {
+    sym_.reserve(96);
+    sym_ += "fbgemm::";
+    sym_ += kernel;
+  }
+
+  JitSymbolBuilder& field(std::string_view name, int64_t value) {
+    sep(name);
+    sym_ += std::to_string(value);
+    return *this;
+  }
+
+  JitSymbolBuilder& field(std::string_view name, std::string_view value) {
+    sep(name);
+    sym_ += value;
+    return *this;
+  }
+
+  // Booleans are emitted as 0/1 rather than omitted, so the field count is the
+  // same for every kernel of a given family and stays greppable.
+  JitSymbolBuilder& flag(std::string_view name, bool value) {
+    return field(name, value ? 1 : 0);
+  }
+
+  // Not rvalue-qualified: the chaining setters return an lvalue reference, so
+  // the terminal call is made on an lvalue.
+  std::string str() {
+    return std::move(sym_);
+  }
+
+ private:
+  void sep(std::string_view name) {
+    sym_ += "_";
+    sym_ += name;
+    sym_ += "-";
+  }
+
+  std::string sym_;
+};
 
 // Registers a freshly JIT-ed kernel with the perf map. `makeName` is invoked
 // only when emission is enabled, so building the symbol costs nothing on the

--- a/src/RowWiseSparseAdagradFused.cc
+++ b/src/RowWiseSparseAdagradFused.cc
@@ -12,6 +12,7 @@
 #include <cpuinfo.h>
 #include <mutex>
 #include "./CodeCache.h" // @manual
+#include "./JitPerfMap.h" // @manual
 #include "./MaskAvx2.h" // @manual
 #include "./RefImplementations.h" // @manual
 #include "fbgemm/SimdUtils.h"
@@ -741,6 +742,20 @@ typename ReturnFunctionSignature<indxType, offsetType, dataType>::
           cout << "Error: in fn add" << '\n';
           return nullptr;
         }
+
+        registerJitKernel(code, reinterpret_cast<const void*>(fn), [&] {
+          return JitSymbolBuilder("rowwise_sparse_adagrad_fused")
+              .field("idx", indexWidthName<indxType>())
+              .field("offbits", static_cast<int64_t>(sizeof(offsetType) * 8))
+              .field("wbits", static_cast<int64_t>(sizeof(dataType) * 8))
+              .field("isa", instSetName<instSet>())
+              .field("D", block_size)
+              .field("prefetch", prefetch)
+              .flag("offsets", use_offsets)
+              .flag("sr", use_stochastic_rounding)
+              .field("gstride", grad_stride)
+              .str();
+        });
 
 #if defined(FBGEMM_LOG_CODE)
         fclose(codeLogFile);

--- a/src/SparseAdagrad.cc
+++ b/src/SparseAdagrad.cc
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <tuple>
 #include "./CodeCache.h" // @manual
+#include "./JitPerfMap.h" // @manual
 #include "./MaskAvx2.h" // @manual
 #include "./RefImplementations.h" // @manual
 #include "fbgemm/SimdUtils.h"
@@ -768,6 +769,17 @@ GenSparseAdagrad<indxType, instSet>::getOrCreate(
           std::cout << "Error: in fn add" << '\n';
           return nullptr;
         }
+
+        registerJitKernel(code, reinterpret_cast<const void*>(fn), [&] {
+          return JitSymbolBuilder("sparse_adagrad")
+              .field("idx", indexWidthName<indxType>())
+              .field("isa", instSetName<instSet>())
+              .field("D", block_size)
+              .field("prefetch", prefetch)
+              .flag("rowwise", rowwise)
+              .flag("wd", has_weight_decay)
+              .str();
+        });
 
 #if defined(FBGEMM_LOG_CODE)
         fclose(codeLogFile);

--- a/test/JitPerfMapTest.cc
+++ b/test/JitPerfMapTest.cc
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "src/JitPerfMap.h" // @manual
+
+#ifndef _MSC_VER
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <atomic>
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+#endif
+
+using namespace fbgemm;
+
+#ifdef _MSC_VER
+
+TEST(JitPerfMapTest, PosixOnly) {
+  GTEST_SKIP() << "perf maps are a Linux profiling convention";
+}
+
+#else
+
+namespace {
+
+// A plausible code address and size; the map only records them, so any
+// non-null address works.
+const void* const kAddr = reinterpret_cast<const void*>(0x400000);
+constexpr size_t kSize = 0x40;
+constexpr const char* kSymbol = "fbgemm::test_kernel";
+
+std::string mapPathFor(pid_t pid) {
+  return "/tmp/perf-" + std::to_string(pid) + ".map";
+}
+
+std::string readFile(const std::string& path) {
+  std::ifstream in(path);
+  std::ostringstream buf;
+  buf << in.rdbuf();
+  return buf.str();
+}
+
+// Runs `body` in a forked child and returns the child's pid once it has
+// exited. Each scenario needs its own process: the descriptor is opened once
+// per pid, so a single process can only exercise the open path once.
+pid_t runInChild(void (*body)()) {
+  const pid_t pid = fork();
+  if (pid == 0) {
+    body();
+    _exit(0);
+  }
+  EXPECT_GT(pid, 0);
+  int status = 0;
+  EXPECT_EQ(waitpid(pid, &status, 0), pid);
+  return pid;
+}
+
+void enablePerfMap() {
+  // Must happen before the first registration in this process; the flag is
+  // read once and cached.
+  setenv("FBGEMM_JIT_PERF_MAP", "1", 1);
+}
+
+} // namespace
+
+// A map left behind by a dead process that happened to hold this pid must not
+// be appended to: its address ranges describe code that no longer exists, so a
+// profiler would attribute our samples to its symbols.
+TEST(JitPerfMapTest, StaleMapFromRecycledPidIsDiscarded) {
+  enablePerfMap();
+  const pid_t child = runInChild([] {
+    const std::string path = mapPathFor(getpid());
+    {
+      std::ofstream out(path);
+      out << "deadbeef 10 stale::kernel_from_previous_process\n";
+    }
+    // Backdate it an hour so it clearly predates this process.
+    struct timeval times[2];
+    gettimeofday(&times[0], nullptr);
+    times[0].tv_sec -= 3600;
+    times[1] = times[0];
+    utimes(path.c_str(), times);
+
+    registerJitCodeForProfiling(kAddr, kSize, kSymbol);
+  });
+
+  const std::string path = mapPathFor(child);
+  const std::string contents = readFile(path);
+  EXPECT_EQ(
+      contents.find("stale::kernel_from_previous_process"), std::string::npos)
+      << "stale content survived:\n"
+      << contents;
+  EXPECT_NE(contents.find(kSymbol), std::string::npos)
+      << "own record missing:\n"
+      << contents;
+  unlink(path.c_str());
+}
+
+// Discarding a stale map and writing records race each other: if a thread is
+// handed an O_APPEND descriptor before another finishes truncating, its record
+// is thrown away and the kernel reads as [unknown] in the profile.
+TEST(JitPerfMapTest, StaleMapTruncationDoesNotDropConcurrentRecords) {
+  enablePerfMap();
+  constexpr int kThreads = 32;
+
+  const pid_t child = runInChild([] {
+    const std::string path = mapPathFor(getpid());
+    {
+      std::ofstream out(path);
+      out << "deadbeef 10 stale::kernel_from_previous_process\n";
+    }
+    struct timeval times[2];
+    gettimeofday(&times[0], nullptr);
+    times[0].tv_sec -= 3600;
+    times[1] = times[0];
+    utimes(path.c_str(), times);
+
+    // Released together so several threads reach their first registration --
+    // and therefore the open that truncates -- at the same moment.
+    std::atomic<int> ready{0};
+    std::atomic<bool> go{false};
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+      threads.emplace_back([&ready, &go] {
+        ready.fetch_add(1, std::memory_order_relaxed);
+        while (!go.load(std::memory_order_acquire)) {
+          std::this_thread::yield();
+        }
+        registerJitCodeForProfiling(kAddr, kSize, "fbgemm::race_kernel");
+      });
+    }
+    while (ready.load(std::memory_order_relaxed) < kThreads) {
+      std::this_thread::yield();
+    }
+    go.store(true, std::memory_order_release);
+    for (auto& thread : threads) {
+      thread.join();
+    }
+  });
+
+  const std::string path = mapPathFor(child);
+  const std::string contents = readFile(path);
+  int records = 0;
+  for (size_t i = contents.find("fbgemm::race_kernel"); i != std::string::npos;
+       i = contents.find("fbgemm::race_kernel", i + 1)) {
+    ++records;
+  }
+  EXPECT_EQ(records, kThreads)
+      << "records were discarded by the stale-map truncation";
+  EXPECT_EQ(
+      contents.find("stale::kernel_from_previous_process"), std::string::npos)
+      << "stale content survived";
+  unlink(path.c_str());
+}
+
+// Content written during this process's lifetime belongs to another JIT writer
+// sharing the map, and must survive.
+TEST(JitPerfMapTest, ContentFromThisProcessIsPreserved) {
+  enablePerfMap();
+  const pid_t child = runInChild([] {
+    const std::string path = mapPathFor(getpid());
+    std::ofstream out(path);
+    out << "cafe1000 20 other_jit::kernel\n";
+    out.close();
+
+    registerJitCodeForProfiling(kAddr, kSize, kSymbol);
+  });
+
+  const std::string path = mapPathFor(child);
+  const std::string contents = readFile(path);
+  EXPECT_NE(contents.find("other_jit::kernel"), std::string::npos)
+      << "co-writer's record was discarded:\n"
+      << contents;
+  EXPECT_NE(contents.find(kSymbol), std::string::npos)
+      << "own record missing:\n"
+      << contents;
+  unlink(path.c_str());
+}
+
+// The path is predictable, so a symlink planted there must not redirect the
+// write into someone else's file.
+TEST(JitPerfMapTest, SymlinkAtMapPathIsRefused) {
+  enablePerfMap();
+  const std::string victim = "/tmp/fbgemm_perf_map_victim.txt";
+  unlink(victim.c_str());
+  {
+    std::ofstream create(victim);
+  }
+
+  const pid_t child = runInChild([] {
+    const std::string path = mapPathFor(getpid());
+    unlink(path.c_str());
+    symlink("/tmp/fbgemm_perf_map_victim.txt", path.c_str());
+    registerJitCodeForProfiling(kAddr, kSize, kSymbol);
+  });
+
+  EXPECT_EQ(readFile(victim), "") << "write followed the symlink";
+  unlink(victim.c_str());
+  unlink(mapPathFor(child).c_str());
+}
+
+// Nothing serialises writers in userspace, so the guarantee that a record
+// arrives whole comes from handing each one to the kernel as a single
+// O_APPEND write. Concurrent writers must not tear or interleave records.
+TEST(JitPerfMapTest, ConcurrentWritesProduceWellFormedRecords) {
+  enablePerfMap();
+  constexpr int kThreads = 16;
+  constexpr int kPerThread = 200;
+
+  const pid_t child = runInChild([] {
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+      threads.emplace_back([t] {
+        for (int i = 0; i < kPerThread; ++i) {
+          registerJitCodeForProfiling(
+              kAddr, kSize, "fbgemm::thread" + std::to_string(t));
+        }
+      });
+    }
+    for (auto& thread : threads) {
+      thread.join();
+    }
+  });
+
+  const std::string path = mapPathFor(child);
+  std::ifstream in(path);
+  std::string line;
+  int lines = 0;
+  int malformed = 0;
+  while (std::getline(in, line)) {
+    ++lines;
+    unsigned long long addr = 0;
+    unsigned long long size = 0;
+    char symbol[128] = {};
+    // Exactly three fields, and the symbol must be one of the ones written.
+    if (sscanf(line.c_str(), "%llx %llx %127s", &addr, &size, symbol) != 3 ||
+        !std::string(symbol).starts_with("fbgemm::thread")) {
+      ++malformed;
+    }
+  }
+  EXPECT_EQ(lines, kThreads * kPerThread);
+  EXPECT_EQ(malformed, 0) << malformed << " of " << lines
+                          << " records were torn or interleaved";
+  unlink(path.c_str());
+}
+
+// fork() clones only the calling thread. A lock held by any other thread at
+// that instant would be inherited permanently locked, and the child would hang
+// on its first registration -- the PyTorch DataLoader pattern.
+TEST(JitPerfMapTest, ForkDuringConcurrentRegistrationDoesNotDeadlock) {
+  enablePerfMap();
+  constexpr int kForks = 100;
+  // A healthy child exits in about a millisecond. The loop stops at the first
+  // hang, so a regression fails in seconds instead of kForks * kTimeoutMs.
+  constexpr int kTimeoutMs = 2000;
+
+  std::atomic<bool> stop{false};
+  std::thread writer([&stop] {
+    while (!stop.load(std::memory_order_relaxed)) {
+      registerJitCodeForProfiling(kAddr, kSize, "fbgemm::concurrent_kernel");
+    }
+  });
+
+  int hung = 0;
+  for (int i = 0; i < kForks; ++i) {
+    const pid_t pid = fork();
+    if (pid == 0) {
+      registerJitCodeForProfiling(kAddr, kSize, kSymbol);
+      _exit(0);
+    }
+    ASSERT_GT(pid, 0);
+
+    bool exited = false;
+    for (int waited = 0; waited < kTimeoutMs; ++waited) {
+      int status = 0;
+      if (waitpid(pid, &status, WNOHANG) == pid) {
+        exited = true;
+        break;
+      }
+      usleep(1000);
+    }
+    if (!exited) {
+      ++hung;
+      kill(pid, SIGKILL);
+      waitpid(pid, nullptr, 0);
+    }
+    unlink(mapPathFor(pid).c_str());
+    if (hung > 0) {
+      break;
+    }
+  }
+
+  stop.store(true, std::memory_order_relaxed);
+  writer.join();
+  unlink(mapPathFor(getpid()).c_str());
+
+  EXPECT_EQ(hung, 0)
+      << "a child deadlocked on its first registration after forking while "
+         "another thread was registering";
+}
+
+#endif // _MSC_VER

--- a/test/JitPerfMapTest.cc
+++ b/test/JitPerfMapTest.cc
@@ -8,6 +8,10 @@
 
 #include <gtest/gtest.h>
 
+#include <set>
+#include <string>
+#include <vector>
+
 #include "src/JitPerfMap.h" // @manual
 
 #ifndef _MSC_VER
@@ -21,12 +25,67 @@
 #include <cstdlib>
 #include <fstream>
 #include <sstream>
-#include <string>
 #include <thread>
-#include <vector>
 #endif
 
 using namespace fbgemm;
+
+// JitSymbolBuilder decides the whole on-disk symbol format, and symbols are
+// only built when FBGEMM_JIT_PERF_MAP is set, so a formatting regression would
+// otherwise surface only in a profile.
+TEST(JitPerfMapTest, SymbolBuilderFormat) {
+  EXPECT_EQ(
+      JitSymbolBuilder("gemm")
+          .field("MC", 16)
+          .field("isa", "avx2")
+          .flag("accum", true)
+          .flag("trans", false)
+          .str(),
+      "fbgemm::gemm_MC-16_isa-avx2_accum-1_trans-0");
+  // A kernel with no fields is still namespace-qualified.
+  EXPECT_EQ(JitSymbolBuilder("bare").str(), "fbgemm::bare");
+}
+
+// Every inst_set_t has to name itself. instSetName() ends in an "anyarch"
+// fallback, so an enumerator added without a branch there would silently share
+// a name with anyarch, and kernels built for it would read in a profile as the
+// wrong instruction set. Distinctness is what catches that.
+TEST(JitPerfMapTest, EveryInstSetHasADistinctName) {
+  // The list below is hand-written because instSetName() is templated, so this
+  // switch is what keeps it honest: it has no default, so adding an
+  // inst_set_t enumerator makes it non-exhaustive and -Wswitch fails the
+  // build until both it and the list are updated.
+  const auto exhaustive = [](inst_set_t set) {
+    switch (set) {
+      case inst_set_t::anyarch:
+      case inst_set_t::avx2:
+      case inst_set_t::avx512:
+      case inst_set_t::avx512_ymm:
+      case inst_set_t::avx512_vnni:
+      case inst_set_t::avx512_vnni_ymm:
+      case inst_set_t::sve:
+        return true;
+    }
+    return false;
+  };
+  EXPECT_TRUE(exhaustive(inst_set_t::anyarch));
+
+  const std::vector<std::string> names = {
+      instSetName<inst_set_t::anyarch>(),
+      instSetName<inst_set_t::avx2>(),
+      instSetName<inst_set_t::avx512>(),
+      instSetName<inst_set_t::avx512_ymm>(),
+      instSetName<inst_set_t::avx512_vnni>(),
+      instSetName<inst_set_t::avx512_vnni_ymm>(),
+      instSetName<inst_set_t::sve>(),
+  };
+  for (const auto& name : names) {
+    EXPECT_FALSE(name.empty());
+  }
+  const std::set<std::string> unique(names.begin(), names.end());
+  EXPECT_EQ(unique.size(), names.size())
+      << "two inst_set_t values share a perf-map name";
+}
 
 #ifdef _MSC_VER
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3156

Follow-up to D118894440, which added `src/JitPerfMap.{h,cc}` and wired the two
embedding JIT sites. This covers the other 11 `runtime().add()` sites so no
asmjit-generated fbgemm kernel lands in a profile as `[unknown] ([Anon Map])`:

- `FbgemmI64.cc`
- `GenerateKernelU8S8S32ACC16.cc`, `...ACC16Avx512.cc`
- `GenerateKernelU8S8S32ACC32.cc`, `...ACC32Avx512VNNI.cc`
- `GenerateKernelDirectConvU8S8S32ACC32.cc` (2 sites)
- `GenerateI8Depthwise.cc`
- `SparseAdagrad.cc`
- `RowWiseSparseAdagradFused.cc`
- `GroupwiseConv.cc`

The five `CodeGenBase` GEMM kernels already had `getCodeLoggingFile()`, which
builds exactly the descriptive shape wanted for a symbol. That is split into a
new `getKernelName()` and `getCodeLoggingFile()` becomes
`getKernelName() + ".txt"`, so the two cannot drift. `getKernelName()` also
gains an `int64_t` branch -- `FbgemmI64` was falling into the `unknown_` case,
which is tolerable in a debug filename but not in a symbol. The other six sites
build a name from their own kernel signature.

Behaviour is unchanged unless `FBGEMM_JIT_PERF_MAP` is set.

Reviewed By: q10

Differential Revision: D118896564


