### PR TITLE
Dispatch VBE fp16 forward TBE to 32-wide thread groups (1.90x on production D=8 shape)

### DIFF
--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
@@ -996,6 +996,17 @@ batch_index_select_dim0_codegen_forward_kernel
     codegen/embedding_common_code_generator.py for more details
 */ #}
 
+{%- if is_rocm and vbe and not dense and not ssd and not weighted and not is_gwd %}
+{{ template_instantiation(
+    "at::Half",
+    "at::Half",
+    "float",
+    "int64_t",
+    "false",
+    1,
+    32)
+}}
+{%- endif %}
 {{ instantiate_templates(use_subwarp_shuffle=False) }}
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
@@ -248,6 +248,23 @@ batch_index_select_dim0_codegen_forward_kernel(
 #else
 #define {{ dispatch_macro_name }}(MAX_D, ...) \
   [&] {                                        \
+    {%- if is_rocm and vbe and not dense and not ssd and not weighted and not is_gwd %}
+    if constexpr (                              \
+        std::is_same_v<emb_t, at::Half> &&      \
+        std::is_same_v<cache_t, at::Half> &&    \
+        std::is_same_v<output_t, float> &&      \
+        std::is_same_v<index_t, int64_t> && !use_cache_t) { \
+      /* Use two half-wave groups: at small D most full-wave lanes are idle, */ \
+      /* so a 32-lane group doubles the fraction of useful lanes. */ \
+      if (MAX_D <= 128) {                      \
+        [[maybe_unused]] const int max_vecs_per_thread = 1; \
+        constexpr int kFixedMaxVecsPerThread = 1; \
+        [[maybe_unused]] constexpr int kThreadGroupSize = 32; \
+        [[maybe_unused]] constexpr bool kUseVecBlocking = false; \
+        return __VA_ARGS__();                  \
+      }                                       \
+    }                                         \
+    {%- endif %}
     {{
        dispatch_non_vec_blocking_kernel(
            items_per_warp,


### PR DESCRIPTION
Summary:
On ROCm the bagged split-TBE forward runs one row per full 64-lane wavefront
(FBGEMM_USE_SUBWARP_SHUFFLE is disabled for ROCm), so the dispatch macro is
stuck at kThreadGroupSize == kWarpSize == 64. Each lane covers VEC_WIDTH=4
elements, so only ceil(D/4) lanes carry data; at small D most of the wave is
idle (at D=8, 2 of 64 lanes).

This is real: a production APS trace (rank-9 of aps-f1126975723-1126985332,
MI350X/gfx950) shows split_embedding_codegen_forward_unweighted_vbe_kernel
<Half,Half,float,false,long,1,64> at T=1, D=8, E=80M, L~1, B~90.8M costing
213.6 ms over 5 launches -- 2.0% of GPU kernel time and the largest
non-NCCL/non-GEMM kernel on that rank.

Fix: add a ROCm-only fast path in the non-subwarp-shuffle forward dispatch
macro for the unweighted, non-dense, non-SSD, non-GWD VBE case. When
<emb=at::Half, cache=at::Half, output=float, index=int64_t> (with !use_cache_t)
and MAX_D <= 128, route to kThreadGroupSize=32 (two half-wave groups),
kFixedMaxVecsPerThread=1, kUseVecBlocking=false. Halving the group doubles the
fraction of useful lanes. MAX_D<=128 is the largest dim still covered by 1
vec/thread at 32 lanes (32*4).

The matching explicit instantiation
<at::Half,at::Half,float,int64_t,use_cache=false,1,32> is emitted in
embedding_forward_split_kernel_template.cu behind the same guard, in the #else
(non-subwarp-shuffle) branch so it does not collide with the CUDA <...,1,32>
instantiation.

Both edits are gated on `is_rocm and vbe and not dense and not ssd and not
weighted and not is_gwd`; non-ROCm builds and all other TBE variants are
unchanged.

Reviewed By: spcyppt

Differential Revision: D117212171


