### PR TITLE
Fix release Nova CUDA runner override; use g5.12xlarge, not r5.12xlarge

### DIFF
--- a/.github/workflows/build_wheels_genai_linux_x86.yml
+++ b/.github/workflows/build_wheels_genai_linux_x86.yml
@@ -62,12 +62,13 @@ jobs:
       #
       # Nova Runner Overrides (release pipeline only):
       # cuda: see build_wheels_linux_x86.yml - the Nova default
-      #   linux.g5.4xlarge.nvidia.gpu is FBGEMM's CUDA *test* machine (8 cores,
-      #   64 GB, and a GPU the build container cannot even see).  RC/final tag
-      #   pushes build on linux.12xlarge.memory instead, which is exactly what
-      #   `generate_ci_matrix.py` `host_machines()` already selects for the
-      #   GenAI CUDA build in-repo.  The general Nova CI - nightly, main, PRs
-      #   and manual dispatch - is left on the Nova default runner.
+      #   linux.g5.4xlarge.nvidia.gpu is FBGEMM's CUDA *test* machine, only 8
+      #   physical cores and 64 GB.  RC/final tag pushes build on
+      #   linux.g5.12xlarge.nvidia.gpu instead: 24 cores and 192 GB, same g5
+      #   family so test-infra's unconditional `--gpus all` for cuda rows is
+      #   still satisfied.  A CPU-only runner is not an option here even
+      #   though the build never uses the GPU.  The general Nova CI - nightly,
+      #   main, PRs and manual dispatch - is left on the Nova default runner.
       run: |
         set -ex
         pwd
@@ -75,7 +76,7 @@ jobs:
 
         runner_args=()
         if [[ "${GITHUB_EVENT_NAME}" == push && "${GITHUB_REF}" == refs/tags/v* ]]; then
-          runner_args=(--runner 'gpu_arch_type:cuda=linux.12xlarge.memory')
+          runner_args=(--runner 'gpu_arch_type:cuda=linux.g5.12xlarge.nvidia.gpu')
         fi
 
         MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter gpu_arch_version:11.8 --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2,13.4' --filter 'gpu_arch_type:rocm;gpu_arch_version:7.14' "${runner_args[@]}" )"

--- a/.github/workflows/build_wheels_linux_x86.yml
+++ b/.github/workflows/build_wheels_linux_x86.yml
@@ -60,19 +60,26 @@ jobs:
       # cuda: the Nova default is linux.g5.4xlarge.nvidia.gpu, which is
       #   FBGEMM's *test* machine, not its build machine.  In-repo,
       #   `.github/scripts/generate_ci_matrix.py` `host_machines()` reserves
-      #   that label for the CUDA test job - where the GPU is real - and builds
-      #   CUDA on linux.24xlarge / linux.12xlarge.memory / linux.24xlarge.memory
-      #   depending on target.  Nova collapses build and test into one job and
-      #   gets the test box for both, and the GPU is not even visible there
-      #   (the container reports torch.cuda.is_available() == False, so the
-      #   post-build suite runs CPU-only regardless).
+      #   that label for the CUDA test job and builds CUDA on much larger
+      #   hosts (linux.24xlarge / linux.12xlarge.memory / linux.24xlarge.memory
+      #   depending on target).  Nova collapses build and test into one job, so
+      #   the CUDA wheel gets built on the small test box: 8 physical cores and
+      #   64 GB, for a build that runs well over an hour.
       #
-      #   linux.12xlarge.memory (r5.12xlarge) is a strict improvement on every
-      #   axis that matters here vs g5.4xlarge: 24 physical cores vs 8, 384 GB
-      #   vs 64, 600 GB disk vs 150.  Cores are what count - `-j` is derived
-      #   from `lscpu` cores x sockets, not vCPUs, so it is 8 today and would
-      #   stay 8 on any other 4xlarge.  It is also the machine the GenAI CUDA
-      #   build already uses in-repo, so the capacity is established.
+      #   The replacement has to stay on a *.nvidia.gpu label.  test-infra's
+      #   build_wheels_linux.yml runs the job container with `--gpus all` for
+      #   every gpu_arch_type == cuda row, so a CPU-only runner cannot start
+      #   the container at all ("could not select device driver") - regardless
+      #   of the fact that the build itself never touches the GPU, and that
+      #   the container reports torch.cuda.is_available() == False even on the
+      #   default runner.
+      #
+      #   linux.g5.12xlarge.nvidia.gpu (g5.12xlarge) is the same instance
+      #   family and AMI as the default, so `--gpus all` is satisfied, but with
+      #   24 physical cores instead of 8 and 192 GB instead of 64.  Cores are
+      #   what count - `-j` is derived from `lscpu` cores x sockets, not vCPUs,
+      #   so this triples build parallelism.  Disk is 150 GB either way, which
+      #   the current build already fits inside.
       #
       #   Scoped to RC/final tag pushes, i.e. the release pipeline only.  The
       #   general Nova CI - nightly, main, PRs and manual dispatch - is left on
@@ -84,7 +91,7 @@ jobs:
 
         runner_args=()
         if [[ "${GITHUB_EVENT_NAME}" == push && "${GITHUB_REF}" == refs/tags/v* ]]; then
-          runner_args=(--runner 'gpu_arch_type:cuda=linux.12xlarge.memory')
+          runner_args=(--runner 'gpu_arch_type:cuda=linux.g5.12xlarge.nvidia.gpu')
         fi
 
         MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' --filter 'gpu_arch_version:13.2,13.4' "${runner_args[@]}" )"


### PR DESCRIPTION
Summary:
D119373417 pointed the release-pipeline CUDA wheel builds at
`linux.12xlarge.memory`. That runner has no GPU, and it breaks the job
outright.

test-infra's `build_wheels_linux.yml` runs the job container with

  options: ${{ matrix.gpu_arch_type == 'cuda' && '--gpus all -e
            NVIDIA_DRIVER_CAPABILITIES=compute,utility,video' || ' ' }}

so every `gpu_arch_type == cuda` row gets `--gpus all` unconditionally.
On an r5.12xlarge there is no NVIDIA device driver, so Docker cannot
start the container and the job dies before the build begins. Observed
on v1.9.0-rc1.

The earlier reasoning was that the GPU is irrelevant to the build - the
container reports `torch.cuda.is_available() == False` even on the
default runner, so the post-build suite runs CPU-only either way. That
part is still true, but it does not follow that a CPU-only host works:
`--gpus all` is keyed off the arch of the wheel being built, not off
whether anything uses the GPU. Any CUDA row must be on a `*.nvidia.gpu`
label.

Switches the override to `linux.g5.12xlarge.nvidia.gpu`, keeping the
original intent - the Nova default `linux.g5.4xlarge.nvidia.gpu` is
FBGEMM's CUDA *test* machine, and Nova collapses build and test into one
job, so the release wheel is built on 8 physical cores and 64 GB:

  g5.4xlarge    8 cores   64 GB   150 GB disk   (default)
  g5.12xlarge  24 cores  192 GB   150 GB disk   (this diff)

Same g5 family and AMI, so `--gpus all` is satisfied. `-j` comes from
`lscpu` cores x sockets rather than vCPUs, so parallelism goes 8 -> 24.
Disk is unchanged and was never the constraint.

Still scoped to RC/final tag pushes. Nightly, main, PRs and manual
dispatch keep the Nova default runner. Comments in both workflows are
updated to record why a CPU-only runner is not an option.

Differential Revision: D119535652


