### PR TITLE
Avoid FP32 scratch allocation in FP16 communication

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/config/feature_list.py
+++ b/fbgemm_gpu/fbgemm_gpu/config/feature_list.py
@@ -75,6 +75,9 @@ class FeatureGateName(Enum):
     # Gate the bounds_check_indices offsets-adjustment assertions
     DISABLE_OFFSETS_ADJUSTMENT = auto()
 
+    # Gate the in-place FP16 clamp fast path in fp32_to_fp16_with_clamp
+    FP16_COMM_INPLACE_CLAMP = auto()
+
     def is_enabled(self) -> bool:
         return FeatureGate.is_enabled(self)
 

--- a/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
@@ -12,6 +12,7 @@ import logging
 import torch  # isort:skip
 
 import fbgemm_gpu
+from fbgemm_gpu.config import FeatureGate, FeatureGateName
 from fbgemm_gpu.split_embedding_configs import SparseType
 from fbgemm_gpu.triton.common import RoundingMode
 from fbgemm_gpu.triton.quantize_ref import py_dequantize_mx4, py_quantize_mx4
@@ -209,7 +210,23 @@ def mx4_to_float(
         )
 
 
+@torch.compiler.assume_constant_result
+def _fp16_comm_inplace_clamp_enabled() -> bool:
+    # The C++ feature gate cache is fixed for the lifetime of the process.
+    return FeatureGate.is_enabled(FeatureGateName.FP16_COMM_INPLACE_CLAMP)
+
+
 def fp32_to_fp16_with_clamp(tensor: torch.Tensor) -> torch.Tensor:
+    if (
+        not torch.is_grad_enabled()
+        and isinstance(tensor, torch.Tensor)
+        and tensor.dtype == torch.float32
+        and _fp16_comm_inplace_clamp_enabled()
+    ):
+        # Keep the temporary in FP16; autograd requires the original clamp order.
+        return tensor.to(torch.float16, copy=True).clamp_(
+            TORCH_HALF_MIN, TORCH_HALF_MAX
+        )
     return torch.clamp(tensor, TORCH_HALF_MIN, TORCH_HALF_MAX).half()
 
 

--- a/fbgemm_gpu/test/quantize/comm_codec_test.py
+++ b/fbgemm_gpu/test/quantize/comm_codec_test.py
@@ -8,12 +8,131 @@
 # pyre-strict
 
 import unittest
+from unittest.mock import patch
 
 import hypothesis.strategies as st
 import torch
 from fbgemm_gpu.quantize_comm import none_throws, QuantizedCommCodec
+from fbgemm_gpu.quantize_utils import fp32_to_fp16_with_clamp
 from fbgemm_gpu.split_embedding_configs import SparseType
 from hypothesis import assume, given, settings
+from parameterized import parameterized
+
+
+class FP16ClampTest(unittest.TestCase):
+    def test_compiled_no_grad(self) -> None:
+        values = torch.tensor(
+            [-1e30, -65504.01, -1, 0, 1, 65504.01, 1e30],
+            dtype=torch.float32,
+            device="cpu",
+        )
+        compiled = torch.compile(
+            fp32_to_fp16_with_clamp, backend="eager", fullgraph=True
+        )
+        with torch.no_grad():
+            output = compiled(values)
+            expected = values.clamp(-65504, 65504).half()
+        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+    @parameterized.expand(
+        [("cpu", False), ("cpu", True), ("cuda", False), ("cuda", True)]
+    )
+    def test_values_and_input_preservation(self, device: str, enabled: bool) -> None:
+        if device == "cuda" and not torch.cuda.is_available():
+            self.skipTest("CUDA is unavailable")
+        # Citrine C3: construct inputs directly on the device under test.
+        values = (
+            torch.tensor(
+                [
+                    -float("inf"),
+                    -1e30,
+                    -65520,
+                    -65504.01,
+                    -65504,
+                    -65503.99,
+                    -1,
+                    -(2**-24),
+                    -(2**-25),
+                    -0.0,
+                    0.0,
+                    2**-25,
+                    2**-24,
+                    1,
+                    65503.99,
+                    65504,
+                    65504.01,
+                    65520,
+                    1e30,
+                    float("inf"),
+                    float("nan"),
+                ],
+                dtype=torch.float32,
+                device=device,
+            )
+            .repeat(3, 1)
+            .t()
+        )
+        before = values.clone()
+        with (
+            patch("torch.ops.fbgemm.check_feature_gate_key", return_value=enabled),
+            torch.no_grad(),
+        ):
+            output = fp32_to_fp16_with_clamp(values)
+            expected = values.clamp(-65504, 65504).half()
+        torch.testing.assert_close(output, expected, rtol=0, atol=0, equal_nan=True)
+        torch.testing.assert_close(values, before, rtol=0, atol=0, equal_nan=True)
+        self.assertNotEqual(output.data_ptr(), values.data_ptr())
+        zero = expected == 0
+        self.assertTrue(
+            torch.equal(torch.signbit(output[zero]), torch.signbit(expected[zero]))
+        )
+
+    @parameterized.expand(
+        [("cpu", False), ("cpu", True), ("cuda", False), ("cuda", True)]
+    )
+    def test_preserves_clamp_gradients(self, device: str, enabled: bool) -> None:
+        if device == "cuda" and not torch.cuda.is_available():
+            self.skipTest("CUDA is unavailable")
+        values = torch.tensor(
+            [-65504.01, -65504, -1, 0, 1, 65504, 65504.01],
+            dtype=torch.float32,
+            device=device,
+            requires_grad=True,
+        )
+        reference = values.detach().clone().requires_grad_()
+        with patch("torch.ops.fbgemm.check_feature_gate_key", return_value=enabled):
+            output = fp32_to_fp16_with_clamp(values)
+        expected = reference.clamp(-65504, 65504).half()
+        output.backward(torch.ones_like(output))
+        expected.backward(torch.ones_like(expected))
+        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+        torch.testing.assert_close(values.grad, reference.grad, rtol=0, atol=0)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
+    def test_no_grad_avoids_fp32_temporary(self) -> None:
+        values = torch.ones(
+            128 * 1024 * 1024,
+            device=torch.accelerator.current_accelerator(),
+            dtype=torch.float32,
+        )
+        with torch.no_grad():
+            torch.cuda.synchronize()
+            baseline = torch.cuda.memory_allocated()
+            torch.cuda.reset_peak_memory_stats()
+            with patch("torch.ops.fbgemm.check_feature_gate_key", return_value=False):
+                reference = fp32_to_fp16_with_clamp(values)
+            torch.cuda.synchronize()
+            reference_peak = torch.cuda.max_memory_allocated() - baseline
+            del reference
+            torch.cuda.synchronize()
+            baseline = torch.cuda.memory_allocated()
+            torch.cuda.reset_peak_memory_stats()
+            with patch("torch.ops.fbgemm.check_feature_gate_key", return_value=True):
+                output = fp32_to_fp16_with_clamp(values)
+            torch.cuda.synchronize()
+            candidate_peak = torch.cuda.max_memory_allocated() - baseline
+        self.assertEqual(output.dtype, torch.float16)
+        self.assertGreaterEqual(reference_peak - candidate_peak, values.nbytes * 0.9)
 
 
 class QuantizedCommCodecTest(unittest.TestCase):


### PR DESCRIPTION
Summary:
The FP16 communication conversion creates an extra full-size FP32 copy, which can cause out-of-memory errors for large tensors.

With the rollout flag enabled, convert to FP16 first and clamp in place to avoid that copy. Embeddings remain trainable through the existing custom backward pass.

Keep the flag lookup compatible with compilation and test both flag settings.

Differential Revision: D119536338


