### PR TITLE
Build FBGEMM release CUDA wheels on linux.12xlarge.memory

### DIFF
--- a/.github/scripts/filter_nova_matrix.py
+++ b/.github/scripts/filter_nova_matrix.py
@@ -12,19 +12,9 @@ import sys
 from collections import defaultdict
 
 
-def parse_filters() -> list[dict[str, list[str]]]:
-    """
-    Parse filters from command line arguments into a list of dictionaries.
-
-    Each --filter flag corresponds to one dictionary group.
-    Supports syntax like:
-      --filter key1:val1,val2;key2:val3 --filter key3:val4
-
-    Returns:
-      list[dict[str, list[str]]]: A list of filter groups.
-    """
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Parse filters into a list of grouped dictionaries."
+        description="Filter and adjust a Nova build matrix."
     )
     parser.add_argument(
         "--filter",
@@ -34,11 +24,32 @@ def parse_filters() -> list[dict[str, list[str]]]:
         "where value_list is of the format val1,[val2]. "
         "Multiple --filter flags are allowed.",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--runner",
+        action="append",
+        default=[],
+        help="Runner override(s) of the format <selector>=<runner_label>, where "
+        "<selector> uses the same grammar as --filter. Coordinates matching the "
+        "selector have their validation_runner replaced with <runner_label>. "
+        "Multiple --runner flags are allowed; the first match wins.",
+    )
+    return parser.parse_args()
 
+
+def parse_filters(groups: list[str]) -> list[dict[str, list[str]]]:
+    """
+    Parse filter groups into a list of dictionaries.
+
+    Each group corresponds to one dictionary.
+    Supports syntax like:
+      key1:val1,val2;key2:val3
+
+    Returns:
+      list[dict[str, list[str]]]: A list of filter groups.
+    """
     result = []
 
-    for group in args.filter:
+    for group in groups:
         filter_dict = defaultdict(list)
         parts = group.split(";")
         for part in parts:
@@ -77,10 +88,65 @@ def query_match(
     return any([and_match(coordinate, query) for query in queries])
 
 
+def parse_runner_overrides(specs: list[str]) -> list[tuple[dict[str, list[str]], str]]:
+    """
+    Parse runner overrides of the format <selector>=<runner_label> into
+    (selector, runner_label) pairs, where <selector> uses the --filter grammar.
+
+    Returns:
+      list[tuple[dict[str, list[str]], str]]: A list of (selector, runner) pairs.
+    """
+    result = []
+
+    for spec in specs:
+        if "=" not in spec:
+            raise ValueError(
+                f"Invalid runner override format: {spec}. "
+                "Expected <selector>=<runner_label>"
+            )
+
+        selector_str, runner = spec.split("=", 1)
+        [selector] = parse_filters([selector_str])
+        result.append((selector, runner))
+
+    return result
+
+
+def strict_and_match(coordinate: dict[str, str], query: dict[str, list[str]]) -> bool:
+    """
+    Check if a build matrix coordinate matches all the query parameters, and
+    carries every key the query selects on.
+
+    This is deliberately stricter than `and_match`.  Filtering is subtractive,
+    so treating an absent key as satisfied there only ever drops coordinates.
+    A runner override is targeted, and the same leniency would silently
+    retarget any coordinate that never declared the field being selected on.
+    """
+    return all(coordinate.get(key) in values for key, values in query.items())
+
+
+def apply_runner_overrides(
+    coordinates: list[dict[str, str]],
+    overrides: list[tuple[dict[str, list[str]], str]],
+) -> None:
+    """
+    Rewrite the validation_runner of every coordinate matching an override
+    selector, in place.  The first matching override wins.
+    """
+    for coordinate in coordinates:
+        for selector, runner in overrides:
+            if strict_and_match(coordinate, selector):
+                coordinate["validation_runner"] = runner
+                break
+
+
 def main():
-    # Parse the filter rules
-    filter_rules = parse_filters()
-    print(filter_rules, file=sys.stderr)
+    args = parse_args()
+
+    # Parse the filter rules and the runner overrides
+    filter_rules = parse_filters(args.filter)
+    runner_overrides = parse_runner_overrides(args.runner)
+    print(filter_rules, runner_overrides, file=sys.stderr)
 
     # Exztract the full matrix
     full_matrix_string = os.environ["MAT"]
@@ -93,6 +159,10 @@ def main():
         # Filter out build matrix coordinates if they match one of the queries
         if not query_match(coordinate, filter_rules)
     ]
+
+    # Move the surviving coordinates onto bigger machines where requested
+    apply_runner_overrides(new_matrix_entries, runner_overrides)
+
     new_matrix = {"include": new_matrix_entries}
 
     # Print the filtered matrix

--- a/.github/workflows/build_wheels_genai_linux_x86.yml
+++ b/.github/workflows/build_wheels_genai_linux_x86.yml
@@ -59,11 +59,26 @@ jobs:
       # rocm/7.14: not supported in the Nova scripts yet (nova_dir.bash knows
       #   rocm 7.0/6.4/6.3/6.2); the build produces no wheel and the job fails
       #   on the empty dist/. Drop until supported.
+      #
+      # Nova Runner Overrides (release pipeline only):
+      # cuda: see build_wheels_linux_x86.yml - the Nova default
+      #   linux.g5.4xlarge.nvidia.gpu is FBGEMM's CUDA *test* machine (8 cores,
+      #   64 GB, and a GPU the build container cannot even see).  RC/final tag
+      #   pushes build on linux.12xlarge.memory instead, which is exactly what
+      #   `generate_ci_matrix.py` `host_machines()` already selects for the
+      #   GenAI CUDA build in-repo.  The general Nova CI - nightly, main, PRs
+      #   and manual dispatch - is left on the Nova default runner.
       run: |
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter gpu_arch_version:11.8 --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2,13.4' --filter 'gpu_arch_type:rocm;gpu_arch_version:7.14' )"
+
+        runner_args=()
+        if [[ "${GITHUB_EVENT_NAME}" == push && "${GITHUB_REF}" == refs/tags/v* ]]; then
+          runner_args=(--runner 'gpu_arch_type:cuda=linux.12xlarge.memory')
+        fi
+
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter gpu_arch_version:11.8 --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2,13.4' --filter 'gpu_arch_type:rocm;gpu_arch_version:7.14' "${runner_args[@]}" )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/build_wheels_linux_x86.yml
+++ b/.github/workflows/build_wheels_linux_x86.yml
@@ -54,11 +54,40 @@ jobs:
       # cuda 13.2 (cu132), 13.4 (cu134): not supported by FBGEMM yet; test-infra
       #   emits them and the validate step fails with "Unknown distribution".
       #   13.4 is still on toolkit 13.4.0rc1 (not GA). Drop until each is supported.
+      #
+      #
+      # Nova Runner Overrides (release pipeline only):
+      # cuda: the Nova default is linux.g5.4xlarge.nvidia.gpu, which is
+      #   FBGEMM's *test* machine, not its build machine.  In-repo,
+      #   `.github/scripts/generate_ci_matrix.py` `host_machines()` reserves
+      #   that label for the CUDA test job - where the GPU is real - and builds
+      #   CUDA on linux.24xlarge / linux.12xlarge.memory / linux.24xlarge.memory
+      #   depending on target.  Nova collapses build and test into one job and
+      #   gets the test box for both, and the GPU is not even visible there
+      #   (the container reports torch.cuda.is_available() == False, so the
+      #   post-build suite runs CPU-only regardless).
+      #
+      #   linux.12xlarge.memory (r5.12xlarge) is a strict improvement on every
+      #   axis that matters here vs g5.4xlarge: 24 physical cores vs 8, 384 GB
+      #   vs 64, 600 GB disk vs 150.  Cores are what count - `-j` is derived
+      #   from `lscpu` cores x sockets, not vCPUs, so it is 8 today and would
+      #   stay 8 on any other 4xlarge.  It is also the machine the GenAI CUDA
+      #   build already uses in-repo, so the capacity is established.
+      #
+      #   Scoped to RC/final tag pushes, i.e. the release pipeline only.  The
+      #   general Nova CI - nightly, main, PRs and manual dispatch - is left on
+      #   the Nova default runner.
       run: |
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2,13.4' )"
+
+        runner_args=()
+        if [[ "${GITHUB_EVENT_NAME}" == push && "${GITHUB_REF}" == refs/tags/v* ]]; then
+          runner_args=(--runner 'gpu_arch_type:cuda=linux.12xlarge.memory')
+        fi
+
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2,13.4' "${runner_args[@]}" )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
Summary:
Nova builds FBGEMM's release CUDA wheels on `linux.g5.4xlarge.nvidia.gpu`, which `generate_ci_matrix.py` `host_machines()` reserves for the CUDA *test* job, not for builds. Nova collapses build and test into one job, so the build lands on the test box: 8 physical cores, 64 GB, and a GPU the container cannot see (`torch.cuda.is_available() == False`, so the post-build suite is CPU-only anyway).

This adds a `--runner <selector>=<label>` flag to `filter_nova_matrix.py` that rewrites `validation_runner` on matching matrix coordinates, and uses it to send release CUDA builds to `linux.12xlarge.memory` — 24 cores / 384 GB / 600 GB disk, the machine the GenAI CUDA build already uses in-repo.

Gated to RC/final tag pushes (`github.event_name == push` and `refs/tags/v*`). Nightly, main, PRs and manual dispatch keep the Nova default; CPU and ROCm are untouched on every trigger.

Why not a smaller bump: `-j` derives from `lscpu` cores × sockets, i.e. physical cores, so `linux.4xlarge.memory` would leave it at 8 and not move build time at all. Cores matter here — rc0's `cuda13_0` jobs ran 3h5m against the workflow's 300-minute cap.

Context: rc0 (run 33779246790) lost `build-manywheel-py3_10-cuda12_6`. The build itself succeeded; the job then stopped 12s into `backward_adagrad_test.py` and emitted nothing for its remaining ~17 minutes, with no exit status recorded — the host went away. 40 of the other 41 jobs passed on the default runner, so treat this as a headroom change, not a proven fix for that one host loss.

Reviewed By: q10

Differential Revision: D119373417


