### PR TITLE
Fix ROCm build failures related to return values discarding

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
@@ -246,10 +246,10 @@ inline uint32_t cap_grid_dim_x_from_workload(
 inline auto get_compute_versions() {
   static const auto versions = [] {
     int runtime_version = 0;
-    cudaRuntimeGetVersion(&runtime_version);
+    C10_CUDA_CHECK(cudaRuntimeGetVersion(&runtime_version));
 
     int driver_version = 0;
-    cudaDriverGetVersion(&driver_version);
+    C10_CUDA_CHECK(cudaDriverGetVersion(&driver_version));
 
     return std::tuple{runtime_version, driver_version};
   }();

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
@@ -10,6 +10,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAStream.h>
 
 #include "fbgemm_gpu/utils/kernel_execution_timer.cuh"
@@ -317,7 +318,7 @@ struct __attribute__((visibility("hidden"))) KernelLauncher {
     // launching the kernel.  This has roughly the same effect as setting
     // `CUDA_LAUNCH_BLOCKING=1` as an environment variable.
     if constexpr (EnableBarrierIsolation) {
-      cudaDeviceSynchronize();
+      C10_CUDA_CHECK(cudaDeviceSynchronize());
     }
 
     // If execution timer is enabled, initialize and start the CUDAEvents-based
@@ -362,7 +363,7 @@ struct __attribute__((visibility("hidden"))) KernelLauncher {
     // If barrier isolation is enabled, synchronize the stream again to wait for
     // kernel execution to complete
     if constexpr (EnableBarrierIsolation) {
-      cudaDeviceSynchronize();
+      C10_CUDA_CHECK(cudaDeviceSynchronize());
     }
 
     // Check for CUDA errors.  This is a replacement for

--- a/fbgemm_gpu/src/intraining_embedding_pruning_ops/intraining_embedding_pruning.cu
+++ b/fbgemm_gpu/src/intraining_embedding_pruning_ops/intraining_embedding_pruning.cu
@@ -572,7 +572,7 @@ std::tuple<Tensor, Tensor, int64_t> prune_embedding_tables_cuda(
     int64_t length = sampling_offsets_a[i + 1] - sampling_offsets_a[i];
     size_t temp_storage_bytes = 0;
 
-    cub::DeviceRadixSort::SortKeys(
+    AT_CUDA_CHECK(cub::DeviceRadixSort::SortKeys(
         nullptr,
         temp_storage_bytes,
         sampled_utilities.const_data_ptr<float>() + sampling_offsets_a[i],
@@ -580,14 +580,14 @@ std::tuple<Tensor, Tensor, int64_t> prune_embedding_tables_cuda(
         length,
         0,
         sizeof(float) * 8,
-        at::cuda::getCurrentCUDAStream());
+        at::cuda::getCurrentCUDAStream()));
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 
     auto temp_storage = at::empty(
         {static_cast<int64_t>(temp_storage_bytes)},
         row_utils.options().dtype(at::kByte));
 
-    cub::DeviceRadixSort::SortKeys(
+    AT_CUDA_CHECK(cub::DeviceRadixSort::SortKeys(
         temp_storage.data_ptr(),
         temp_storage_bytes,
         sampled_utilities.const_data_ptr<float>() + sampling_offsets_a[i],
@@ -595,7 +595,7 @@ std::tuple<Tensor, Tensor, int64_t> prune_embedding_tables_cuda(
         length,
         0,
         sizeof(float) * 8,
-        at::cuda::getCurrentCUDAStream());
+        at::cuda::getCurrentCUDAStream()));
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
   // Second, get util thresholds
@@ -805,7 +805,7 @@ Tensor remap_indices_update_utils_cuda(
                 at::zeros({full_length}, full_values.options());
             size_t temp_storage_bytes_0 = 0;
 
-            cub::DeviceRadixSort::SortKeys(
+            AT_CUDA_CHECK(cub::DeviceRadixSort::SortKeys(
                 nullptr,
                 temp_storage_bytes_0,
                 full_values.const_data_ptr<index_t>() + full_start,
@@ -813,14 +813,14 @@ Tensor remap_indices_update_utils_cuda(
                 full_length,
                 0,
                 sizeof(index_t) * 8,
-                at::cuda::getCurrentCUDAStream());
+                at::cuda::getCurrentCUDAStream()));
             C10_CUDA_KERNEL_LAUNCH_CHECK();
 
             auto temp_storage_0 = at::empty(
                 {static_cast<index_t>(temp_storage_bytes_0)},
                 values.options().dtype(at::kByte));
 
-            cub::DeviceRadixSort::SortKeys(
+            AT_CUDA_CHECK(cub::DeviceRadixSort::SortKeys(
                 temp_storage_0.data_ptr(),
                 temp_storage_bytes_0,
                 full_values.const_data_ptr<index_t>() + full_start,
@@ -828,7 +828,7 @@ Tensor remap_indices_update_utils_cuda(
                 full_length,
                 0,
                 sizeof(index_t) * 8,
-                at::cuda::getCurrentCUDAStream());
+                at::cuda::getCurrentCUDAStream()));
             C10_CUDA_KERNEL_LAUNCH_CHECK();
 
             // run length encode to count access frequency to each row
@@ -839,7 +839,7 @@ Tensor remap_indices_update_utils_cuda(
                 at::zeros({1}, values_sorted.options().dtype(at::kInt));
             size_t temp_storage_bytes_1 = 0;
 
-            cub::DeviceRunLengthEncode::Encode(
+            AT_CUDA_CHECK(cub::DeviceRunLengthEncode::Encode(
                 nullptr,
                 temp_storage_bytes_1,
                 values_sorted.const_data_ptr<index_t>(),
@@ -847,14 +847,14 @@ Tensor remap_indices_update_utils_cuda(
                 values_sorted_counts_run.data_ptr<int32_t>(),
                 values_sorted_num_runs.data_ptr<int32_t>(),
                 full_length,
-                at::cuda::getCurrentCUDAStream());
+                at::cuda::getCurrentCUDAStream()));
             C10_CUDA_KERNEL_LAUNCH_CHECK();
 
             auto temp_storage_1 = at::empty(
                 {static_cast<index_t>(temp_storage_bytes_1)},
                 values.options().dtype(at::kByte));
 
-            cub::DeviceRunLengthEncode::Encode(
+            AT_CUDA_CHECK(cub::DeviceRunLengthEncode::Encode(
                 temp_storage_1.data_ptr(),
                 temp_storage_bytes_1,
                 values_sorted.const_data_ptr<index_t>(),
@@ -862,7 +862,7 @@ Tensor remap_indices_update_utils_cuda(
                 values_sorted_counts_run.data_ptr<int32_t>(),
                 values_sorted_num_runs.data_ptr<int32_t>(),
                 full_length,
-                at::cuda::getCurrentCUDAStream());
+                at::cuda::getCurrentCUDAStream()));
             C10_CUDA_KERNEL_LAUNCH_CHECK();
 
             // remap indices and update row utils

--- a/fbgemm_gpu/src/split_embeddings_utils/transpose_embedding_input.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils/transpose_embedding_input.cu
@@ -378,7 +378,7 @@ transpose_embedding_input(
                 rocprim::default_config,
                 rocprim::default_config,
                 400000>;
-	        rocprim::radix_sort_pairs<config>(
+	        AT_CUDA_CHECK(rocprim::radix_sort_pairs<config>(
                     nullptr,
                     temp_storage_bytes,
                     linear_indices.data_ptr<index_t>(),
@@ -389,11 +389,11 @@ transpose_embedding_input(
                     0,
                     total_hash_size_bits,
                     at::cuda::getCurrentCUDAStream(),
-                    false);
+                    false));
                 auto temp_storage = at::empty(
                     {static_cast<int64_t>(temp_storage_bytes)},
                     indices.options().dtype(at::kByte));
-                rocprim::radix_sort_pairs<config>(
+                AT_CUDA_CHECK(rocprim::radix_sort_pairs<config>(
                     temp_storage.data_ptr(),
                     temp_storage_bytes,
                     linear_indices.data_ptr<index_t>(),
@@ -404,7 +404,7 @@ transpose_embedding_input(
                     0,
                     total_hash_size_bits,
                     at::cuda::getCurrentCUDAStream(),
-                    false);
+                    false));
 #endif
               }
               if (total_unique_indices != -1) {


### PR DESCRIPTION
Wrapped HIP/CUDA functions marked as `[[nodiscard]]` with `C10/ATEN_CUDA_CHECK` to address fail-on-warning ROCm build issues.