### PR TITLE
Add the two warnings that only the internal build had

### DIFF
--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -74,7 +74,11 @@ function(fbgemm_get_warning_flags)
     -Wunused-const-variable
     -Wunused-but-set-variable
     -Wunused-function
-    -Wunused-result)
+    -Wunused-result
+    # The internal build of this library uses these two flags. This list keeps
+    # the two builds the same.
+    -Wignored-qualifiers
+    -Wtautological-compare)
 
   # Clang-only flags. g++ does not know these flags. g++ stops with an error
   # when it gets an unknown `-W` option. This error occurs even when `-Werror`


### PR DESCRIPTION
Summary:
NOTE: No linked task. Please associate a task with this diff.

The internal build of this library uses two warnings that this list did not
contain:

  -Wignored-qualifiers      from the internal compiler flags
  -Wtautological-compare    from the directory settings

Both compilers accept the two flags and the matching `-Wno-error=` forms, so
the flags go in the portable list.

`-Wignored-qualifiers` makes no change to the behaviour. `-Wextra` already
switches it on. A test file gives one warning with `-Wall -Wextra` alone, and
the same count with the flag present.

`-Wtautological-compare` can give new warnings. The internal build has this
flag on for the host code, and the host code is clean. Device code is
different: the internal flags do not reach device code, but this list does.
Device code can therefore contain sites that nobody has compiled with this
flag. The ROCm CI is the first build that will show them. If the count is
large, the correct next step is to add `-Wno-error=tautological-compare`, fix
the sites, and then remove the line again.

After this change, the flags in this list contain all the flags of the
internal build.

Reviewed By: jwfromm

Differential Revision: D117144344


