### PR TITLE
Cap remaining block-bucketize launches (#6292)

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features.cu
@@ -136,7 +136,7 @@ __launch_bounds__(kMaxThreads) void _block_bucketize_sparse_features_cuda_kernel
             : (idx % global_num_blks) / local_num_blks;
         atomicAdd(&new_lengths_data[p * lengths_size + b_t], 1);
       }
-      return;
+      continue;
     }
 
     const index_t bucketize_max_idx = (t + 1) * (my_size + 1) - 1;

--- a/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features_2d_weights.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features_2d_weights.cu
@@ -79,7 +79,11 @@ void adjust_block_bucketize_sparse_features_2d_weights_kernel_launch_configs_bas
       block_dims->y > 0,
       "block_bucketize_sparse_features_2d_weights does not have sufficient shared memory."
       "Please contact the FBGEMM team.")
-  grid_dims->x = cuda_calc_xblock_count(lengths_size, block_dims->y);
+  grid_dims->x = utils::cuda::cap_grid_dim_x(
+      cuda_calc_xblock_count(lengths_size, block_dims->y),
+      static_cast<int64_t>(block_dims->x) * block_dims->y,
+      at::cuda::getCurrentCUDAStream(),
+      utils::cuda::BlockCapPolicy::OverflowOnly);
 }
 
 // Kernel for bucketize lengths, with the Block distribution (vs. cyclic,
@@ -131,7 +135,7 @@ __launch_bounds__(kMaxThreads) void _block_bucketize_sparse_features_cuda_kernel
             : (idx % global_num_blks) / local_num_blks;
         atomicAdd(&new_lengths_data[p * lengths_size + b_t], 1);
       }
-      return;
+      continue;
     }
 
     const index_t bucketize_max_idx = (t + 1) * (my_size + 1) - 1;
@@ -658,7 +662,10 @@ _block_bucketize_sparse_features_2d_weights_cuda(
     // is correctness-preserving (the loop iterates over all work items).
     // See: https://github.com/ROCm/hip/issues/2253
     const auto num_blocks = utils::cuda::cap_grid_dim_x_from_workload(
-        max_B * T, threads_per_block, at::cuda::getCurrentCUDAStream());
+        max_B * T,
+        threads_per_block,
+        at::cuda::getCurrentCUDAStream(),
+        utils::cuda::BlockCapPolicy::OverflowOnly);
 
     AT_DISPATCH_INDEX_TYPES(
         offsets_contig.scalar_type(),
@@ -703,7 +710,12 @@ _block_bucketize_sparse_features_2d_weights_cuda(
   }
   static_assert(kMaxThreads % kWarpSize == 0);
   dim3 block_dims(kWarpSizeHost(), kMaxThreads / kWarpSizeHost());
-  dim3 grid_dims(cuda_calc_xblock_count(lengths_size, block_dims.y));
+  dim3 grid_dims(
+      utils::cuda::cap_grid_dim_x(
+          cuda_calc_xblock_count(lengths_size, block_dims.y),
+          static_cast<int64_t>(block_dims.x) * block_dims.y,
+          at::cuda::getCurrentCUDAStream(),
+          utils::cuda::BlockCapPolicy::OverflowOnly));
   const auto smem_adjust_threshold =
       at::cuda::getCurrentDeviceProperties()->sharedMemPerBlock;
   AT_DISPATCH_INDEX_TYPES(
@@ -746,8 +758,11 @@ _block_bucketize_sparse_features_2d_weights_cuda(
             });
       });
   constexpr auto threads_per_block = 256;
-  const auto num_blocks =
-      cuda_calc_xblock_count(lengths_size, threads_per_block);
+  const auto num_blocks = utils::cuda::cap_grid_dim_x_from_workload(
+      lengths_size,
+      threads_per_block,
+      at::cuda::getCurrentCUDAStream(),
+      utils::cuda::BlockCapPolicy::OverflowOnly);
   // bucketize nonzeros
   new_offsets = asynchronous_exclusive_cumsum_gpu(new_lengths);
   if (sequence) {

--- a/fbgemm_gpu/test/sparse/block_bucketize_cap_amd_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_cap_amd_test.py
@@ -1,0 +1,77 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+import fbgemm_gpu  # noqa: F401
+import torch
+
+
+class BlockBucketizeCapAmdTest(unittest.TestCase):
+    def test_default_path_covers_tail_after_grid_cap(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("No GPU available")
+
+        device = torch.accelerator.current_accelerator()
+        lengths_size = 1 << 27
+        sentinel_rows = torch.tensor(
+            [0, lengths_size // 2, lengths_size - 1], device=device
+        )
+        lengths = torch.zeros(lengths_size, dtype=torch.int, device=device)
+        lengths[sentinel_rows] = 1
+        indices = torch.tensor([0, 1, 2], dtype=torch.int, device=device)
+        block_sizes = torch.tensor([4], dtype=torch.int, device=device)
+
+        new_lengths, *_ = torch.ops.fbgemm.block_bucketize_sparse_features(
+            lengths,
+            indices,
+            False,
+            False,
+            block_sizes,
+            1,
+        )
+
+        torch.testing.assert_close(
+            new_lengths[sentinel_rows],
+            torch.ones(3, dtype=torch.int, device=device),
+            rtol=0,
+            atol=0,
+        )
+
+    def test_2d_weights_default_path_covers_tail_after_grid_cap(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("No GPU available")
+
+        device = torch.accelerator.current_accelerator()
+        lengths_size = 1 << 27
+        sentinel_rows = torch.tensor(
+            [0, lengths_size // 2, lengths_size - 1], device=device
+        )
+        lengths = torch.zeros(lengths_size, dtype=torch.int, device=device)
+        lengths[sentinel_rows] = 1
+        indices = torch.tensor([0, 1, 2], dtype=torch.int, device=device)
+        block_sizes = torch.tensor([4], dtype=torch.int, device=device)
+        weights = torch.tensor([[1.0], [2.0], [3.0]], device=device)
+
+        new_lengths, *_ = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+            lengths,
+            indices,
+            False,
+            False,
+            block_sizes,
+            1,
+            weights,
+            1,
+        )
+
+        torch.testing.assert_close(
+            new_lengths[sentinel_rows],
+            torch.ones(3, dtype=torch.int, device=device),
+            rtol=0,
+            atol=0,
+        )


### PR DESCRIPTION
Summary:

NOTE: No linked task. Please associate a task with this diff.

Cap the remaining one-dimensional block-bucketize launches on ROCm. Keep the two-dimensional thread-block size as `threads_per_block`.

Change capped-loop early exits from `return` to `continue` so head, middle, and tail rows remain covered.

Reviewed By: jianyuh

Differential Revision: D116013308


