### PR TITLE
Account for X/Z blocks in grid-Y caps

### DIFF
--- a/fbgemm_gpu/src/quantize_ops/quantize_fp8_rowwise.cu
+++ b/fbgemm_gpu/src/quantize_ops/quantize_fp8_rowwise.cu
@@ -313,9 +313,10 @@ Tensor _float_to_FP8rowwise_gpu_t(const Tensor& input, const bool forward) {
           std::min(ncols, static_cast<int64_t>(threads_per_block));
       dim3 blockDim(blockDim_x, threads_per_block / blockDim_x);
       const auto gridDim_x = cuda_calc_xblock_count(ncols, blockDim.x);
-      const auto gridDim_y = utils::cuda::cap_grid_dim_x(
+      const auto gridDim_y = utils::cuda::cap_grid_dim_y_with_xz_blocks(
           cuda_calc_block_count(nrows, blockDim.y),
-          static_cast<int64_t>(gridDim_x) * threads_per_block,
+          threads_per_block,
+          static_cast<int64_t>(gridDim_x),
           at::cuda::getCurrentCUDAStream());
       dim3 gridDim(gridDim_x, gridDim_y);
 
@@ -407,9 +408,10 @@ Tensor _FP8rowwise_to_float_gpu_t(
   const dim3 blockDim(blockDim_x, threads_per_block / blockDim_x);
 
   const auto gridDim_x = cuda_calc_xblock_count(output_columns, blockDim.x);
-  const auto gridDim_y = utils::cuda::cap_grid_dim_x(
+  const auto gridDim_y = utils::cuda::cap_grid_dim_y_with_xz_blocks(
       cuda_calc_block_count(nrows, blockDim.y),
-      static_cast<int64_t>(gridDim_x) * threads_per_block,
+      threads_per_block,
+      static_cast<int64_t>(gridDim_x),
       at::cuda::getCurrentCUDAStream());
   const dim3 gridDim(gridDim_x, gridDim_y);
 

--- a/fbgemm_gpu/src/quantize_ops/quantize_fused_8bit_rowwise.cu
+++ b/fbgemm_gpu/src/quantize_ops/quantize_fused_8bit_rowwise.cu
@@ -359,10 +359,12 @@ Tensor _float_to_fused8bitrowwise_gpu_t(const Tensor& input) {
       const auto gridDim_x = cuda_calc_xblock_count(ncols, blockDim.x);
       // Cap grid.y so total threads (gridDim.x * gridDim.y * threads_per_block)
       // stay under the HIP 2^32 limit; the kernel grid-strides over rows.
-      // OverflowOnly => no-op on CUDA.
-      const auto gridDim_y = utils::cuda::cap_grid_dim_x(
+      // OverflowOnly skips the total-thread cap on CUDA, while the helper still
+      // enforces CUDA's grid.y driver limit.
+      const auto gridDim_y = utils::cuda::cap_grid_dim_y_with_xz_blocks(
           cuda_calc_block_count(nrows, blockDim.y),
-          static_cast<int64_t>(gridDim_x) * threads_per_block,
+          threads_per_block,
+          static_cast<int64_t>(gridDim_x),
           at::cuda::getCurrentCUDAStream());
       dim3 gridDim(gridDim_x, gridDim_y);
 
@@ -487,10 +489,12 @@ Tensor _fused8bitrowwise_to_float_gpu_t(
   const auto gridDim_x = cuda_calc_xblock_count(output_columns, blockDim.x);
   // Cap grid.y so total threads (gridDim.x * gridDim.y * threads_per_block)
   // stay under the HIP 2^32 limit; the kernel grid-strides over rows.
-  // OverflowOnly => no-op on CUDA.
-  const auto gridDim_y = utils::cuda::cap_grid_dim_x(
+  // OverflowOnly skips the total-thread cap on CUDA, while the helper still
+  // enforces CUDA's grid.y driver limit.
+  const auto gridDim_y = utils::cuda::cap_grid_dim_y_with_xz_blocks(
       cuda_calc_block_count(nrows, blockDim.y),
-      static_cast<int64_t>(gridDim_x) * threads_per_block,
+      threads_per_block,
+      static_cast<int64_t>(gridDim_x),
       at::cuda::getCurrentCUDAStream());
   const dim3 gridDim(gridDim_x, gridDim_y);
 

--- a/fbgemm_gpu/src/quantize_ops/quantize_fused_nbit_rowwise.cu
+++ b/fbgemm_gpu/src/quantize_ops/quantize_fused_nbit_rowwise.cu
@@ -270,9 +270,10 @@ Tensor _fusednbitrowwise_to_float_gpu_t(
   const int blockDim_x = std::min(output_columns, threads_per_block);
   const dim3 blockDim(blockDim_x, threads_per_block / blockDim_x);
   const auto gridDim_x = cuda_calc_xblock_count(output_columns, blockDim.x);
-  const auto gridDim_y = utils::cuda::cap_grid_dim_x(
+  const auto gridDim_y = utils::cuda::cap_grid_dim_y_with_xz_blocks(
       cuda_calc_block_count(nrows, blockDim.y),
-      static_cast<int64_t>(gridDim_x) * threads_per_block,
+      threads_per_block,
+      static_cast<int64_t>(gridDim_x),
       at::cuda::getCurrentCUDAStream());
   const dim3 gridDim(gridDim_x, gridDim_y);
 


### PR DESCRIPTION
Summary:
NOTE: No linked task. Please associate a task with this diff.

Migrate rowwise quantization launches to cap `grid.y` with the Y-specific helper. Pass `threads_per_block` and the unchanged X/Z plane separately; kernels keep X/Z unchanged and grid-stride over rows.

Document that `OverflowOnly` skips the total-thread cap on CUDA while the helper still enforces the CUDA grid-y driver limit.

Reviewed By: jianyuh

Differential Revision: D116806924


