### PR TITLE
Fix GenAI ROCm build

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/bf16_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/bf16_grouped_gemm.hip
@@ -217,11 +217,11 @@ void set_static_kernel_args(
       ggemm_kargs.push_back(group_args);
     }
     // Copy data onto device.
-    hipMemcpy(
+    C10_CUDA_CHECK(hipMemcpy(
         kernel_args.data_ptr(), // Destination
         ggemm_kargs.data(), // Source
         sizeof(KernelArguments) * group_count, // Number of bytes
-        hipMemcpyHostToDevice); // Copy Type
+        hipMemcpyHostToDevice)); // Copy Type
   } else {
     // Launch a kernel for each group to set kernel memory on device.
     // Using multiple kernels this way allows us to support arbitrary M,N,K.


### PR DESCRIPTION
Wrap hipMemcpy with C10_CUDA_CHECK so `[[nodiscard]]` return value is not discarded