### PR TITLE
Prepare packed INT4 KV lookup rows (#6280)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/kv_embedding_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/kv_embedding_ops_inference.py
@@ -30,6 +30,17 @@ from fbgemm_gpu.utils.loader import load_torch_module
 
 from .cache_config import CacheAlgorithm  # usort:skip
 
+KV_STORAGE_ROW_ALIGNMENT = 8
+KV_INT4_LOGICAL_ROW_ALIGNMENT = 1
+# Keep disabled until the native custom-class schema is in the minimum serving
+# package. Enabling it makes new TorchScript artifacts require that schema.
+KV_INT4_PACKED_ROWS_ROLLOUT_ENABLED = False
+
+
+def _supports_packed_int4_rows(kv_embedding_cache: object) -> bool:
+    return hasattr(kv_embedding_cache, "init_with_row_alignments")
+
+
 try:
     load_torch_module(
         "//deeplearning/fbgemm/fbgemm_gpu:dram_kv_embedding_inference",
@@ -43,6 +54,12 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
     KV Table-batched version of nn.EmbeddingBag(sparse=False)
     Inference version, with support for FP32/FP16/FP8/INT8/INT4/INT2 weights
     """
+
+    __constants__ = [
+        "use_packed_int4_rows",
+        "kv_int4_logical_row_alignment",
+        "kv_storage_row_alignment",
+    ]
 
     def __init__(  # noqa C901
         self,
@@ -137,6 +154,36 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
             (rows, dims, sparse_type.as_int())
             for (_, rows, dims, sparse_type, _) in self.embedding_specs
         ]
+        first_logical_row_bytes = (
+            rounded_row_size_in_bytes(
+                self.embedding_specs[0][2],
+                self.embedding_specs[0][3],
+                KV_INT4_LOGICAL_ROW_ALIGNMENT,
+                scale_bias_size_in_bytes,
+            )
+            if self.embedding_specs
+            else 0
+        )
+        self.use_packed_int4_rows: bool = (
+            _supports_packed_int4_rows(self.kv_embedding_cache)
+            and KV_INT4_PACKED_ROWS_ROLLOUT_ENABLED
+            and bool(self.embedding_specs)
+            and all(
+                [
+                    sparse_type == SparseType.INT4
+                    and rounded_row_size_in_bytes(
+                        dims,
+                        sparse_type,
+                        KV_INT4_LOGICAL_ROW_ALIGNMENT,
+                        scale_bias_size_in_bytes,
+                    )
+                    == first_logical_row_bytes
+                    for (_, _, dims, sparse_type, _) in self.embedding_specs
+                ]
+            )
+        )
+        self.kv_int4_logical_row_alignment: int = KV_INT4_LOGICAL_ROW_ALIGNMENT
+        self.kv_storage_row_alignment: int = KV_STORAGE_ROW_ALIGNMENT
         # table shard offset if inference sharding is enabled, otherwise, should be all zeros
         self.table_sharding_offset: list[int] = [0] * len(self.embedding_specs)
         self.kv_embedding_cache_initialized = False
@@ -367,9 +414,12 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
     @torch.jit.export
     def initialize_kv_embedding_cache(self) -> None:
         if not self.kv_embedding_cache_initialized:
+            self.row_alignment = (
+                self.kv_int4_logical_row_alignment
+                if self.use_packed_int4_rows
+                else self.kv_storage_row_alignment
+            )
             self.initialize_logical_weights_placements_and_offsets()
-
-            self.row_alignment = 8  # in order to use mempool implementation for kv embedding it needs to be divisible by 8
 
             hash_size_cumsum = self.construct_hash_size_cumsum()
             self.hash_size_cumsum = torch.tensor(
@@ -385,10 +435,19 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
                 device=self.current_device,
             )
 
-            self.kv_embedding_cache.init(
-                self.specs,
-                self.row_alignment,
-                self.scale_bias_size_in_bytes,
-                self.hash_size_cumsum,
-            )
+            if self.use_packed_int4_rows:
+                self.kv_embedding_cache.init_with_row_alignments(
+                    self.specs,
+                    self.kv_int4_logical_row_alignment,
+                    self.kv_storage_row_alignment,
+                    self.scale_bias_size_in_bytes,
+                    self.hash_size_cumsum,
+                )
+            else:
+                self.kv_embedding_cache.init(
+                    self.specs,
+                    self.kv_storage_row_alignment,
+                    self.scale_bias_size_in_bytes,
+                    self.hash_size_cumsum,
+                )
             self.kv_embedding_cache_initialized = True

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
@@ -23,6 +23,66 @@ DEFINE_bool(
     "This should be true for dram but might be different for other non-Dram backends.");
 
 namespace fbgemm_gpu {
+namespace {
+
+using SerializedSpec = DramKVEmbeddingInferenceWrapper::SerializedSepcType;
+
+std::pair<int64_t, int64_t> legacy_row_sizes(
+    const std::vector<SerializedSpec>& specs,
+    const int64_t row_alignment,
+    const int64_t scale_bias_size_in_bytes) {
+  int64_t max_dim = 0;
+  for (const auto& spec : specs) {
+    max_dim = std::max(max_dim, std::get<1>(spec));
+  }
+  const auto row_bytes = nbit::padded_row_size_in_bytes(
+      static_cast<int32_t>(max_dim),
+      static_cast<fbgemm_gpu::SparseType>(std::get<2>(specs.front())),
+      static_cast<int32_t>(row_alignment),
+      static_cast<int32_t>(scale_bias_size_in_bytes));
+  return {row_bytes, row_bytes};
+}
+
+std::pair<int64_t, int64_t> separate_row_sizes(
+    const std::vector<SerializedSpec>& specs,
+    const int64_t logical_row_alignment,
+    const int64_t storage_row_alignment,
+    const int64_t scale_bias_size_in_bytes) {
+  std::optional<int64_t> expected_storage_row_bytes;
+  std::optional<int64_t> expected_lookup_row_bytes;
+  for (const auto& spec : specs) {
+    const auto dim = std::get<1>(spec);
+    const auto sparse_type =
+        static_cast<fbgemm_gpu::SparseType>(std::get<2>(spec));
+    const auto storage_row_bytes = nbit::padded_row_size_in_bytes(
+        static_cast<int32_t>(dim),
+        sparse_type,
+        static_cast<int32_t>(storage_row_alignment),
+        static_cast<int32_t>(scale_bias_size_in_bytes));
+    const auto lookup_row_bytes = nbit::padded_row_size_in_bytes(
+        static_cast<int32_t>(dim),
+        sparse_type,
+        static_cast<int32_t>(logical_row_alignment),
+        static_cast<int32_t>(scale_bias_size_in_bytes));
+    TORCH_CHECK(
+        lookup_row_bytes <= storage_row_bytes,
+        "Dram KV logical row width must not exceed storage row width");
+    if (expected_lookup_row_bytes.has_value()) {
+      TORCH_CHECK(
+          lookup_row_bytes == expected_lookup_row_bytes.value(),
+          "Dram KV embedding requires one logical row width across tables");
+      TORCH_CHECK(
+          storage_row_bytes == expected_storage_row_bytes.value(),
+          "Dram KV embedding requires one storage row width across tables");
+    }
+    expected_lookup_row_bytes = lookup_row_bytes;
+    expected_storage_row_bytes = storage_row_bytes;
+  }
+  return {
+      expected_storage_row_bytes.value(), expected_lookup_row_bytes.value()};
+}
+
+} // namespace
 
 DramKVEmbeddingInferenceWrapper::DramKVEmbeddingInferenceWrapper(
     int64_t num_shards,
@@ -43,26 +103,91 @@ void DramKVEmbeddingInferenceWrapper::init(
     const int64_t row_alignment,
     const int64_t scale_bias_size_in_bytes,
     const std::optional<at::Tensor>& hash_size_cumsum) {
-  LOG(INFO) << "DramKVEmbeddingInferenceWrapper::init() starts";
-  int64_t max_D = 0;
-  for (auto i = 0; i < specs.size(); ++i) {
-    max_D = std::max(max_D, std::get<1>(specs[i]));
-  }
-  max_row_bytes_ = nbit::padded_row_size_in_bytes(
-      static_cast<int32_t>(max_D),
-      static_cast<fbgemm_gpu::SparseType>(std::get<2>(specs[0])),
-      static_cast<int32_t>(row_alignment),
-      static_cast<int32_t>(scale_bias_size_in_bytes));
-  LOG(INFO) << "Initialize dram_kv with max_D: " << max_D
-            << ", sparse_type: " << std::get<2>(specs[0])
-            << ", row_alignment: " << row_alignment
+  init_impl(
+      specs,
+      row_alignment,
+      row_alignment,
+      scale_bias_size_in_bytes,
+      hash_size_cumsum,
+      InitMode::Legacy);
+}
+
+void DramKVEmbeddingInferenceWrapper::init_with_row_alignments(
+    const std::vector<SerializedSepcType>& specs,
+    const int64_t logical_row_alignment,
+    const int64_t storage_row_alignment,
+    const int64_t scale_bias_size_in_bytes,
+    const std::optional<at::Tensor>& hash_size_cumsum) {
+  init_impl(
+      specs,
+      logical_row_alignment,
+      storage_row_alignment,
+      scale_bias_size_in_bytes,
+      hash_size_cumsum,
+      InitMode::SeparateAlignments);
+}
+
+void DramKVEmbeddingInferenceWrapper::init_impl(
+    const std::vector<SerializedSepcType>& specs,
+    const int64_t logical_row_alignment,
+    const int64_t storage_row_alignment,
+    const int64_t scale_bias_size_in_bytes,
+    const std::optional<at::Tensor>& hash_size_cumsum,
+    const InitMode mode) {
+  LOG(INFO) << "DramKVEmbeddingInferenceWrapper::init_impl() starts";
+  TORCH_CHECK(!specs.empty(), "Dram KV embedding specs must not be empty");
+  TORCH_CHECK(
+      logical_row_alignment > 0,
+      "Dram KV logical row alignment must be positive");
+  TORCH_CHECK(
+      storage_row_alignment > 0,
+      "Dram KV storage row alignment must be positive");
+  const auto [storage_max_row_bytes, lookup_max_row_bytes] =
+      mode == InitMode::Legacy
+      ? legacy_row_sizes(specs, storage_row_alignment, scale_bias_size_in_bytes)
+      : separate_row_sizes(
+            specs,
+            logical_row_alignment,
+            storage_row_alignment,
+            scale_bias_size_in_bytes);
+  LOG(INFO) << "Initialize dram_kv with logical_row_alignment: "
+            << logical_row_alignment
+            << ", storage_row_alignment: " << storage_row_alignment
             << ", scale_bias_size_in_bytes: " << scale_bias_size_in_bytes
-            << ", max_row_bytes_: " << max_row_bytes_;
+            << ", storage_max_row_bytes: " << storage_max_row_bytes
+            << ", lookup_max_row_bytes: " << lookup_max_row_bytes;
+  if (initialized_) {
+    TORCH_CHECK(
+        storage_max_row_bytes == storage_max_row_bytes_,
+        "Cannot change KV storage row width after backend initialization: "
+        "existing width=",
+        storage_max_row_bytes_,
+        ", requested width=",
+        storage_max_row_bytes);
+    TORCH_CHECK(
+        lookup_max_row_bytes == lookup_max_row_bytes_,
+        "Cannot change KV lookup row width after backend initialization: "
+        "existing width=",
+        lookup_max_row_bytes_,
+        ", requested width=",
+        lookup_max_row_bytes);
+  }
+  if (backend_storage_row_bytes_.has_value()) {
+    TORCH_CHECK(
+        storage_max_row_bytes <= backend_storage_row_bytes_.value(),
+        "KV storage row width exceeds backend capacity: backend capacity=",
+        backend_storage_row_bytes_.value(),
+        ", requested width=",
+        storage_max_row_bytes);
+  }
+  storage_max_row_bytes_ = storage_max_row_bytes;
+  lookup_max_row_bytes_ = lookup_max_row_bytes;
+  initialized_ = true;
   if (kv_backend_ != nullptr) {
     return;
   }
   kv_backend_ = std::make_shared<kv_mem::DramKVInferenceEmbedding<uint8_t>>(
-      max_row_bytes_,
+      storage_max_row_bytes_,
       uniform_init_lower_,
       uniform_init_upper_,
       c10::make_intrusive<kv_mem::FeatureEvictConfig>(
@@ -91,10 +216,16 @@ void DramKVEmbeddingInferenceWrapper::init(
       std::nullopt /* table_dims */,
       hash_size_cumsum,
       disable_random_init_);
+  uses_dram_backend_ = true;
+  backend_storage_row_bytes_ = storage_max_row_bytes_;
 }
 
 int64_t DramKVEmbeddingInferenceWrapper::get_max_row_bytes() const {
-  return max_row_bytes_;
+  return storage_max_row_bytes_;
+}
+
+int64_t DramKVEmbeddingInferenceWrapper::get_lookup_row_bytes() const {
+  return lookup_max_row_bytes_;
 }
 
 std::shared_ptr<kv_mem::KVInferenceEmbeddingInterface<uint8_t>>
@@ -105,13 +236,45 @@ DramKVEmbeddingInferenceWrapper::get_kv_backend() {
 void DramKVEmbeddingInferenceWrapper::set_kv_backend(
     std::shared_ptr<kv_mem::KVInferenceEmbeddingInterface<uint8_t>>
         kv_backend) {
+  TORCH_CHECK(kv_backend != nullptr, "KV backend must not be null");
+  const auto backend_storage_row_bytes = kv_backend->get_storage_row_bytes();
+  if (initialized_ && backend_storage_row_bytes.has_value()) {
+    TORCH_CHECK(
+        storage_max_row_bytes_ <= backend_storage_row_bytes.value(),
+        "KV storage row width exceeds backend capacity: backend capacity=",
+        backend_storage_row_bytes.value(),
+        ", requested width=",
+        storage_max_row_bytes_);
+  }
   kv_backend_ = std::move(kv_backend);
+  const auto* dram_backend =
+      dynamic_cast<kv_mem::DramKVInferenceEmbedding<uint8_t>*>(
+          kv_backend_.get());
+  uses_dram_backend_ = dram_backend != nullptr;
+  backend_storage_row_bytes_ = backend_storage_row_bytes;
+}
+
+void DramKVEmbeddingInferenceWrapper::check_initialized() const {
+  TORCH_CHECK(
+      initialized_ && kv_backend_ != nullptr,
+      "KV embedding cache must be initialized before use");
 }
 
 void DramKVEmbeddingInferenceWrapper::set_embeddings(
     const at::Tensor& indices,
     const at::Tensor& weights,
     std::optional<int64_t> inplace_update_ts_opt) {
+  check_initialized();
+  TORCH_CHECK(
+      weights.dim() == 2, "Embedding updates must be a two-dimensional tensor");
+  const auto backend_row_bytes =
+      backend_storage_row_bytes_.value_or(storage_max_row_bytes_);
+  TORCH_CHECK(
+      weights.size(1) <= storage_max_row_bytes_,
+      "Embedding update row is wider than KV storage");
+  TORCH_CHECK(
+      weights.size(1) <= backend_row_bytes,
+      "Embedding update row is wider than backend storage capacity");
   const auto count = at::tensor({indices.numel()}, at::ScalarType::Long);
   std::optional<uint32_t> inplacee_update_ts = std::nullopt;
   if (inplace_update_ts_opt.has_value()) {
@@ -119,17 +282,27 @@ void DramKVEmbeddingInferenceWrapper::set_embeddings(
         static_cast<std::uint32_t>(inplace_update_ts_opt.value());
   }
 
+  auto backend_weights = weights;
+  if (!uses_dram_backend_ && weights.size(1) < backend_row_bytes) {
+    // External backends consume physical rows. A shared scratch tensor is
+    // unsafe because updates can run concurrently.
+    backend_weights =
+        at::zeros({weights.size(0), backend_row_bytes}, weights.options());
+    backend_weights.slice(1, 0, weights.size(1)).copy_(weights);
+  }
+
   folly::coro::blockingWait(kv_backend_->inference_set_kv_db_async(
-      indices, weights, count, inplacee_update_ts));
+      indices, backend_weights, count, inplacee_update_ts));
 }
 
 at::Tensor DramKVEmbeddingInferenceWrapper::get_embeddings(
     const at::Tensor& indices) {
+  check_initialized();
   const auto count = at::tensor({indices.numel()}, at::ScalarType::Long);
   auto weights = at::empty(
       {
           indices.numel(),
-          max_row_bytes_,
+          lookup_max_row_bytes_,
       },
       at::kByte);
 
@@ -139,16 +312,19 @@ at::Tensor DramKVEmbeddingInferenceWrapper::get_embeddings(
 }
 
 void DramKVEmbeddingInferenceWrapper::log_inplace_update_stats() {
+  check_initialized();
   kv_backend_->log_inplace_update_stats();
 }
 
 std::vector<int64_t>
 DramKVEmbeddingInferenceWrapper::get_read_hit_rate_stats() {
+  check_initialized();
   return kv_backend_->get_read_hit_rate_stats();
 }
 
 void DramKVEmbeddingInferenceWrapper::trigger_evict(
     int64_t inplace_update_ts_64b) {
+  check_initialized();
   uint32_t inplace_update_ts_32b =
       static_cast<std::uint32_t>(inplace_update_ts_64b);
   kv_backend_->trigger_feature_evict(inplace_update_ts_32b);
@@ -156,6 +332,7 @@ void DramKVEmbeddingInferenceWrapper::trigger_evict(
 }
 
 void DramKVEmbeddingInferenceWrapper::wait_evict_completion() {
+  check_initialized();
   kv_backend_->wait_until_eviction_done();
 }
 
@@ -212,6 +389,18 @@ static auto dram_kv_embedding_inference_wrapper =
                 torch::arg("hash_size_cumsum"),
             })
         .def(
+            "init_with_row_alignments",
+            &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::
+                init_with_row_alignments,
+            "",
+            {
+                torch::arg("specs"),
+                torch::arg("logical_row_alignment"),
+                torch::arg("storage_row_alignment"),
+                torch::arg("scale_bias_size_in_bytes"),
+                torch::arg("hash_size_cumsum"),
+            })
+        .def(
             "set_embeddings",
             &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::set_embeddings,
             "",
@@ -223,6 +412,12 @@ static auto dram_kv_embedding_inference_wrapper =
         .def(
             "get_embeddings",
             &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::get_embeddings)
+        .def(
+            "get_max_row_bytes",
+            &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::get_max_row_bytes)
+        .def(
+            "get_lookup_row_bytes",
+            &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::get_lookup_row_bytes)
         .def(
             "trigger_evict",
             &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::trigger_evict)

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
@@ -34,6 +34,13 @@ class DramKVEmbeddingInferenceWrapper : public torch::jit::CustomClassHolder {
       const int64_t scale_bias_size_in_bytes,
       const std::optional<at::Tensor>& hash_size_cumsum);
 
+  void init_with_row_alignments(
+      const std::vector<SerializedSepcType>& specs,
+      const int64_t logical_row_alignment,
+      const int64_t storage_row_alignment,
+      const int64_t scale_bias_size_in_bytes,
+      const std::optional<at::Tensor>& hash_size_cumsum);
+
   void set_embeddings(
       const at::Tensor& indices,
       const at::Tensor& weights,
@@ -62,14 +69,35 @@ class DramKVEmbeddingInferenceWrapper : public torch::jit::CustomClassHolder {
 
   int64_t get_max_row_bytes() const;
 
+  int64_t get_lookup_row_bytes() const;
+
  private:
+  enum class InitMode {
+    Legacy,
+    SeparateAlignments,
+  };
+
+  void init_impl(
+      const std::vector<SerializedSepcType>& specs,
+      int64_t logical_row_alignment,
+      int64_t storage_row_alignment,
+      int64_t scale_bias_size_in_bytes,
+      const std::optional<at::Tensor>& hash_size_cumsum,
+      InitMode mode);
+
+  void check_initialized() const;
+
   int64_t num_shards_ = 32;
   double uniform_init_lower_ = 0.0;
   double uniform_init_upper_ = 0.0;
   bool disable_random_init_ = false;
 
   std::shared_ptr<kv_mem::KVInferenceEmbeddingInterface<uint8_t>> kv_backend_;
-  int64_t max_row_bytes_ = 0;
+  bool uses_dram_backend_ = false;
+  bool initialized_ = false;
+  std::optional<int64_t> backend_storage_row_bytes_;
+  int64_t storage_max_row_bytes_ = 0;
+  int64_t lookup_max_row_bytes_ = 0;
 };
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_inference_embedding.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_inference_embedding.h
@@ -211,11 +211,21 @@ class DramKVInferenceEmbedding
     throw std::runtime_error("get_kv_db_sync is not implemented for DRAM");
   }
 
+  std::optional<int64_t> get_storage_row_bytes() const override {
+    return max_D_;
+  }
+
   folly::SemiFuture<std::vector<folly::Unit>> inference_set_kv_db_async(
       const at::Tensor& indices,
       const at::Tensor& weights,
       const at::Tensor& count,
       std::optional<uint32_t> inplace_update_ts) override {
+    TORCH_CHECK(
+        weights.dim() == 2,
+        "Embedding updates must be a two-dimensional tensor");
+    TORCH_CHECK(
+        weights.size(1) <= max_D_,
+        "Embedding update row is wider than DRAM KV storage");
     auto shardid_to_indexes = shard_input(indices, count);
     std::vector<folly::Future<std::tuple<int64_t, int64_t>>> futures;
     futures.reserve(shardid_to_indexes.size());
@@ -285,6 +295,11 @@ class DramKVInferenceEmbedding
                                 weights_data_ptr + tensor_offset * stride,
                                 weights_data_ptr + (tensor_offset + 1) * stride,
                                 data_ptr);
+                            // Clear physical padding after every logical row.
+                            std::fill(
+                                data_ptr + stride,
+                                data_ptr + max_D_,
+                                weight_type{});
                             // update provided ts for existing blocks
                             if (feature_evict_config_.has_value() &&
                                 feature_evict_config_.value()->trigger_mode_ !=
@@ -317,6 +332,11 @@ class DramKVInferenceEmbedding
                               weights_data_ptr + tensor_offset * stride,
                               weights_data_ptr + (tensor_offset + 1) * stride,
                               data_ptr);
+                          // Clear physical padding after every logical row.
+                          std::fill(
+                              data_ptr + stride,
+                              data_ptr + max_D_,
+                              weight_type{});
 
                           // update provided ts for new allocated blocks
                           if (feature_evict_config_.has_value() &&

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/kv_inference_embedding_interface.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/kv_inference_embedding_interface.h
@@ -29,6 +29,11 @@ class KVInferenceEmbeddingInterface {
  public:
   virtual ~KVInferenceEmbeddingInterface() = default;
 
+  /// Return the physical row capacity in bytes when it is known.
+  virtual std::optional<int64_t> get_storage_row_bytes() const {
+    return std::nullopt;
+  }
+
   /// Initialize the initializers for weight initialization
   ///
   /// @param num_shards number of shards for the kvstore

--- a/fbgemm_gpu/test/tbe/dram_kv/dram_kv_inference_test.py
+++ b/fbgemm_gpu/test/tbe/dram_kv/dram_kv_inference_test.py
@@ -27,6 +27,205 @@ if not open_source:
 
 @unittest.skipIf(open_source, "Not supported in open source yet")
 class DramKvInferenceTest(unittest.TestCase):
+    def test_int4_logical_lookup_width(self) -> None:
+        scale_bias_bytes = 4
+        storage_alignment = 8
+        for dim in (8, 10, 12, 14, 16, 18, 20, 22, 100, 256):
+            with self.subTest(dim=dim):
+                logical_bytes = dim // 2 + scale_bias_bytes
+                storage_bytes = (
+                    (logical_bytes + storage_alignment - 1) // storage_alignment
+                ) * storage_alignment
+                cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(
+                    1, 0.0, 0.0, True
+                )
+                cache.init_with_row_alignments(
+                    [(4, dim, SparseType.INT4.as_int())],
+                    1,
+                    storage_alignment,
+                    scale_bias_bytes,
+                    torch.tensor([0, 4], dtype=torch.int64),
+                )
+                expected = torch.arange(logical_bytes, dtype=torch.uint8).reshape(
+                    1, logical_bytes
+                )
+                cache.set_embeddings(torch.tensor([0]), expected)
+
+                actual = cache.get_embeddings(torch.tensor([0]))
+
+                self.assertEqual(tuple(actual.shape), (1, logical_bytes))
+                self.assertTrue(torch.equal(actual, expected))
+                self.assertEqual(cache.get_max_row_bytes(), storage_bytes)
+                self.assertEqual(cache.get_lookup_row_bytes(), logical_bytes)
+
+    def test_int4_zeroes_storage_padding(self) -> None:
+        dim = 100
+        logical_bytes = dim // 2 + 4
+        storage_alignment = 8
+        storage_bytes = (
+            (logical_bytes + storage_alignment - 1) // storage_alignment
+        ) * storage_alignment
+        specs = [(4, dim, SparseType.INT4.as_int())]
+        hash_size_cumsum = torch.tensor([0, 4], dtype=torch.int64)
+        cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(1, 0.0, 0.0, True)
+        cache.init_with_row_alignments(
+            specs, storage_alignment, storage_alignment, 4, hash_size_cumsum
+        )
+        cache.set_embeddings(
+            torch.tensor([0]), torch.full((1, storage_bytes), 0xFF, dtype=torch.uint8)
+        )
+        expected = torch.arange(logical_bytes, dtype=torch.uint8).reshape(
+            1, logical_bytes
+        )
+        cache.set_embeddings(torch.tensor([0]), expected)
+
+        stored = cache.get_embeddings(torch.tensor([0]))
+
+        self.assertTrue(torch.equal(stored[:, :logical_bytes], expected))
+        self.assertTrue(
+            torch.equal(
+                stored[:, logical_bytes:],
+                torch.zeros((1, storage_bytes - logical_bytes), dtype=torch.uint8),
+            )
+        )
+
+    def test_rejects_empty_specs(self) -> None:
+        cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(1, 0.0, 0.0, True)
+
+        with self.assertRaisesRegex(RuntimeError, "specs must not be empty"):
+            cache.init_with_row_alignments(
+                [], 1, 8, 4, torch.tensor([0], dtype=torch.int64)
+            )
+
+    def test_rejects_operations_before_init(self) -> None:
+        cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(1, 0.0, 0.0, True)
+
+        with self.assertRaisesRegex(RuntimeError, "must be initialized before use"):
+            cache.get_embeddings(torch.tensor([0]))
+        with self.assertRaisesRegex(RuntimeError, "must be initialized before use"):
+            cache.set_embeddings(
+                torch.tensor([0]), torch.zeros((1, 8), dtype=torch.uint8)
+            )
+
+    def test_rejects_update_wider_than_storage(self) -> None:
+        cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(1, 0.0, 0.0, True)
+        cache.init_with_row_alignments(
+            [(4, 8, SparseType.INT4.as_int())],
+            1,
+            8,
+            4,
+            torch.tensor([0, 4], dtype=torch.int64),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "wider than KV storage"):
+            cache.set_embeddings(
+                torch.tensor([0]), torch.zeros((1, 9), dtype=torch.uint8)
+            )
+
+    def test_rejects_non_matrix_update(self) -> None:
+        cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(1, 0.0, 0.0, True)
+        cache.init_with_row_alignments(
+            [(4, 8, SparseType.INT4.as_int())],
+            1,
+            8,
+            4,
+            torch.tensor([0, 4], dtype=torch.int64),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "two-dimensional tensor"):
+            cache.set_embeddings(torch.tensor([0]), torch.zeros(8, dtype=torch.uint8))
+
+    def test_rejects_heterogeneous_separate_row_widths(self) -> None:
+        for sparse_type, dims in (
+            (SparseType.INT4, (8, 10)),
+            (SparseType.INT8, (8, 16)),
+        ):
+            with self.subTest(sparse_type=sparse_type):
+                cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(
+                    1, 0.0, 0.0, True
+                )
+                with self.assertRaisesRegex(RuntimeError, "one logical row width"):
+                    cache.init_with_row_alignments(
+                        [
+                            (4, dims[0], sparse_type.as_int()),
+                            (4, dims[1], sparse_type.as_int()),
+                        ],
+                        8,
+                        8,
+                        4,
+                        torch.tensor([0, 4, 8], dtype=torch.int64),
+                    )
+
+    def test_preserves_sub_byte_unaligned_row_sizing(self) -> None:
+        for sparse_type, dim, logical_bytes, storage_bytes in (
+            (SparseType.INT4, 9, 8, 8),
+            (SparseType.INT2, 9, 6, 8),
+        ):
+            cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(
+                1, 0.0, 0.0, True
+            )
+            cache.init_with_row_alignments(
+                [(4, dim, sparse_type.as_int())],
+                1,
+                8,
+                4,
+                torch.tensor([0, 4], dtype=torch.int64),
+            )
+
+            self.assertEqual(cache.get_lookup_row_bytes(), logical_bytes)
+            self.assertEqual(cache.get_max_row_bytes(), storage_bytes)
+
+    def test_rejects_reinit_with_different_storage_width(self) -> None:
+        cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(1, 0.0, 0.0, True)
+        cache.init_with_row_alignments(
+            [(4, 8, SparseType.INT4.as_int())],
+            1,
+            8,
+            4,
+            torch.tensor([0, 4], dtype=torch.int64),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "Cannot change KV storage row width"):
+            cache.init_with_row_alignments(
+                [(4, 100, SparseType.INT4.as_int())],
+                1,
+                8,
+                4,
+                torch.tensor([0, 4], dtype=torch.int64),
+            )
+
+    def test_legacy_init_preserves_heterogeneous_int4_sizing(self) -> None:
+        cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(1, 0.0, 0.0, True)
+
+        cache.init(
+            [
+                (4, 8, SparseType.INT4.as_int()),
+                (4, 10, SparseType.INT4.as_int()),
+            ],
+            8,
+            4,
+            torch.tensor([0, 4, 8], dtype=torch.int64),
+        )
+
+        self.assertEqual(cache.get_max_row_bytes(), 16)
+        self.assertEqual(cache.get_lookup_row_bytes(), 16)
+
+    def test_legacy_init_preserves_mixed_type_sizing(self) -> None:
+        cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(1, 0.0, 0.0, True)
+
+        cache.init(
+            [
+                (4, 8, SparseType.INT8.as_int()),
+                (4, 100, SparseType.INT4.as_int()),
+            ],
+            8,
+            4,
+            torch.tensor([0, 4, 8], dtype=torch.int64),
+        )
+
+        self.assertEqual(cache.get_max_row_bytes(), 104)
+        self.assertEqual(cache.get_lookup_row_bytes(), 104)
+
     def test_serialize(self) -> None:
         num_shards = 32
         uniform_init_lower: float = -0.01

--- a/fbgemm_gpu/test/tbe/inference/kv_embedding_test.py
+++ b/fbgemm_gpu/test/tbe/inference/kv_embedding_test.py
@@ -6,7 +6,9 @@
 
 # pyre-strict
 
+import io
 from unittest import skipIf, TestCase
+from unittest.mock import patch
 
 import fbgemm_gpu
 import torch
@@ -15,8 +17,12 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
     random_quant_scaled_tensor,
 )
-from fbgemm_gpu.tbe.cache.kv_embedding_ops_inference import KVEmbeddingInference
-from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation
+from fbgemm_gpu.tbe.cache import kv_embedding_ops_inference
+from fbgemm_gpu.tbe.cache.kv_embedding_ops_inference import (
+    _supports_packed_int4_rows,
+    KVEmbeddingInference,
+)
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
 from fbgemm_gpu.tbe.utils import generate_requests
 
 # pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
@@ -25,6 +31,102 @@ open_source: bool = getattr(fbgemm_gpu, "open_source", False)
 
 @skipIf(open_source, "Not supported in open source yet")
 class KVEmbeddingTest(TestCase):
+    def test_heterogeneous_int4_uses_legacy_rows(self) -> None:
+        kv = KVEmbeddingInference(
+            [
+                ("", 4, 8, SparseType.INT4, EmbeddingLocation.HOST),
+                ("", 4, 10, SparseType.INT4, EmbeddingLocation.HOST),
+            ],
+            pooling_mode=PoolingMode.SUM,
+            output_dtype=SparseType.FP16,
+            device="cpu",
+        )
+
+        self.assertFalse(kv.use_packed_int4_rows)
+        kv.initialize_kv_embedding_cache()
+
+        self.assertEqual(kv.row_alignment, 8)
+        self.assertEqual(kv.kv_embedding_cache.get_lookup_row_bytes(), 16)
+
+    def test_int4_module_uses_legacy_schema_before_rollout(self) -> None:
+        kv = KVEmbeddingInference(
+            [("", 4, 100, SparseType.INT4, EmbeddingLocation.HOST)],
+            pooling_mode=PoolingMode.NONE,
+            output_dtype=SparseType.INT4,
+            device="cpu",
+        )
+        kv.initialize_weights()
+
+        scripted = torch.jit.script(kv)
+        self.assertFalse(scripted.use_packed_int4_rows)
+        self.assertNotIn(
+            "init_with_row_alignments",
+            scripted.initialize_kv_embedding_cache.code,
+        )
+
+        archive = io.BytesIO()
+        torch.jit.save(scripted, archive)
+        archive.seek(0)
+        loaded = torch.jit.load(archive)
+        loaded.initialize_kv_embedding_cache()
+
+        self.assertEqual(loaded.row_alignment, 8)
+
+    def test_packed_int4_native_capability_probe(self) -> None:
+        class LegacyNative:
+            def get_lookup_row_bytes(self) -> int:
+                return 54
+
+        class CurrentNative:
+            def init_with_row_alignments(self) -> None:
+                return None
+
+        self.assertFalse(_supports_packed_int4_rows(LegacyNative()))
+        self.assertTrue(_supports_packed_int4_rows(CurrentNative()))
+
+    def test_int4_forward_unaligned_logical_row(self) -> None:
+        dim = 100
+        num_embeddings = 16
+        specs = [("", num_embeddings, dim, SparseType.INT4, EmbeddingLocation.HOST)]
+        baseline = IntNBitTableBatchedEmbeddingBagsCodegen(
+            specs,
+            pooling_mode=PoolingMode.NONE,
+            output_dtype=SparseType.INT4,
+            device="cpu",
+        )
+        baseline.fill_random_weights()
+        with patch.object(
+            kv_embedding_ops_inference,
+            "KV_INT4_PACKED_ROWS_ROLLOUT_ENABLED",
+            True,
+        ):
+            kv = KVEmbeddingInference(
+                specs,
+                pooling_mode=PoolingMode.NONE,
+                output_dtype=SparseType.INT4,
+                device="cpu",
+            )
+        kv.initialize_kv_embedding_cache()
+        fused_weights = baseline.split_embedding_weights(split_scale_shifts=False)[0][0]
+        rows = torch.arange(num_embeddings, dtype=torch.int64)
+        kv.embedding_inplace_update_per_table(0, rows, fused_weights)
+        kv.weight_initialized = True
+        indices = torch.tensor([3, 1, 7], dtype=torch.int32)
+        offsets = torch.arange(indices.numel() + 1, dtype=torch.int32)
+
+        expected = baseline(indices, offsets)
+        actual = kv(indices, offsets)
+
+        logical_bytes = dim // 2 + 4
+        self.assertEqual(
+            tuple(kv.kv_embedding_cache.get_embeddings(indices).shape),
+            (3, logical_bytes),
+        )
+        self.assertEqual(
+            actual.untyped_storage().nbytes(), indices.numel() * logical_bytes
+        )
+        self.assertTrue(torch.equal(actual.int_repr(), expected.int_repr()))
+
     def test_forward(self) -> None:
         dim = 256
         num_tables = 4


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3161

NOTE: No linked task. Please associate a task with this diff.

A KVZCH serving job exposed a no-bag INT4 row-width mismatch: for D=100, TBE needs a 54-byte fused row while KV storage uses a 56-byte aligned row. The mismatch increased request memory and contributed to the observed SPMD failure.

This change separates logical lookup width from physical storage width in the native KV wrapper. DRAM and SSD return the 54-byte logical row while preserving a 56-byte physical row, validate capacity in both backend attachment orders and at the SSD write boundary, and zero-fill DRAM padding.

The review follow-up rejects null backends and non-positive alignments, prevents either row width from changing after initialization, derives Python activation from normalized specs, batches packed-row cache reads and writes, and avoids caching synthetic zero defaults in both packed and aligned layouts. Focused tests now isolate each capacity contract.

Python activation remains behind `KV_INT4_PACKED_ROWS_ROLLOUT_ENABLED = False` until the native schema is available in the minimum serving package.

Reviewed By: emlin

Differential Revision: D118432439


