### PR TITLE
Fix ROCm build failures related to return values discarding (#6277)

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
@@ -246,10 +246,10 @@ inline uint32_t cap_grid_dim_x_from_workload(
 inline auto get_compute_versions() {
   static const auto versions = [] {
     int runtime_version = 0;
-    C10_CUDA_CHECK(cudaRuntimeGetVersion(&runtime_version));
+    C10_CUDA_IGNORE_ERROR(cudaRuntimeGetVersion(&runtime_version));
 
     int driver_version = 0;
-    C10_CUDA_CHECK(cudaDriverGetVersion(&driver_version));
+    C10_CUDA_IGNORE_ERROR(cudaDriverGetVersion(&driver_version));
 
     return std::tuple{runtime_version, driver_version};
   }();

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
@@ -248,12 +248,11 @@ struct __attribute__((visibility("hidden"))) KernelLauncher {
         "]");
   }
 
-  inline void kernelLaunchCheck() const {
+  inline void kernelLaunchCheck(
+      const cudaError_t cuda_error = cudaGetLastError()) const {
     // This is a replacement for C10_CUDA_KERNEL_LAUNCH_CHECK() that adds more
     // context information to the error message.  See:
     //  https://github.com/pytorch/pytorch/blob/main/c10/cuda/CUDAException.cpp
-
-    const auto cuda_error = cudaGetLastError();
 
     const auto cuda_kernel_failure =
         c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().has_failed();
@@ -363,13 +362,13 @@ struct __attribute__((visibility("hidden"))) KernelLauncher {
     // If barrier isolation is enabled, synchronize the stream again to wait for
     // kernel execution to complete
     if constexpr (EnableBarrierIsolation) {
-      C10_CUDA_CHECK(cudaDeviceSynchronize());
+      kernelLaunchCheck(cudaDeviceSynchronize());
+    } else {
+      // Check for CUDA errors. This is a replacement for
+      // C10_CUDA_KERNEL_LAUNCH_CHECK() that adds more context information to
+      // the error message.
+      kernelLaunchCheck();
     }
-
-    // Check for CUDA errors.  This is a replacement for
-    // C10_CUDA_KERNEL_LAUNCH_CHECK() that adds more context information to the
-    // error message.
-    kernelLaunchCheck();
 
     // If NaN checks are enabled, run post-kernel verifications on all kernel
     // arguments that are tensors


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/3165

Wrapped HIP/CUDA functions marked as `[[nodiscard]]` with `C10/ATEN_CUDA_CHECK` to address fail-on-warning ROCm build issues.


Reviewed By: gchalump

Differential Revision: D119363682

Pulled By: q10


