### PR TITLE
Account for Y/Z blocks in grid-X caps (#6281)

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_bmm_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_bmm_forward.cu
@@ -201,20 +201,19 @@ Tensor jagged_dense_bmm_forward_cuda(
 
       const dim3 block(
           (BLOCK_TILE_M * BLOCK_TILE_N) / (THREAD_TILE_M * THREAD_TILE_N));
-      // HIP enforces a hard limit of 2^32 total threads per launch.
-      // The kernel grid-strides over (block_col, block_row, b), so capping
-      // is correctness-preserving.
-      // See: https://github.com/ROCm/hip/issues/2253
-      const auto grid_dim_x = utils::cuda::cap_grid_dim_x(
-          div_round_up(N, BLOCK_TILE_N),
-          (BLOCK_TILE_M * BLOCK_TILE_N) / (THREAD_TILE_M * THREAD_TILE_N),
-          at::cuda::getCurrentCUDAStream());
       const auto grid_dim_y = div_round_up(max_L, BLOCK_TILE_M);
       TORCH_CHECK(
           grid_dim_y <= kMaxBlockYDim,
           "max_L cannot be larger than",
           kMaxBlockYDim * BLOCK_TILE_M + 1 - BLOCK_TILE_M);
       const auto grid_dim_z = std::min(B, kMaxBlockZDim);
+      const int64_t yz_blocks = static_cast<int64_t>(grid_dim_y) * grid_dim_z;
+      const auto grid_dim_x = utils::cuda::cap_grid_dim_x_with_yz_blocks(
+          div_round_up(N, BLOCK_TILE_N),
+          block.x,
+          yz_blocks,
+          at::cuda::getCurrentCUDAStream(),
+          utils::cuda::BlockCapPolicy::OverflowOnly);
       const dim3 grid(grid_dim_x, grid_dim_y, grid_dim_z);
 
       AT_DISPATCH_INDEX_TYPES(
@@ -246,20 +245,19 @@ Tensor jagged_dense_bmm_forward_cuda(
       constexpr int BLOCK_TILE_N = 32;
       const dim3 block(
           (BLOCK_TILE_M * BLOCK_TILE_N) / (THREAD_TILE_M * THREAD_TILE_N));
-      // HIP enforces a hard limit of 2^32 total threads per launch.
-      // The kernel grid-strides over (block_col, block_row, b), so capping
-      // is correctness-preserving.
-      // See: https://github.com/ROCm/hip/issues/2253
-      const auto grid_dim_x = utils::cuda::cap_grid_dim_x(
-          div_round_up(N, BLOCK_TILE_N),
-          (BLOCK_TILE_M * BLOCK_TILE_N) / (THREAD_TILE_M * THREAD_TILE_N),
-          at::cuda::getCurrentCUDAStream());
       const auto grid_dim_y = div_round_up(max_L, BLOCK_TILE_M);
       TORCH_CHECK(
           grid_dim_y <= kMaxBlockYDim,
           "max_L cannot be larger than",
           kMaxBlockYDim * BLOCK_TILE_M + 1 - BLOCK_TILE_M);
       const auto grid_dim_z = std::min(B, kMaxBlockZDim);
+      const int64_t yz_blocks = static_cast<int64_t>(grid_dim_y) * grid_dim_z;
+      const auto grid_dim_x = utils::cuda::cap_grid_dim_x_with_yz_blocks(
+          div_round_up(N, BLOCK_TILE_N),
+          block.x,
+          yz_blocks,
+          at::cuda::getCurrentCUDAStream(),
+          utils::cuda::BlockCapPolicy::OverflowOnly);
       const dim3 grid(grid_dim_x, grid_dim_y, grid_dim_z);
 
       AT_DISPATCH_INDEX_TYPES(

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_jagged_bmm_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_jagged_bmm_forward.cu
@@ -212,20 +212,20 @@ Tensor jagged_jagged_bmm_forward_cuda(
           THREADS_PER_BLOCK % BLOCK_TILE_N == 0,
           "THREADS_PER_BLOCK needs to be multiple of BLOCK_TILE_N");
 
-      // HIP enforces a hard limit of 2^32 total threads per launch.
-      // The kernel grid-strides over (block_col, block_row, b), so capping
-      // is correctness-preserving.
-      // See: https://github.com/ROCm/hip/issues/2253
-      const auto grid_dim_x = utils::cuda::cap_grid_dim_x(
-          div_round_up(N, BLOCK_TILE_N),
-          THREADS_PER_BLOCK,
-          at::cuda::getCurrentCUDAStream());
       const auto grid_dim_y = div_round_up(M, BLOCK_TILE_M);
       TORCH_CHECK(
           grid_dim_y <= kMaxBlockYDim,
           "M cannot be larger than",
           kMaxBlockYDim * BLOCK_TILE_M + 1 - BLOCK_TILE_M);
       const auto grid_dim_z = std::min(B, kMaxBlockZDim);
+
+      const int64_t yz_blocks = static_cast<int64_t>(grid_dim_y) * grid_dim_z;
+      const auto grid_dim_x = utils::cuda::cap_grid_dim_x_with_yz_blocks(
+          div_round_up(N, BLOCK_TILE_N),
+          THREADS_PER_BLOCK,
+          yz_blocks,
+          at::cuda::getCurrentCUDAStream(),
+          utils::cuda::BlockCapPolicy::OverflowOnly);
       const dim3 grid(grid_dim_x, grid_dim_y, grid_dim_z);
 
       AT_DISPATCH_INDEX_TYPES(
@@ -266,20 +266,20 @@ Tensor jagged_jagged_bmm_forward_cuda(
           THREADS_PER_BLOCK % BLOCK_TILE_N == 0,
           "THREADS_PER_BLOCK needs to be multiple of BLOCK_TILE_N");
 
-      // HIP enforces a hard limit of 2^32 total threads per launch.
-      // The kernel grid-strides over (block_col, block_row, b), so capping
-      // is correctness-preserving.
-      // See: https://github.com/ROCm/hip/issues/2253
-      const auto grid_dim_x = utils::cuda::cap_grid_dim_x(
-          div_round_up(N, BLOCK_TILE_N),
-          THREADS_PER_BLOCK,
-          at::cuda::getCurrentCUDAStream());
       const auto grid_dim_y = div_round_up(M, BLOCK_TILE_M);
       TORCH_CHECK(
           grid_dim_y <= kMaxBlockYDim,
           "M cannot be larger than",
           kMaxBlockYDim * BLOCK_TILE_M + 1 - BLOCK_TILE_M);
       const auto grid_dim_z = std::min(B, kMaxBlockZDim);
+
+      const int64_t yz_blocks = static_cast<int64_t>(grid_dim_y) * grid_dim_z;
+      const auto grid_dim_x = utils::cuda::cap_grid_dim_x_with_yz_blocks(
+          div_round_up(N, BLOCK_TILE_N),
+          THREADS_PER_BLOCK,
+          yz_blocks,
+          at::cuda::getCurrentCUDAStream(),
+          utils::cuda::BlockCapPolicy::OverflowOnly);
       const dim3 grid(grid_dim_x, grid_dim_y, grid_dim_z);
 
       AT_DISPATCH_INDEX_TYPES(

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_backward.cu
@@ -104,23 +104,12 @@ Tensor jagged_softmax_backward_cuda(
 
   if (B > 0 && D > 0) {
     constexpr int THREADS_PER_BLOCK = 128;
-    // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
-    // which silently wraps). The launch is dim3(D, blocks_y) x
-    // THREADS_PER_BLOCK, so the total thread count is D * blocks_y *
-    // THREADS_PER_BLOCK. The y dimension must be included in the overflow
-    // check: a large D combined with a large blocks_y overflows even when D *
-    // THREADS_PER_BLOCK alone does not. Pass the full per-grid-x thread count
-    // (THREADS_PER_BLOCK * blocks_y) so cap_grid_dim_x clamps grid.x when the
-    // *total* launch would exceed 2^32. Capping grid.x is
-    // correctness-preserving because jagged_softmax_backward_kernel
-    // grid-strides over `d` (`for (uint32_t d = blockIdx.x; d < D; d +=
-    // gridDim.x)`) and over `b`. See: https://github.com/ROCm/hip/issues/2253
+    // Total launch threads are D * blocks_y * THREADS_PER_BLOCK.
+    // The kernel grid-strides over D and B, so grid.x can be capped.
     const auto blocks_y = static_cast<int32_t>(
         std::min<int64_t>(B, static_cast<int64_t>(kMaxBlockYDim)));
-    const auto blocks_x = utils::cuda::cap_grid_dim_x(
-        D,
-        static_cast<int64_t>(THREADS_PER_BLOCK) * blocks_y,
-        at::cuda::getCurrentCUDAStream());
+    const auto blocks_x = utils::cuda::cap_grid_dim_x_with_yz_blocks(
+        D, THREADS_PER_BLOCK, blocks_y, at::cuda::getCurrentCUDAStream());
     const dim3 grid(blocks_x, blocks_y, 1);
 
     AT_DISPATCH_INDEX_TYPES(

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_forward.cu
@@ -127,23 +127,12 @@ Tensor jagged_softmax_forward_cuda(
 
   if (B > 0 && D > 0) {
     constexpr int THREADS_PER_BLOCK = 128;
-    // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
-    // which silently wraps). The launch is dim3(D, blocks_y) x
-    // THREADS_PER_BLOCK, so the total thread count is D * blocks_y *
-    // THREADS_PER_BLOCK. The y dimension must be included in the overflow
-    // check: a large D combined with a large blocks_y overflows even when D *
-    // THREADS_PER_BLOCK alone does not. Pass the full per-grid-x thread count
-    // (THREADS_PER_BLOCK * blocks_y) so cap_grid_dim_x clamps grid.x when the
-    // *total* launch would exceed 2^32. Capping grid.x is
-    // correctness-preserving because jagged_softmax_kernel grid-strides over
-    // `d` (`for (uint32_t d = blockIdx.x; d < D; d += gridDim.x)`) and over
-    // `b`. See: https://github.com/ROCm/hip/issues/2253
+    // Total launch threads are D * blocks_y * THREADS_PER_BLOCK.
+    // The kernel grid-strides over D and B, so grid.x can be capped.
     const auto blocks_y = static_cast<int32_t>(
         std::min<int64_t>(B, static_cast<int64_t>(kMaxBlockYDim)));
-    const auto blocks_x = utils::cuda::cap_grid_dim_x(
-        D,
-        static_cast<int64_t>(THREADS_PER_BLOCK) * blocks_y,
-        at::cuda::getCurrentCUDAStream());
+    const auto blocks_x = utils::cuda::cap_grid_dim_x_with_yz_blocks(
+        D, THREADS_PER_BLOCK, blocks_y, at::cuda::getCurrentCUDAStream());
     const dim3 grid(blocks_x, blocks_y, 1);
 
     AT_DISPATCH_INDEX_TYPES(

--- a/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
@@ -296,6 +296,15 @@ std::vector<Tensor> permute_multi_embedding_function_gpu(
         at::empty({batch_size, lengths[i]}, pooled_embs[0].options());
     outputs.push_back(output);
   }
+  if (batch_size == 0) {
+    return outputs;
+  }
+  if (permute_size == 0) {
+    for (auto& output : outputs) {
+      output.zero_();
+    }
+    return outputs;
+  }
 
   // This kernel is moving one feature/key per warp.
   // We are launching ( permute_size//warp_per_block, batch_size, ?)
@@ -310,16 +319,12 @@ std::vector<Tensor> permute_multi_embedding_function_gpu(
   const int32_t grid_dim_y =
       std::min(static_cast<int32_t>(batch_size), max_grid_dim);
   const int32_t grid_dim_z = (batch_size + max_grid_dim - 1) / max_grid_dim;
-  // HIP enforces a hard limit of 2^32 total threads per launch.
-  // permute_multi_embs_kernel grid-strides over permute_id, so capping grid.x
-  // is correctness-preserving. cap_grid_dim_x bounds the *total* launch, so we
-  // must fold every other launch dimension (block threads and the y/z batch
-  // dims) into its per-column thread count -- otherwise a large batch_size
-  // multiplies past 2^32 even though grid.x alone fits.
-  // See: https://github.com/ROCm/hip/issues/2253
-  const auto blocks_x = utils::cuda::cap_grid_dim_x(
+  // The kernel grid-strides over permute_id.
+  const int64_t yz_blocks = static_cast<int64_t>(grid_dim_y) * grid_dim_z;
+  const auto blocks_x = utils::cuda::cap_grid_dim_x_with_yz_blocks(
       fbgemm_gpu::div_round_up(permute_size, warp_per_block),
-      static_cast<int64_t>(block_dim.x) * block_dim.y * grid_dim_y * grid_dim_z,
+      static_cast<int64_t>(block_dim.x) * block_dim.y,
+      yz_blocks,
       at::cuda::getCurrentCUDAStream());
   const dim3 grid_dim(blocks_x, grid_dim_y, grid_dim_z);
 

--- a/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops_cpu.cpp
+++ b/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops_cpu.cpp
@@ -39,6 +39,12 @@ std::vector<Tensor> permute_multi_embedding_function_cpu(
     outputs.push_back(at::empty({B, lengths[i]}, pooled_embs[0].options()));
     TORCH_CHECK(outputs[i].is_contiguous());
   }
+  if (permutes.size(0) == 0) {
+    for (auto& output : outputs) {
+      output.zero_();
+    }
+    return outputs;
+  }
   FBGEMM_DISPATCH_FLOATING_TYPES(
       pooled_embs[0].scalar_type(), "permute_multi_embs_cpu", [&] {
         at::parallel_for(0, B, 0, [&](int32_t start, int32_t end) {

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops.cu
@@ -113,16 +113,12 @@ Tensor permute_pooled_embs_gpu_impl(
   const dim3 threads(fbgemm_gpu::kMaxThreads);
   const int32_t blocks_y = std::min(static_cast<int32_t>(B), max_grid_dim_y);
   const int32_t blocks_z = (B + max_grid_dim_y - 1) / max_grid_dim_y;
-  // HIP enforces a hard limit of 2^32 total threads per launch.
-  // permute_pooled_embs_kernel grid-strides over t, so capping grid.x is
-  // correctness-preserving. cap_grid_dim_x bounds the *total* launch, so we
-  // must fold every other launch dimension (block threads and the y/z batch
-  // dims) into its per-column thread count -- otherwise a large B multiplies
-  // past 2^32 even though grid.x alone fits.
-  // See: https://github.com/ROCm/hip/issues/2253
-  const auto blocks_x = utils::cuda::cap_grid_dim_x(
+  // The kernel grid-strides over T.
+  const int64_t yz_blocks = static_cast<int64_t>(blocks_y) * blocks_z;
+  const auto blocks_x = utils::cuda::cap_grid_dim_x_with_yz_blocks(
       fbgemm_gpu::div_round_up(T, warp_per_block),
-      static_cast<int64_t>(threads.x) * blocks_y * blocks_z,
+      threads.x,
+      yz_blocks,
       at::cuda::getCurrentCUDAStream());
   const dim3 blocks(blocks_x, blocks_y, blocks_z);
 

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split.cu
@@ -140,17 +140,12 @@ Tensor permute_pooled_embs_split_gpu_impl(
   const dim3 threads(fbgemm_gpu::kMaxThreads);
   const int32_t blocks_y = std::min(static_cast<int32_t>(B), max_grid_dim_y);
   const int32_t blocks_z = (B + max_grid_dim_y - 1) / max_grid_dim_y;
-  // HIP enforces a hard limit of 2^32 total threads per launch.
-  // permute_pooled_embs_kernel grid-strides over t (kernel-side change
-  // landed in the previous diff in this stack), so capping grid.x is
-  // correctness-preserving. cap_grid_dim_x bounds the *total* launch, so we
-  // must fold every other launch dimension (block threads and the y/z batch
-  // dims) into its per-column thread count -- otherwise a large B multiplies
-  // past 2^32 even though grid.x alone fits.
-  // See: https://github.com/ROCm/hip/issues/2253
-  const auto blocks_x = utils::cuda::cap_grid_dim_x(
+  // The kernel grid-strides over T.
+  const int64_t yz_blocks = static_cast<int64_t>(blocks_y) * blocks_z;
+  const auto blocks_x = utils::cuda::cap_grid_dim_x_with_yz_blocks(
       fbgemm_gpu::div_round_up(T, warp_per_block),
-      static_cast<int64_t>(threads.x) * blocks_y * blocks_z,
+      threads.x,
+      yz_blocks,
       at::cuda::getCurrentCUDAStream());
   const dim3 blocks(blocks_x, blocks_y, blocks_z);
 

--- a/fbgemm_gpu/src/quantize_ops/quantize_msfp.cu
+++ b/fbgemm_gpu/src/quantize_ops/quantize_msfp.cu
@@ -152,16 +152,13 @@ DLL_PUBLIC at::Tensor _float_to_msfp_gpu(
 
   const int blockDim_x = std::min(ncols, threads_per_block);
   const dim3 blockDim(blockDim_x, threads_per_block / blockDim_x);
-  // HIP enforces a hard limit of 2^32 total threads per launch.
-  // The kernel grid-strides on both dims (over row and col), so capping is
-  // correctness-preserving. gridDim.y is already manually capped below at
-  // 65535 — leave it untouched.
-  // See: https://github.com/ROCm/hip/issues/2253
-  const int gridDim_x = utils::cuda::cap_grid_dim_x(
+  // The kernel grid-strides over rows and columns.
+  const int gridDim_y = std::min((nrows + blockDim.y - 1) / blockDim.y, 65535u);
+  const int gridDim_x = utils::cuda::cap_grid_dim_x_with_yz_blocks(
       (ncols + blockDim.x - 1) / blockDim.x,
       threads_per_block,
+      gridDim_y,
       at::cuda::getCurrentCUDAStream());
-  const int gridDim_y = std::min((nrows + blockDim.y - 1) / blockDim.y, 65535u);
   const dim3 gridDim(gridDim_x, gridDim_y);
 
   auto shared_exponents =

--- a/fbgemm_gpu/src/sparse_ops/sparse_batched_unary_embeddings.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_batched_unary_embeddings.cu
@@ -61,26 +61,29 @@ Tensor batched_unary_embeddings_forward_cuda(
   // N: number of tasks, T: number of tables, B: batch size
   const int32_t N = weight.size(0);
   const int32_t T = table_offsets.numel() - 1;
-  const int32_t B = (offsets.numel() - 1) / T;
   TORCH_CHECK(N > 0);
-  TORCH_CHECK(B > 0);
   TORCH_CHECK(T > 0);
   TORCH_CHECK(T <= 65535);
   TORCH_CHECK(N <= 65535);
+  TORCH_CHECK(
+      offsets.numel() >= 1, "offsets must contain at least one element");
+  TORCH_CHECK(
+      (offsets.numel() - 1) % T == 0,
+      "offsets.numel() - 1 must be divisible by T");
+  const int32_t B = (offsets.numel() - 1) / T;
+  auto output = at::empty({N, B, T}, weight.options());
+  if (B == 0) {
+    return output;
+  }
   int32_t threads = std::min<int32_t>(B, 512);
-  // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
-  // which silently wraps). The forward kernel grid-strides over b, so capping
-  // is correctness-preserving. T and N are y/z grid dims; they contribute
-  // multiplicatively to the total thread count, so the threshold check uses
-  // `threads * T * N` (the full per-block thread cost) to keep
-  // blocks_x * threads * T * N below 2^32 on ROCm.
-  // See: https://github.com/ROCm/hip/issues/2253
-  const auto blocks_x = utils::cuda::cap_grid_dim_x(
+  // The forward kernel grid-strides over B.
+  const int64_t yz_blocks = static_cast<int64_t>(T) * N;
+  const auto blocks_x = utils::cuda::cap_grid_dim_x_with_yz_blocks(
       cuda_calc_xblock_count(B, threads),
-      static_cast<int64_t>(threads) * T * N,
+      threads,
+      yz_blocks,
       at::cuda::getCurrentCUDAStream());
   dim3 blocks(blocks_x, T, N);
-  auto output = at::empty({N, B, T}, weight.options());
   AT_DISPATCH_INDEX_TYPES(
       indices.scalar_type(), "batched_unary_embeddings_forward_kernel", [&] {
         FBGEMM_DISPATCH_FLOATING_TYPES(
@@ -201,8 +204,11 @@ DLL_PUBLIC Tensor batched_unary_embeddings_backward_cuda(
   const int32_t B = grad_output.size(1);
   const int32_t T = grad_output.size(2);
   TORCH_CHECK(N > 0);
-  TORCH_CHECK(B > 0);
   TORCH_CHECK(T > 0);
+  auto grad_weight = at::zeros_like(weight);
+  if (B == 0) {
+    return grad_weight;
+  }
 
   int32_t info_B_num_bits;
   uint32_t info_B_mask;
@@ -235,18 +241,18 @@ DLL_PUBLIC Tensor batched_unary_embeddings_backward_cuda(
           info_B_num_bits,
           info_B_mask);
 
+  if (sorted_linear_indices_run.numel() == 0) {
+    return grad_weight;
+  }
+
   int threads = std::min<int32_t>(sorted_linear_indices_run.numel(), 512);
-  // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
-  // which silently wraps). The backward kernel grid-strides over run_id, so
-  // capping is correctness-preserving. y dim is bounded by N <= 65535 and
-  // needs no cap.
-  // See: https://github.com/ROCm/hip/issues/2253
-  const auto blocks_x = utils::cuda::cap_grid_dim_x_from_workload(
-      sorted_linear_indices_run.numel(),
+  // The backward kernel grid-strides over run_id.
+  const auto blocks_x = utils::cuda::cap_grid_dim_x_with_yz_blocks(
+      cuda_calc_xblock_count(sorted_linear_indices_run.numel(), threads),
       threads,
+      N,
       at::cuda::getCurrentCUDAStream());
   dim3 blocks(blocks_x, N);
-  auto grad_weight = at::zeros_like(weight);
   AT_DISPATCH_INDEX_TYPES(
       indices.scalar_type(), "batched_unary_embeddings_backward_kernel", [&] {
         FBGEMM_DISPATCH_FLOATING_TYPES(

--- a/fbgemm_gpu/src/sparse_ops/sparse_index_add.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_index_add.cu
@@ -153,18 +153,11 @@ DLL_PUBLIC Tensor index_add_with_unique_indices_cuda(
               }
 
               const int num_y_blocks = (D + stride_D - 1) / stride_D;
-              // HIP enforces a hard limit of 2^32 total threads per launch
-              // (unlike CUDA, which silently wraps).
-              // index_add_2d_with_unique_indices_kernel grid-strides over the
-              // unique index (x) dim, so capping x is correctness-preserving.
-              // The y dim is not grid-strided, so fold num_y_blocks into the
-              // per-launch thread count used for the overflow check, keeping
-              // the cap accounting consistent with the launcher's total-thread
-              // check (grid.x * grid.y * block_size). See:
-              // https://github.com/ROCm/hip/issues/2253
-              const auto blocks_x = utils::cuda::cap_grid_dim_x(
+              // The kernel grid-strides over the unique-index dimension.
+              const auto blocks_x = utils::cuda::cap_grid_dim_x_with_yz_blocks(
                   cuda_calc_xblock_count(num_unique_indices, 1),
-                  static_cast<int64_t>(block_size) * num_y_blocks,
+                  block_size,
+                  num_y_blocks,
                   at::cuda::getCurrentCUDAStream());
               const dim3 grid_size(blocks_x, num_y_blocks, 1);
 

--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
@@ -2373,10 +2373,14 @@ Tensor batched_unary_embeddings_forward_cpu(
   // N: number of tasks, T: number of tables, B: batch size
   const int64_t N = weight.sizes()[0];
   const int64_t T = table_offsets.numel() - 1;
-  const int64_t B = (offsets.numel() - 1) / T;
   TORCH_CHECK(N > 0);
   TORCH_CHECK(T > 0);
-  TORCH_CHECK(B > 0);
+  TORCH_CHECK(
+      offsets.numel() >= 1, "offsets must contain at least one element");
+  TORCH_CHECK(
+      (offsets.numel() - 1) % T == 0,
+      "offsets.numel() - 1 must be divisible by T");
+  const int64_t B = (offsets.numel() - 1) / T;
 
   // Make sure the index_t are consistent among table_offsets, offsets and
   // indices
@@ -2384,6 +2388,9 @@ Tensor batched_unary_embeddings_forward_cpu(
   TORCH_CHECK(table_offsets.scalar_type() == indices.scalar_type());
 
   auto output = at::empty({N, B, T}, weight.options());
+  if (B == 0) {
+    return output;
+  }
 
   AT_DISPATCH_INDEX_TYPES(table_offsets.scalar_type(), "unary_indices", [&] {
     FBGEMM_DISPATCH_FLOATING_TYPES(

--- a/fbgemm_gpu/src/split_embeddings_utils/generate_vbe_metadata.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils/generate_vbe_metadata.cu
@@ -201,13 +201,12 @@ generate_vbe_metadata(
       at::empty({total_B_}, output_offsets_feature_rank.options());
   Tensor b_t_map = at::empty({total_B_}, B_offsets.options());
 
-  // Cap grid.x on ROCm so total threads (grid.x * kMaxThreads * num_ranks * T)
-  // stay under the HIP 2^32 threads-per-launch limit; the kernel grid-strides
-  // over b. grid.y (num_ranks) and grid.z (T) are factored into the per-x-block
-  // thread count for the overflow check. No-op on CUDA.
-  const auto grid_dim_x = utils::cuda::cap_grid_dim_x(
+  // The kernel grid-strides over B.
+  const int64_t yz_blocks = static_cast<int64_t>(num_ranks) * T;
+  const auto grid_dim_x = utils::cuda::cap_grid_dim_x_with_yz_blocks(
       div_round_up(max_B_feature_rank_, kMaxThreads),
-      static_cast<int64_t>(kMaxThreads) * num_ranks * T,
+      kMaxThreads,
+      yz_blocks,
       at::cuda::getCurrentCUDAStream());
   const dim3 grid_size(grid_dim_x, num_ranks, T);
   const auto& [max_grid_x, max_grid_y, max_grid_z] = get_max_grid_size();

--- a/fbgemm_gpu/test/batched_unary_embeddings_test.py
+++ b/fbgemm_gpu/test/batched_unary_embeddings_test.py
@@ -192,8 +192,9 @@ class TableBatchedEmbeddingsTest(unittest.TestCase):
         if torch_compile:
             return
 
+        # Citrine C3: create the gradient directly on the target device.
         d_output = (
-            torch.randn([num_tasks, batch_size, len(hash_sizes)]).to(device) * 0.1
+            torch.randn([num_tasks, batch_size, len(hash_sizes)], device=device) * 0.1
         )
         output_ref.backward(d_output)
         output.backward(d_output)
@@ -216,8 +217,11 @@ class TableBatchedEmbeddingsTest(unittest.TestCase):
             hash_sizes=[71, 107],
             long_index=True,
         ).to(device)
-        offsets = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.long).to(device)
-        values = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8], dtype=torch.long).to(device)
+        # Citrine C3: create test inputs directly on the target device.
+        offsets = torch.tensor(
+            [0, 1, 2, 3, 4, 5, 6, 7, 8], dtype=torch.long, device=device
+        )
+        values = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8], dtype=torch.long, device=device)
         for _ in range(10):
             output = unary_embedding_module(offsets, values).transpose(1, 0)
             output = output[1:]
@@ -242,6 +246,123 @@ class TableBatchedEmbeddingsTest(unittest.TestCase):
 
     def test_cpu(self) -> None:
         self._test_main(gpu_infer=False)
+
+    def test_batched_unary_embeddings_zero_batch_cpu(self) -> None:
+        num_tasks = 2
+        hash_sizes = [2, 3]
+        unary_emb = batched_unary_embeddings_ops.BatchedUnaryEmbeddingBag(
+            num_tasks=num_tasks,
+            hash_sizes=hash_sizes,
+            long_index=True,
+        )
+        offsets = torch.zeros(1, dtype=torch.long)
+        indices = torch.empty(0, dtype=torch.long)
+
+        output = unary_emb(offsets, indices)
+
+        self.assertEqual(output.shape, (num_tasks, 0, len(hash_sizes)))
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_batched_unary_embeddings_zero_batch(self) -> None:
+        num_tasks = 2
+        hash_sizes = [2, 3]
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        unary_emb = batched_unary_embeddings_ops.BatchedUnaryEmbeddingBag(
+            num_tasks=num_tasks,
+            hash_sizes=hash_sizes,
+            long_index=True,
+        ).to(device)
+        offsets = torch.zeros(1, dtype=torch.long, device=device)
+        indices = torch.empty(0, dtype=torch.long, device=device)
+
+        output = unary_emb(offsets, indices)
+        output.sum().backward()
+
+        self.assertEqual(output.shape, (num_tasks, 0, len(hash_sizes)))
+        torch.testing.assert_close(
+            none_throws(unary_emb.weight.grad),
+            torch.zeros_like(unary_emb.weight),
+        )
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_batched_unary_embeddings_empty_indices_backward(self) -> None:
+        num_tasks = 2
+        hash_sizes = [2, 3]
+        batch_size = 3
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        unary_emb = batched_unary_embeddings_ops.BatchedUnaryEmbeddingBag(
+            num_tasks=num_tasks,
+            hash_sizes=hash_sizes,
+            long_index=True,
+        ).to(device)
+        offsets = torch.zeros(
+            len(hash_sizes) * batch_size + 1,
+            dtype=torch.long,
+            device=device,
+        )
+        indices = torch.empty(0, dtype=torch.long, device=device)
+
+        output = unary_emb(offsets, indices)
+        output.sum().backward()
+
+        self.assertEqual(output.shape, (num_tasks, batch_size, len(hash_sizes)))
+        torch.testing.assert_close(output, torch.zeros_like(output))
+        torch.testing.assert_close(
+            none_throws(unary_emb.weight.grad),
+            torch.zeros_like(unary_emb.weight),
+        )
+
+    def test_batched_unary_embeddings_rejects_malformed_offsets_cpu(self) -> None:
+        weight = torch.ones((2, 5))
+        table_offsets = torch.tensor([0, 2, 5], dtype=torch.long)
+        indices = torch.empty(0, dtype=torch.long)
+        invalid_offsets = (
+            (
+                torch.empty(0, dtype=torch.long),
+                "offsets must contain at least one element",
+            ),
+            (
+                torch.zeros(2, dtype=torch.long),
+                r"offsets.numel\(\) - 1 must be divisible by T",
+            ),
+        )
+
+        for offsets, error_pattern in invalid_offsets:
+            with self.subTest(offsets_numel=offsets.numel()):
+                with self.assertRaisesRegex(RuntimeError, error_pattern):
+                    torch.ops.fbgemm.batched_unary_embeddings(
+                        weight,
+                        table_offsets,
+                        offsets,
+                        indices,
+                    )
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_batched_unary_embeddings_rejects_malformed_offsets(self) -> None:
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        weight = torch.ones((2, 5), device=device)
+        table_offsets = torch.tensor([0, 2, 5], dtype=torch.long, device=device)
+        indices = torch.empty(0, dtype=torch.long, device=device)
+        invalid_offsets = (
+            (
+                torch.empty(0, dtype=torch.long, device=device),
+                "offsets must contain at least one element",
+            ),
+            (
+                torch.zeros(2, dtype=torch.long, device=device),
+                r"offsets.numel\(\) - 1 must be divisible by T",
+            ),
+        )
+
+        for offsets, error_pattern in invalid_offsets:
+            with self.subTest(offsets_numel=offsets.numel()):
+                with self.assertRaisesRegex(RuntimeError, error_pattern):
+                    torch.ops.fbgemm.batched_unary_embeddings(
+                        weight,
+                        table_offsets,
+                        offsets,
+                        indices,
+                    )
 
     @unittest.skipIf(*gpu_unavailable)
     # This test exercises the HIP launch-side limit and requires a large

--- a/fbgemm_gpu/test/permute/permute_multi_embedding_ops_test.py
+++ b/fbgemm_gpu/test/permute/permute_multi_embedding_ops_test.py
@@ -39,6 +39,90 @@ SHAPES_DTYPE: torch.dtype = torch.int32
 
 class PermuteMultiEmbeddingOpsTest(unittest.TestCase):
     @unittest.skipIf(*gpu_unavailable)
+    def test_permute_multi_embedding_returns_empty_batch(self) -> None:
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+        lengths = [4]
+        permutes = torch.tensor(
+            [[0, 0, 0, 0, 4, -1]], dtype=PERMUTES_DTYPE, device=device
+        )
+        shapes = torch.tensor(lengths, dtype=SHAPES_DTYPE, device=device)
+        pooled_embs = [torch.empty((0, lengths[0]), device=device)]
+
+        outputs = torch.ops.fbgemm.permute_multi_embedding(
+            pooled_embs,
+            permutes,
+            shapes,
+            shapes,
+            lengths,
+        )
+
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(outputs[0].shape, (0, lengths[0]))
+        self.assertEqual(outputs[0].numel(), 0)
+
+    def _assert_empty_permutes_return_zeros(self, device: torch.device) -> None:
+        batch_size = 2
+        lengths = [4]
+        permutes = torch.empty((0, 6), dtype=PERMUTES_DTYPE, device=device)
+        shapes = torch.tensor(lengths, dtype=SHAPES_DTYPE, device=device)
+        pooled_embs = [
+            torch.ones((batch_size, lengths[0]), device=device, requires_grad=True)
+        ]
+
+        outputs = torch.ops.fbgemm.permute_multi_embedding(
+            pooled_embs,
+            permutes,
+            shapes,
+            shapes,
+            lengths,
+        )
+
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(outputs[0].shape, (batch_size, lengths[0]))
+        torch.testing.assert_close(
+            outputs[0], torch.zeros_like(outputs[0]), rtol=0, atol=0
+        )
+
+        outputs[0].sum().backward()
+        torch.testing.assert_close(
+            pooled_embs[0].grad,
+            torch.zeros_like(pooled_embs[0]),
+            rtol=0,
+            atol=0,
+        )
+
+    def test_permute_multi_embedding_returns_empty_permutes_cpu(self) -> None:
+        deterministic_algorithms_enabled = torch.are_deterministic_algorithms_enabled()
+        deterministic_warn_only_enabled = (
+            torch.is_deterministic_algorithms_warn_only_enabled()
+        )
+        torch.use_deterministic_algorithms(True)
+        try:
+            self._assert_empty_permutes_return_zeros(torch.device("cpu"))
+        finally:
+            torch.use_deterministic_algorithms(
+                deterministic_algorithms_enabled,
+                warn_only=deterministic_warn_only_enabled,
+            )
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_permute_multi_embedding_returns_empty_permutes_gpu(self) -> None:
+        deterministic_algorithms_enabled = torch.are_deterministic_algorithms_enabled()
+        deterministic_warn_only_enabled = (
+            torch.is_deterministic_algorithms_warn_only_enabled()
+        )
+        torch.use_deterministic_algorithms(True)
+        try:
+            self._assert_empty_permutes_return_zeros(
+                torch.device(torch.accelerator.current_accelerator() or "cuda")
+            )
+        finally:
+            torch.use_deterministic_algorithms(
+                deterministic_algorithms_enabled,
+                warn_only=deterministic_warn_only_enabled,
+            )
+
+    @unittest.skipIf(*gpu_unavailable)
     def test_permute_multi_embedding_smoke(self) -> None:
         """Small-input correctness regression. Gates the kernel-side
         grid-stride transformation against breakage on small inputs."""


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3162

NOTE: No linked task is associated with this diff.

Migrate multidimensional launch capping to account for the unchanged grid plane while kernels grid-stride over the capped dimension.

Validate sparse batched-unary offset structure consistently on CPU and CUDA, accept valid zero-batch inputs on both backends, and preserve zero-work backward behavior. Define empty multi-embedding permutations to return zero-filled outputs and zero gradients on CPU and GPU without constructing a zero-dimension launch.

Add focused CPU/GPU coverage for zero batches, empty indices, malformed offsets, and empty permutations. Reuse the exact jagged GPU remote-execution policy, routing dense_bmm to MI300 under AMD configurations for ROCm/HIP path coverage while preserving the descendant unique_indices selection.

Reviewed By: jianyuh

Differential Revision: D116806923


