### PR TITLE
Stop the HIP flags from cancelling -Wunused-result (#6282)

### DIFF
--- a/cmake/modules/RocmSetup.cmake
+++ b/cmake/modules/RocmSetup.cmake
@@ -24,8 +24,7 @@ if(FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM)
     -Wno-cuda-compat
     -Wno-deprecated-declarations
     -Wno-format
-    -Wno-ignored-attributes
-    -Wno-unused-result)
+    -Wno-ignored-attributes)
 
   # is this hipify v2?
   execute_process(

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/bf16_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/bf16_grouped_gemm.hip
@@ -17,7 +17,7 @@
 #include <unordered_map>
 
 #include <ATen/ATen.h>
-#include <c10/cuda/CUDAException.h>
+#include <c10/hip/HIPException.h>
 #include <c10/hip/HIPStream.h>
 
 #include "ck/ck.hpp"


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/3164

NOTE: No linked task. Please associate a task with this diff.

`RocmSetup.cmake` added `-Wno-unused-result` to `HIP_HCC_FLAGS`. The HIP
compile line places those flags after the warning flags, so that suppression
silently cancelled the intended `-Wunused-result` check for device code.

Remove the contradictory suppression from the mirrored fbcode and xplat
configuration while keeping the remaining HIP flag ordering intact. Check the
remaining CK grouped-GEMM host-to-device copy with `C10_CUDA_CHECK`, so a copy
failure propagates through PyTorch's existing HIP error handling.

The runtime-version, synchronization, device-property, and rocPRIM checks from
the earlier version of this diff are now present on master. This rebased version
retains master's newer implementations and avoids duplicating those changes.

Reviewed By: gchalump

Differential Revision: D117144908


