### PR TITLE
Resolve PT2, Meta, and autograd warnings (#6275)

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -158,6 +158,39 @@ set(fbgemm_sources_include_directories
 #
 # Do NOT add first-party paths to this list: doing so silently disables all
 # warnings for that code.
+if(FBGEMM_BUILD_TARGET STREQUAL BUILD_TARGET_GENAI
+  AND FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM
+  AND EXISTS "${THIRDPARTY}/composable_kernel/include/ck/config.h.in")
+  set(CK_ENABLE_ALL_DTYPES ON)
+  if(AMDGPU_TARGETS MATCHES "gfx9")
+    set(CK_USE_XDL ON)
+  endif()
+  if(AMDGPU_TARGETS MATCHES "gfx94|gfx95")
+    set(CK_USE_GFX94 ON)
+  endif()
+  if(AMDGPU_TARGETS MATCHES "gfx11|gfx12")
+    set(CK_USE_WMMA ON)
+  endif()
+  if(AMDGPU_TARGETS MATCHES "gfx12")
+    set(CK_USE_WMMA_FP8 ON)
+  endif()
+  if(AMDGPU_TARGETS MATCHES "gfx12|gfx950")
+    set(CK_USE_OCP_FP8 ON)
+  endif()
+  if(AMDGPU_TARGETS MATCHES "gfx90a|gfx94")
+    set(CK_USE_FNUZ_FP8 ON)
+  endif()
+  if(AMDGPU_TARGETS MATCHES "gfx950")
+    set(CK_USE_NATIVE_MX_SUPPORT ON)
+  endif()
+
+  set(ck_generated_include_directory
+    "${CMAKE_CURRENT_BINARY_DIR}/composable_kernel/include")
+  configure_file(
+    "${THIRDPARTY}/composable_kernel/include/ck/config.h.in"
+    "${ck_generated_include_directory}/ck/config.h")
+endif()
+
 set(fbgemm_thirdparty_include_directories
   # PyTorch
   ${TORCH_INCLUDE_DIRS}
@@ -168,6 +201,7 @@ set(fbgemm_thirdparty_include_directories
   ${THIRDPARTY}/cutlass/tools/util/include
   ${THIRDPARTY}/composable_kernel/include
   ${THIRDPARTY}/composable_kernel/library/include
+  ${ck_generated_include_directory}
   ${THIRDPARTY}/json/include
   ${NCCL_INCLUDE_DIRS})
 

--- a/fbgemm_gpu/codegen/genscript/optimizer_args.py
+++ b/fbgemm_gpu/codegen/genscript/optimizer_args.py
@@ -73,13 +73,28 @@ def decl_surfaces(
     return frozenset(resolved)
 
 
+# A meta function shadows a CUDA op so that shape propagation can run without a
+# device. It must accept the op's whole argument list, including the optimizer
+# state, but it only computes output shapes and never reads an optimizer
+# argument. That is a property of the declaration surface rather than of any one
+# argument, so it is stated once here instead of on every optimizer spec.
+SURFACES_NOT_READING_OPTIMIZER_ARGS: frozenset[DeclSurface] = frozenset(
+    {DeclSurface.META}
+)
+
+
 def annotate_unused_declaration(
     declaration: str,
     unused_on: frozenset[DeclSurface],
     surface: DeclSurface,
 ) -> str:
-    """Prefix a C++ parameter declaration when it is unused on `surface`."""
-    return f"[[maybe_unused]] {declaration}" if surface in unused_on else declaration
+    """Prefix a C++ optimizer-argument declaration that `surface` does not read.
+
+    Either the argument's own policy names the surface, or the surface reads no
+    optimizer argument at all.
+    """
+    unused = surface in unused_on or surface in SURFACES_NOT_READING_OPTIMIZER_ARGS
+    return f"[[maybe_unused]] {declaration}" if unused else declaration
 
 
 def maybe_unused_args(args_str: str, apply: bool = True) -> str:
@@ -1288,7 +1303,7 @@ class OptimizerArgsSet:
                 f"{name}_host",
                 default,
                 is_optional=is_optional,
-                unused_on=unused_on,
+                unused_on=unused_on | {DeclSurface.PT2_CUDA},
             ),
             # pyre-fixme[19]: Expected 1 positional argument.
             OptimItem(
@@ -1297,7 +1312,7 @@ class OptimizerArgsSet:
                 default,
                 ph_tys,
                 is_optional=is_optional,
-                unused_on=unused_on,
+                unused_on=unused_on | {DeclSurface.PT2_CPU},
             ),
             # pyre-fixme[19]: Expected 1 positional argument.
             OptimItem(
@@ -1306,7 +1321,7 @@ class OptimizerArgsSet:
                 default,
                 ph_tys,
                 is_optional=is_optional,
-                unused_on=unused_on,
+                unused_on=unused_on | {DeclSurface.PT2_CPU},
             ),
             # pyre-fixme[19]: Expected 1 positional argument.
             OptimItem(

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_meta_template.cpp
@@ -59,13 +59,13 @@ Tensor batch_index_select_dim0_codegen_backward_meta(
 Tensor {{ mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ desc_suffix }}_meta(
 {%- endif %}
     const Tensor& grad_output [[maybe_unused]],
-    const Tensor& dev_weights,
+    {{ "" if (dense or optimizer == "none") else "[[maybe_unused]] " }}const Tensor& dev_weights,
     {%- if not dense %}
     const Tensor& uvm_weights [[maybe_unused]],
     const Tensor& lxu_cache_weights [[maybe_unused]],
     const Tensor& weights_placements [[maybe_unused]],
     {%- endif %}
-    const Tensor& weights_offsets,
+    {{ "" if (nobag and not is_index_select) else "[[maybe_unused]] " }}const Tensor& weights_offsets,
     {%- if not nobag or is_index_select %}
     const Tensor& D_offsets,
     const c10::SymInt max_D,
@@ -121,13 +121,13 @@ Tensor {{ mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ desc
     const bool permute_output_dim_0_1
     {%- elif optimizer != "none" %}
     {%- if is_gwd %}
-    const Tensor& prev_iter_dev,
+    [[maybe_unused]] const Tensor& prev_iter_dev,
     {%- if "iter" not in args.split_function_arg_names %}
-    const int64_t iter,
+    [[maybe_unused]] const int64_t iter,
     {%- endif %}
-    const double gwd_lower_bound,
+    [[maybe_unused]] const double gwd_lower_bound,
     {%- endif -%}
-    {{ args.split_function_args_no_defaults | join(", ") }}
+    {{ args.split_function_args_no_defaults_by_surface["meta"] | join(", ") }}
     {%- else %}
     // This is actually passed via args.split_function_args_no_defaults but explicitly list
     // it here for code readability

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -680,7 +680,8 @@ class {{ autograd_func }} :
   static torch::autograd::variable_list forward(
     torch::autograd::AutogradContext* ctx,
     {%- if not dense %}
-    const Tensor& placeholder_autograd_tensor,
+    {#- /* Exists only to give autograd a differentiable leaf input. */ #}
+    [[maybe_unused]] const Tensor& placeholder_autograd_tensor,
     {%- endif %}
     const int64_t output_dtype,
     {%- if dense %}
@@ -721,7 +722,10 @@ class {{ autograd_func }} :
     {%- if not dense %}
     std::vector<std::optional<at::Tensor>> aux_tensor,
     std::vector<int64_t> aux_int,
-    std::vector<double> aux_float,
+    {#- /* The packed float auxiliaries are the gradient clip bound and the
+          global-weight-decay lower bound; the `none` optimizer applies
+          neither. */ #}
+    {{ "" if ((optimizer != "none" and not dense) or is_gwd) else "[[maybe_unused]] " }}std::vector<double> aux_float,
     c10::List<bool> aux_bool,
     {%- endif %}
     {%- if ssd %}
@@ -1378,17 +1382,21 @@ Tensor {{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function_pt2(
     c10::List<bool> aux_bool,
     {%- endif %} {#-/* if not dense */#}
     {{ args_pt2.unified_pt2.split_function_args | join(", ") }},
-    const c10::SymInt max_B = -1,
-    const c10::SymInt max_B_feature_rank = -1,
+    {#- /* The VBE arguments are on every unified lookup signature so the PT2
+          schema is one shape for all optimizers, and are forwarded only by
+          optimizers that support VBE. */ #}
+    {%- set mu_vbe = "" if has_vbe_support else "[[maybe_unused]] " %}
+    {{ mu_vbe }}const c10::SymInt max_B = -1,
+    {{ mu_vbe }}const c10::SymInt max_B_feature_rank = -1,
     {%- if not dense %}
-    const c10::SymInt vbe_output_size = -1,
+    {{ mu_vbe }}const c10::SymInt vbe_output_size = -1,
     {%- if ssd %}
     const std::optional<at::TensorList>& ssd_tensors = std::nullopt,
     {%- endif %} {#-/* if ssd */#}
-    std::optional<Tensor> vbe_output = std::nullopt
+    {{ mu_vbe }}std::optional<Tensor> vbe_output = std::nullopt
     {%- else %}
     {#- /* ssd and pre-allocated vbe_output is not yet supported in Dense TBE */ -#}
-    const c10::SymInt vbe_output_size = -1
+    {{ mu_vbe }}const c10::SymInt vbe_output_size = -1
     {%- endif %} {#-/* if not dense */#}
 ) {
 

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
@@ -66,10 +66,13 @@ Tensor split_embedding_codegen_grad_indice_weights{{ vdesc }}_pt2_cpu_wrapper(
     const Tensor& /*lxu_cache_locations*/,
     {%- if vbe %}
     const Tensor& feature_requires_grad,
-    const Tensor& vbe_row_output_offsets,
-    const Tensor& vbe_b_t_map,
-    const int64_t info_B_num_bits,
-    const int64_t info_B_mask_int64,
+    {#- /* The CPU path reshapes its own VBE offsets from
+          vbe_B_offsets_rank_per_feature and max_B; the flattened row layout
+          and the packed (b, t) bit widths are CUDA-side metadata. */ #}
+    [[maybe_unused]] const Tensor& vbe_row_output_offsets,
+    [[maybe_unused]] const Tensor& vbe_b_t_map,
+    [[maybe_unused]] const int64_t info_B_num_bits,
+    [[maybe_unused]] const int64_t info_B_mask_int64,
     const Tensor& vbe_B_offsets_rank_per_feature,
     const c10::SymInt max_B
     {%- else %}
@@ -141,20 +144,23 @@ Tensor split_embedding{{ ndesc }}_codegen_forward_{{ wdesc }}{{ vdesc }}_pt2_cpu
     const Tensor& /*lxu_cache_locations*/,
     const Tensor& /*uvm_cache_stats*/,
     {%- if vbe %}
-    const Tensor& vbe_row_output_offsets,
-    const Tensor& vbe_b_t_map,
+    {#- /* As above: the CPU forward reshapes from
+          vbe_B_offsets_rank_per_feature and max_B, and allocates its own
+          output rather than writing into a caller-supplied one. */ #}
+    [[maybe_unused]] const Tensor& vbe_row_output_offsets,
+    [[maybe_unused]] const Tensor& vbe_b_t_map,
     const c10::SymInt vbe_output_size,
-    const int64_t info_B_num_bits,
-    const int64_t info_B_mask_int64,
+    [[maybe_unused]] const int64_t info_B_num_bits,
+    [[maybe_unused]] const int64_t info_B_mask_int64,
     const Tensor& vbe_B_offsets_rank_per_feature,
     const Tensor& vbe_output_offsets_feature_rank,
     const c10::SymInt max_B,
-    const Tensor& B_offsets,
+    [[maybe_unused]] const Tensor& B_offsets,
     {%- endif %}
     const bool /*is_experimental = false*/,
     {%- if vbe %}
     const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32),
-    std::optional<Tensor> vbe_output = std::nullopt
+    [[maybe_unused]] std::optional<Tensor> vbe_output = std::nullopt
     {%- else %}
     const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)
     {%- endif %}
@@ -262,7 +268,9 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{
     {%- else %}
     const Tensor& D_offsets,
     const c10::SymInt max_D,
-    const bool mixed_D,
+    {#- /* Mixed-D dispatch and the packed (b, t) bit layout exist for the CUDA
+          backward; the CPU backward walks the tables directly. */ #}
+    [[maybe_unused]] const bool mixed_D,
     {%- endif %}
     const Tensor& hash_size_cumsum,
     const int64_t total_hash_size_bits,
@@ -276,14 +284,14 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{
     const int64_t /*BT_block_size*/,
     const int64_t /*max_segment_length_per_warp*/,
     const bool stochastic_rounding,
-    const int64_t info_B_num_bits,
-    const int64_t info_B_mask_int64,
+    [[maybe_unused]] const int64_t info_B_num_bits,
+    [[maybe_unused]] const int64_t info_B_mask_int64,
     {%- if vbe %}
     const c10::SymInt max_B,
     {%- endif %}
     const bool /*use_uniq_cache_locations*/,
     const bool /*use_homogeneous_placements*/,
-    {{ args_pt2.split_function_args | join(", ") }}
+    {{ args_pt2.split_function_args_by_surface["pt2_cpu"] | join(", ") }}
     {%- if not nobag %}
     , const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)
     {%- endif %})

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
@@ -88,12 +88,14 @@ Tensor {{ fwd_mdesc }}_embedding{{ ndesc }}_codegen_forward_{{ desc_suffix }}_pt
     const c10::SymInt total_D,
     const c10::SymInt max_D,
     {%- endif %}
-    const Tensor& hash_size_cumsum,
+    {#- /* The forward op reads the hash size cumsum only on the global
+          weight decay path. */ #}
+    {{ "" if is_gwd else "[[maybe_unused]] " }}const Tensor& hash_size_cumsum,
     const Tensor& indices,
     const Tensor& offsets,
     {%- if not nobag %}
     const int64_t pooling_mode,
-    const Tensor& indice_weights, // CPU always takes indice_weights
+    {{ "" if weighted else "[[maybe_unused]] " }}const Tensor& indice_weights, // CPU always takes indice_weights
     {%- endif %}
     const Tensor& {{ "ssd_row_addrs" if ssd else "lxu_cache_locations" }},
     const Tensor& uvm_cache_stats,
@@ -103,10 +105,13 @@ Tensor {{ fwd_mdesc }}_embedding{{ ndesc }}_codegen_forward_{{ desc_suffix }}_pt
     const c10::SymInt vbe_output_size,
     const int64_t info_B_num_bits,
     const int64_t info_B_mask_int64,
-    const Tensor& vbe_B_offsets_rank_per_feature,
-    const Tensor& vbe_output_offsets_feature_rank,
-    const c10::SymInt max_B,
-    const Tensor& B_offsets,
+    {#- /* The rank-per-feature VBE metadata is used by the CPU wrapper to
+          reshape its output; the CUDA forward op takes the flattened form
+          above. */ #}
+    [[maybe_unused]] const Tensor& vbe_B_offsets_rank_per_feature,
+    [[maybe_unused]] const Tensor& vbe_output_offsets_feature_rank,
+    [[maybe_unused]] const c10::SymInt max_B,
+    [[maybe_unused]] const Tensor& B_offsets,
     {%- endif %}
     {%- if is_gwd %}
     const Tensor& prev_iter_dev,
@@ -247,7 +252,8 @@ Tensor {{ bwd_mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ 
     const Tensor& offsets,
     {%- if not nobag %}
     const int64_t pooling_mode,
-    const Tensor& indice_weights, // currently supports no bag with unweighted
+    {#- /* Only the weighted backward forwards the indice weights. */ #}
+    {{ "" if weighted else "[[maybe_unused]] " }}const Tensor& indice_weights, // currently supports no bag with unweighted
     {%- endif %}
     const at::TensorList aux_tensor_bwd,
     const int64_t BT_block_size,
@@ -274,9 +280,11 @@ Tensor {{ bwd_mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ 
     {%- endif %}
     const double gwd_lower_bound,
     {%- endif %}
-    {{ args_pt2.split_function_args | join(", ") }}
+    {{ args_pt2.split_function_args_by_surface["pt2_cuda"] | join(", ") }}
     {%- if not nobag %}
-    , const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)
+    {#- /* Present so the PT2 backward schema mirrors the forward one; the
+          backward op derives its own output type. */ #}
+    , [[maybe_unused]] const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)
     {%- endif %}){
         TORCH_CHECK(
             weights.size() == 5,
@@ -458,8 +466,10 @@ Tensor {{ fwd_mdesc }}_embedding_codegen_grad_indice_weights{{ vdesc }}_pt2_{{ d
     const Tensor& vbe_b_t_map,
     const int64_t info_B_num_bits,
     const int64_t info_B_mask_int64,
-    const Tensor& vbe_B_offsets_rank_per_feature,
-    const c10::SymInt max_B
+    {#- /* The CPU wrapper reshapes its offsets from these two; the CUDA
+          grad-indice-weights op takes the flattened row layout above. */ #}
+    [[maybe_unused]] const Tensor& vbe_B_offsets_rank_per_feature,
+    [[maybe_unused]] const c10::SymInt max_B
     {%- else %}
     const Tensor& feature_requires_grad
     {%- endif %}

--- a/fbgemm_gpu/experimental/gen_ai/src/moe/index_shuffling.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/moe/index_shuffling.cu
@@ -544,7 +544,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> index_shuffling_torch(
         static int num_sms = -1;
         if (num_sms < 0) {
           cudaDeviceProp deviceProp;
-          cudaGetDeviceProperties(&deviceProp, 0);
+          C10_CUDA_CHECK(cudaGetDeviceProperties(&deviceProp, 0));
           num_sms = deviceProp.multiProcessorCount;
         }
 

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
@@ -246,10 +246,10 @@ inline uint32_t cap_grid_dim_x_from_workload(
 inline auto get_compute_versions() {
   static const auto versions = [] {
     int runtime_version = 0;
-    cudaRuntimeGetVersion(&runtime_version);
+    C10_CUDA_CHECK(cudaRuntimeGetVersion(&runtime_version));
 
     int driver_version = 0;
-    cudaDriverGetVersion(&driver_version);
+    C10_CUDA_CHECK(cudaDriverGetVersion(&driver_version));
 
     return std::tuple{runtime_version, driver_version};
   }();

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
@@ -10,6 +10,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAStream.h>
 
 #include "fbgemm_gpu/utils/kernel_execution_timer.cuh"
@@ -317,7 +318,7 @@ struct __attribute__((visibility("hidden"))) KernelLauncher {
     // launching the kernel.  This has roughly the same effect as setting
     // `CUDA_LAUNCH_BLOCKING=1` as an environment variable.
     if constexpr (EnableBarrierIsolation) {
-      cudaDeviceSynchronize();
+      C10_CUDA_CHECK(cudaDeviceSynchronize());
     }
 
     // If execution timer is enabled, initialize and start the CUDAEvents-based
@@ -362,7 +363,7 @@ struct __attribute__((visibility("hidden"))) KernelLauncher {
     // If barrier isolation is enabled, synchronize the stream again to wait for
     // kernel execution to complete
     if constexpr (EnableBarrierIsolation) {
-      cudaDeviceSynchronize();
+      C10_CUDA_CHECK(cudaDeviceSynchronize());
     }
 
     // Check for CUDA errors.  This is a replacement for

--- a/fbgemm_gpu/src/intraining_embedding_pruning_ops/intraining_embedding_pruning.cu
+++ b/fbgemm_gpu/src/intraining_embedding_pruning_ops/intraining_embedding_pruning.cu
@@ -572,30 +572,32 @@ std::tuple<Tensor, Tensor, int64_t> prune_embedding_tables_cuda(
     int64_t length = sampling_offsets_a[i + 1] - sampling_offsets_a[i];
     size_t temp_storage_bytes = 0;
 
-    cub::DeviceRadixSort::SortKeys(
-        nullptr,
-        temp_storage_bytes,
-        sampled_utilities.const_data_ptr<float>() + sampling_offsets_a[i],
-        sampled_utilities_sorted.data_ptr<float>() + sampling_offsets_a[i],
-        length,
-        0,
-        sizeof(float) * 8,
-        at::cuda::getCurrentCUDAStream());
+    AT_CUDA_CHECK(
+        cub::DeviceRadixSort::SortKeys(
+            nullptr,
+            temp_storage_bytes,
+            sampled_utilities.const_data_ptr<float>() + sampling_offsets_a[i],
+            sampled_utilities_sorted.data_ptr<float>() + sampling_offsets_a[i],
+            length,
+            0,
+            sizeof(float) * 8,
+            at::cuda::getCurrentCUDAStream()));
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 
     auto temp_storage = at::empty(
         {static_cast<int64_t>(temp_storage_bytes)},
         row_utils.options().dtype(at::kByte));
 
-    cub::DeviceRadixSort::SortKeys(
-        temp_storage.data_ptr(),
-        temp_storage_bytes,
-        sampled_utilities.const_data_ptr<float>() + sampling_offsets_a[i],
-        sampled_utilities_sorted.data_ptr<float>() + sampling_offsets_a[i],
-        length,
-        0,
-        sizeof(float) * 8,
-        at::cuda::getCurrentCUDAStream());
+    AT_CUDA_CHECK(
+        cub::DeviceRadixSort::SortKeys(
+            temp_storage.data_ptr(),
+            temp_storage_bytes,
+            sampled_utilities.const_data_ptr<float>() + sampling_offsets_a[i],
+            sampled_utilities_sorted.data_ptr<float>() + sampling_offsets_a[i],
+            length,
+            0,
+            sizeof(float) * 8,
+            at::cuda::getCurrentCUDAStream()));
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
   // Second, get util thresholds
@@ -805,30 +807,32 @@ Tensor remap_indices_update_utils_cuda(
                 at::zeros({full_length}, full_values.options());
             size_t temp_storage_bytes_0 = 0;
 
-            cub::DeviceRadixSort::SortKeys(
-                nullptr,
-                temp_storage_bytes_0,
-                full_values.const_data_ptr<index_t>() + full_start,
-                values_sorted.data_ptr<index_t>(),
-                full_length,
-                0,
-                sizeof(index_t) * 8,
-                at::cuda::getCurrentCUDAStream());
+            AT_CUDA_CHECK(
+                cub::DeviceRadixSort::SortKeys(
+                    nullptr,
+                    temp_storage_bytes_0,
+                    full_values.const_data_ptr<index_t>() + full_start,
+                    values_sorted.data_ptr<index_t>(),
+                    full_length,
+                    0,
+                    sizeof(index_t) * 8,
+                    at::cuda::getCurrentCUDAStream()));
             C10_CUDA_KERNEL_LAUNCH_CHECK();
 
             auto temp_storage_0 = at::empty(
                 {static_cast<index_t>(temp_storage_bytes_0)},
                 values.options().dtype(at::kByte));
 
-            cub::DeviceRadixSort::SortKeys(
-                temp_storage_0.data_ptr(),
-                temp_storage_bytes_0,
-                full_values.const_data_ptr<index_t>() + full_start,
-                values_sorted.data_ptr<index_t>(),
-                full_length,
-                0,
-                sizeof(index_t) * 8,
-                at::cuda::getCurrentCUDAStream());
+            AT_CUDA_CHECK(
+                cub::DeviceRadixSort::SortKeys(
+                    temp_storage_0.data_ptr(),
+                    temp_storage_bytes_0,
+                    full_values.const_data_ptr<index_t>() + full_start,
+                    values_sorted.data_ptr<index_t>(),
+                    full_length,
+                    0,
+                    sizeof(index_t) * 8,
+                    at::cuda::getCurrentCUDAStream()));
             C10_CUDA_KERNEL_LAUNCH_CHECK();
 
             // run length encode to count access frequency to each row
@@ -839,30 +843,32 @@ Tensor remap_indices_update_utils_cuda(
                 at::zeros({1}, values_sorted.options().dtype(at::kInt));
             size_t temp_storage_bytes_1 = 0;
 
-            cub::DeviceRunLengthEncode::Encode(
-                nullptr,
-                temp_storage_bytes_1,
-                values_sorted.const_data_ptr<index_t>(),
-                values_sorted_unique_run.data_ptr<index_t>(),
-                values_sorted_counts_run.data_ptr<int32_t>(),
-                values_sorted_num_runs.data_ptr<int32_t>(),
-                full_length,
-                at::cuda::getCurrentCUDAStream());
+            AT_CUDA_CHECK(
+                cub::DeviceRunLengthEncode::Encode(
+                    nullptr,
+                    temp_storage_bytes_1,
+                    values_sorted.const_data_ptr<index_t>(),
+                    values_sorted_unique_run.data_ptr<index_t>(),
+                    values_sorted_counts_run.data_ptr<int32_t>(),
+                    values_sorted_num_runs.data_ptr<int32_t>(),
+                    full_length,
+                    at::cuda::getCurrentCUDAStream()));
             C10_CUDA_KERNEL_LAUNCH_CHECK();
 
             auto temp_storage_1 = at::empty(
                 {static_cast<index_t>(temp_storage_bytes_1)},
                 values.options().dtype(at::kByte));
 
-            cub::DeviceRunLengthEncode::Encode(
-                temp_storage_1.data_ptr(),
-                temp_storage_bytes_1,
-                values_sorted.const_data_ptr<index_t>(),
-                values_sorted_unique_run.data_ptr<index_t>(),
-                values_sorted_counts_run.data_ptr<int32_t>(),
-                values_sorted_num_runs.data_ptr<int32_t>(),
-                full_length,
-                at::cuda::getCurrentCUDAStream());
+            AT_CUDA_CHECK(
+                cub::DeviceRunLengthEncode::Encode(
+                    temp_storage_1.data_ptr(),
+                    temp_storage_bytes_1,
+                    values_sorted.const_data_ptr<index_t>(),
+                    values_sorted_unique_run.data_ptr<index_t>(),
+                    values_sorted_counts_run.data_ptr<int32_t>(),
+                    values_sorted_num_runs.data_ptr<int32_t>(),
+                    full_length,
+                    at::cuda::getCurrentCUDAStream()));
             C10_CUDA_KERNEL_LAUNCH_CHECK();
 
             // remap indices and update row utils

--- a/fbgemm_gpu/src/split_embeddings_utils/transpose_embedding_input.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils/transpose_embedding_input.cu
@@ -378,7 +378,7 @@ transpose_embedding_input(
                 rocprim::default_config,
                 rocprim::default_config,
                 400000>;
-	        rocprim::radix_sort_pairs<config>(
+	        AT_CUDA_CHECK(rocprim::radix_sort_pairs<config>(
                     nullptr,
                     temp_storage_bytes,
                     linear_indices.data_ptr<index_t>(),
@@ -389,11 +389,11 @@ transpose_embedding_input(
                     0,
                     total_hash_size_bits,
                     at::cuda::getCurrentCUDAStream(),
-                    false);
+                    false));
                 auto temp_storage = at::empty(
                     {static_cast<int64_t>(temp_storage_bytes)},
                     indices.options().dtype(at::kByte));
-                rocprim::radix_sort_pairs<config>(
+                AT_CUDA_CHECK(rocprim::radix_sort_pairs<config>(
                     temp_storage.data_ptr(),
                     temp_storage_bytes,
                     linear_indices.data_ptr<index_t>(),
@@ -404,7 +404,7 @@ transpose_embedding_input(
                     0,
                     total_hash_size_bits,
                     at::cuda::getCurrentCUDAStream(),
-                    false);
+                    false));
 #endif
               }
               if (total_unique_indices != -1) {

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -1380,7 +1380,7 @@ TEST(FusedNBitRowwiseEmbeddingLookupTest, NoBagInt4DropsInputRowPadding) {
       EXPECT_TRUE(all_of(
           output.begin() + kOutputSize * kInt4NoBagPackedRowSize,
           output.end(),
-          [](uint8_t value) { return value == kCanary; }))
+          [canary = kCanary](uint8_t value) { return value == canary; }))
           << "kernel_choice=" << kernel_choice
           << ", requested_output_stride=" << requested_output_stride;
     }
@@ -1419,7 +1419,7 @@ TEST(
     EXPECT_TRUE(all_of(
         output.begin() + expected.size(),
         output.end(),
-        [](uint8_t value) { return value == kCanary; }))
+        [canary = kCanary](uint8_t value) { return value == canary; }))
         << path;
   };
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3157

NOTE: No linked task. Please associate a task with this diff.

Project unified optimizer arguments onto their PT2 CPU, PT2 CUDA, Meta, and autograd declaration surfaces.

Each generated wrapper keeps the shared operator contract while annotating the host, device, VBE, and optimizer-state arguments that its implementation does not read.

The OSS validation run also exposed failures from changes that landed after this diff branched. The diff now makes the INT4 no-bag canary predicates portable across Clang and GCC; checks CUDA runtime/driver queries and barrier synchronizations through `C10_CUDA_CHECK`; and checks rocPRIM and CUB/HIPCUB sorting results through `AT_CUDA_CHECK`. These checks consume the newer ROCm APIs' `[[nodiscard]]` results and preserve runtime error reporting. For GenAI ROCm builds, CMake now materializes the `ck/config.h` required by the updated Composable Kernel submodule and exposes architecture features derived from `AMDGPU_TARGETS`.

Reviewed By: gchalump

Differential Revision: D117024951


