### PR TITLE
Resolve generated training-forward warnings

### DIFF
--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
@@ -64,7 +64,9 @@ Tensor
     const Tensor& lxu_cache_weights [[maybe_unused]],
     const Tensor& weights_placements [[maybe_unused]],
     {%- endif %}
-    const Tensor& weights_offsets,
+    {#- /* The bagged path takes its table count from D_offsets and its total
+          length from offsets; only the nobag path reads these two. */ #}
+    {{ "" if nobag else "[[maybe_unused]] " }}const Tensor& weights_offsets,
     {%- if not nobag %}
     const Tensor& D_offsets,
     {%- else %}
@@ -76,7 +78,7 @@ Tensor
     {%- if not nobag %}
     const c10::SymInt max_D,
     {% endif %}
-    const Tensor& indices,
+    {{ "" if nobag else "[[maybe_unused]] " }}const Tensor& indices,
     const Tensor& offsets,
     {%- if not nobag %}
     const int64_t pooling_mode [[maybe_unused]],

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
@@ -397,10 +397,12 @@ batch_index_select_dim0_codegen_forward_cuda(
     const double gwd_lower_bound,
     {%- endif %}
     {%- if vbe and not dense %}
-    const bool is_experimental,
+    {#- /* Selects the TBE v2 forward, which exists only for the bagged,
+          non-VBE, non-SSD configuration. */ #}
+    {{ "" if has_experimental else "[[maybe_unused]] " }}const bool is_experimental,
     std::optional<Tensor> vbe_output
     {%- else %}
-    const bool is_experimental
+    {{ "" if has_experimental else "[[maybe_unused]] " }}const bool is_experimental
     {%- endif %}
     {%- endif %} {#- /*if is_index_select*/ #}
 ) {


### PR DESCRIPTION
Summary:
NOTE: No linked task. Please associate a task with this diff.

Resolve the remaining generated training-forward unused-parameter warnings.

Forward CUDA, Meta, and PT2 wrapper declarations now annotate only configuration-specific contract parameters, preserving signatures, schemas, and generated dispatch behavior.

Reviewed By: gchalump

Differential Revision: D117024946


