### PR TITLE
Mark GenerateEmbeddingSpMDM* is_bf16 params [[maybe_unused]]; use to_float/from_float in QuantUtils (#6237)

### DIFF
--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -565,7 +565,7 @@ void FloatOrHalfToFusedNBitRowwiseQuantizedSBHalfRef(
       if constexpr (std::is_same_v<InputType, float>) {
         input_row_float[col] = input_row[col];
       } else {
-        input_row_float[col] = cpu_half2float(input_row[col]);
+        input_row_float[col] = to_float(input_row[col]);
       }
     }
 
@@ -574,12 +574,12 @@ void FloatOrHalfToFusedNBitRowwiseQuantizedSBHalfRef(
     // Truncate since bias will be represented by fp16. Keep higher precision
     // max untouched.
     float16 minimum_element_fp16 = cpu_float2half_rn(minimum_element);
-    minimum_element = cpu_half2float(minimum_element_fp16);
+    minimum_element = to_float(minimum_element_fp16);
     const float range = maximum_element - minimum_element;
 
     float scale = range == 0 ? 1.0f : range / ((1 << bit_rate) - 1);
     float16 scale_fp16 = cpu_float2half_rn(scale);
-    scale = cpu_half2float(scale_fp16);
+    scale = to_float(scale_fp16);
     if (scale == 0) {
       // Corner case handling when maximum_element == minimum_element
       // Any scale would work because X - minimum_element will be 0 for all X
@@ -699,7 +699,7 @@ void FloatOrHalfToFused8BitRowwiseQuantizedSBFloatRef(
       if constexpr (std::is_same_v<InputType, float>) {
         input_row_float[col] = input_row[col];
       } else {
-        input_row_float[col] = cpu_half2float(input_row[col]);
+        input_row_float[col] = to_float(input_row[col]);
       }
     }
 
@@ -765,8 +765,8 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef(
         (scale_bias_last
              ? (output_columns + num_elem_per_byte - 1) / num_elem_per_byte
              : 0));
-    float scale = cpu_half2float(input_row_scale_bias[0]);
-    float bias = cpu_half2float(input_row_scale_bias[1]);
+    float scale = to_float(input_row_scale_bias[0]);
+    float bias = to_float(input_row_scale_bias[1]);
     const std::uint8_t* nums =
         (scale_bias_last) ? input_row : input_row + 2 * sizeof(float16);
     OutputType* output_row = output + row * output_columns;
@@ -780,7 +780,7 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef(
       if constexpr (std::is_same_v<OutputType, float>) {
         output_row[col] = output_value;
       } else if constexpr (std::is_same_v<OutputType, bfloat16>) {
-        output_row[col] = cpu_float2bfloat16(output_value);
+        output_row[col] = from_float<OutputType>(output_value);
       } else {
         output_row[col] = cpu_float2half_rn(output_value);
       }
@@ -883,7 +883,7 @@ void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfRef(
       if constexpr (std::is_same_v<OutputType, float>) {
         output_row[col] = output_value;
       } else if constexpr (std::is_same_v<OutputType, bfloat16>) {
-        output_row[col] = cpu_float2bfloat16(output_value);
+        output_row[col] = from_float<OutputType>(output_value);
       } else {
         output_row[col] = cpu_float2half_rn(output_value);
       }

--- a/test/Float16ConvertTest.cc
+++ b/test/Float16ConvertTest.cc
@@ -7,11 +7,13 @@
  */
 
 #include <gtest/gtest.h>
+#include <array>
 #include <cmath>
 #include <random>
 
 #include "bench/BenchUtils.h" // @manual
 #include "fbgemm/FbgemmConvert.h"
+#include "fbgemm/FloatConversion.h"
 #include "src/RefImplementations.h" // @manual
 
 using namespace std;
@@ -19,12 +21,25 @@ using namespace fbgemm;
 
 namespace {
 class FBGemmFloat16Test : public testing::TestWithParam<bool> {};
+
+template <FbgemmHalfType T>
+void expectScalarRoundTrips() {
+  constexpr std::array values{-42.0f, -1.5f, 0.0f, 1.5f, 42.0f};
+  for (const float value : values) {
+    EXPECT_FLOAT_EQ(to_float(from_float<T>(value)), value);
+  }
+}
 }; // namespace
 
 INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     FBGemmFloat16Test,
     ::testing::Bool());
+
+TEST(FBGemmHalfConversionTest, ScalarHelpersRoundTrip) {
+  expectScalarRoundTrips<float16>();
+  expectScalarRoundTrips<bfloat16>();
+}
 
 TEST_P(FBGemmFloat16Test, Conversion) {
   bool do_clip = GetParam();


### PR DESCRIPTION
Summary:
Prerequisite for https://github.com/pytorch/FBGEMM/issues/6194 ("Use distinct float16 and bfloat16 CPU template types").


This PR originally also added a `FbgemmHalfType` concept and generic `to_float<T>`/`from_float<T>` helpers, but that part has since landed on `main` via https://github.com/pytorch/FBGEMM/issues/6049 ("Make float16/bfloat16 distinct types"), so it's been dropped from this branch as redundant. It now contains two small, independent, backward-compatible pieces:

- `include/fbgemm/FbgemmEmbedding.h`: mark the `is_bf16_out`/`is_bf16_in` parameters on `GenerateEmbeddingSpMDM*` as `[[maybe_unused]]`, in preparation for callers moving to compile-time dispatch on the distinct types instead of these runtime flags. No signature change.
- `src/QuantUtils.cc`: use the `to_float`/`from_float<T>` helpers (from https://github.com/pytorch/FBGEMM/issues/6049) instead of the equivalent direct `cpu_half2float`/`cpu_bf162float`/`cpu_float2bfloat16` calls in `FloatOrHalfToFusedNBitRowwiseQuantizedSBHalfRef`, `FloatOrHalfToFused8BitRowwiseQuantizedSBFloatRef`, `FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef`, and `Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfRef`. Purely a call-site rename to the same underlying function in each case — no behavior change. The `float16` quantize (write) branches intentionally keep the explicit `cpu_float2half_rn` call rather than `from_float<float16>` (which resolves to the hardware-accelerated `cpu_float2half` when available) to avoid changing rounding behavior, and the `cpu_half2float_ref` call in the Ref-suffixed `Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfRef` scale/bias read is left untouched since it's deliberately the portable, non-hardware-accelerated reference path.

https://github.com/pytorch/FBGEMM/issues/6194 currently carries the first of these two pieces on its branch and will rebase to drop it once this lands.


Test Plan:
- [x] Verified existing (pre-https://github.com/pytorch/FBGEMM/issues/6194) `src/EmbeddingSpMDM.cc`, `EmbeddingSpMDMAutovec.cc`, `EmbeddingSpMDMNBit.cc` still compile unchanged against these headers (`clang++ -fsyntax-only`) — confirms this is non-breaking for current callers.
- [x] `src/QuantUtils.cc` compiles clean with `clang++ -fsyntax-only`.
- [ ] CI green

Reviewed By: gchalump

Differential Revision: D118088642

Pulled By: q10


