### PR TITLE
Enable -Wunused-variable on the CPU build

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -17,7 +17,6 @@ def default_compiler_flags():
             "-Wno-gnu-zero-variadic-macro-arguments",
             "-Wno-c99-extensions",
             "-Wno-unused-parameter",
-            "-Wno-unused-variable",
             "-Wimplicit-fallthrough",
             "-Wignored-qualifiers",
             "-Wno-vla",

--- a/src/EmbeddingSpMDMAutovec.cc
+++ b/src/EmbeddingSpMDMAutovec.cc
@@ -172,7 +172,8 @@ static bool ALWAYS_INLINE EmbeddingSpMDM8Bit_autovec(
   const int64_t prefetch_stride =
       std::min(MAX_INITIAL_PREFETCH_ROWS, index_size);
   for (int64_t pf_idx = 0; pf_idx < prefetch_stride; ++pf_idx) {
-    const uint8_t* prefetch_addr = input + input_stride * indices[pf_idx];
+    [[maybe_unused]] const uint8_t* prefetch_addr =
+        input + input_stride * indices[pf_idx];
     for (int64_t offset = 0; offset < input_stride; offset += CACHE_LINE_SIZE) {
       do_prefetch(prefetch_addr + offset, 0, 0);
     }
@@ -280,7 +281,8 @@ static bool ALWAYS_INLINE EmbeddingSpMDM8Bit_autovec(
 
       IndexType prefetch_idx =
           indices[std::min(current + prefetch_stride, index_size - 1)];
-      const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
+      [[maybe_unused]] const uint8_t* prefetch_addr =
+          input + input_stride * prefetch_idx;
       for (int64_t offset = 0; offset < input_stride;
            offset += CACHE_LINE_SIZE) {
         do_prefetch(prefetch_addr + offset, 1);
@@ -588,7 +590,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
             data_size,
             l1_prefetch_distance);
       } else if (l1_distance == -1) {
-        const int64_t prefetch_idx =
+        [[maybe_unused]] const int64_t prefetch_idx =
             indices[std::min(current + l1_prefetch_distance, last_index)];
         // Prefetch of an out-of-range address is a harmless no-op, so the
         // default path issues it unconditionally (matching the
@@ -903,8 +905,9 @@ static bool ALWAYS_INLINE EmbeddingSpMDM_autovec(
   // input_stride being greater or not greater than cache line size will make
   // the branch predictor work better. Same for line 113-126.
   for (int pf_idx = 0; pf_idx < prefetch_stride; ++pf_idx) {
-    const uint8_t* prefetch_addr = reinterpret_cast<const uint8_t*>(
-        input + input_stride * indices[pf_idx]);
+    [[maybe_unused]] const uint8_t* prefetch_addr =
+        reinterpret_cast<const uint8_t*>(
+            input + input_stride * indices[pf_idx]);
     for (int64_t offset = 0; offset < input_stride; offset += CACHE_LINE_SIZE) {
       do_prefetch(prefetch_addr + offset, 0, 0);
     }
@@ -942,7 +945,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDM_autovec(
         return false;
       }
 
-      int64_t prefetch_idx =
+      [[maybe_unused]] int64_t prefetch_idx =
           indices[std::min(current + prefetch_stride, index_size - 1)];
 
       do_prefetch(
@@ -1277,7 +1280,8 @@ static bool ALWAYS_INLINE EmbeddingSpMDMFP8_autovec(
   // greater or not greater than cache line size will make the branch predictor
   // work better. Same for line 113-126.
   for (int pf_idx = 0; pf_idx < prefetch_stride; ++pf_idx) {
-    const uint8_t* prefetch_addr = input + input_stride * indices[pf_idx];
+    [[maybe_unused]] const uint8_t* prefetch_addr =
+        input + input_stride * indices[pf_idx];
     for (int64_t offset = 0; offset < input_stride; offset += CACHE_LINE_SIZE) {
       do_prefetch(prefetch_addr + offset, 0, 0);
     }
@@ -1320,7 +1324,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDMFP8_autovec(
         return false;
       }
 
-      int64_t prefetch_idx =
+      [[maybe_unused]] int64_t prefetch_idx =
           indices[std::min(current + prefetch_stride, index_size - 1)];
 
       do_prefetch(

--- a/test/EmbeddingSpMDMTest.cc
+++ b/test/EmbeddingSpMDMTest.cc
@@ -455,8 +455,8 @@ TEST_P(EmbeddingSpMDMTest, noBagUint8Test) {
       GetParam();
   ScopedKernelOverride kernel_override(kernel_choice);
 
-  // Fix the input and output types to be uint8_t
-  const auto in_type = QINT8, out_type = QINT8;
+  // This test always uses uint8_t input and output, so the parameterised
+  // input/output types are discarded as `_tmp1` and `_tmp2` above.
 
   // Skip corner cases for this focused test
   if (corner_case != NONE) {


### PR DESCRIPTION
Summary:
`defs.bzl` carries `-Wno-unused-variable`. The flag is one of the 44 warnings
that fbcode enables for all clang compilation, so this line turned off a
warning that the rest of fbcode gets. The OSS CMake build enables it. This
change removes the line, so the internal CPU build matches both.

One site needs a correction first. `EmbeddingSpMDMTest.cc:459` declares:

  const auto in_type = QINT8, out_type = QINT8;

Neither name is read. The test `noBagUint8Test` always uses uint8_t, and it
already discards the parameterised types as `_tmp1` and `_tmp2` on line 454.
The declaration restated that intent and then went unused. This change removes
it and keeps a comment that gives the reason for the two discards.

The names `in_type` and `out_type` stay in use at line 127, in a different
test, where they come from `GetParam()` and are read on lines 132-135.

Measurement, with a build of `fbcode//deeplearning/fbgemm:`

  before : 1896 actions, 2 errors, both on line 459
  after  : 0 errors, 0 warnings, build passes

A first measurement of the single `:fbgemm` target reported zero, which was
wrong. That target does not contain the test. The count above comes from the
whole package.

Differential Revision: D119588907


