### PR TITLE
Add INT4 no-bag stride diagnostics

### DIFF
--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "./Assert.h" // @manual
 #include "./FbgemmBuild.h" // @manual
 #include "./UtilsAvx2.h" // @manual
 
@@ -434,36 +435,10 @@ FBGEMM_API void set_autovec_disabled(bool val);
 FBGEMM_API void set_autovec_forced(bool val);
 FBGEMM_API void set_asmjit_disabled(bool val);
 
-#define WARN_ONCE(...)              \
-  do {                              \
-    static bool _warned = false;    \
-    if (!_warned) {                 \
-      _warned = true;               \
-      fprintf(stderr, __VA_ARGS__); \
-    }                               \
-  } while (0)
-
 constexpr int64_t nbit_embedding_int4_row_size_in_bytes(
     const int64_t block_size) {
   constexpr int64_t kScaleBiasSize = 2 * sizeof(uint16_t);
   return (block_size + 1) / 2 + kScaleBiasSize;
-}
-
-inline bool nbit_embedding_int4_validate_strides(
-    const int64_t block_size,
-    const int64_t input_stride,
-    const int64_t output_stride) {
-  const auto row_size = nbit_embedding_int4_row_size_in_bytes(block_size);
-  if (input_stride >= row_size && output_stride >= row_size) {
-    return true;
-  }
-  WARN_ONCE(
-      "no_bag strides must be at least the packed INT4 row size: "
-      "input_stride=%ld output_stride=%ld packed_row_size=%ld\n",
-      static_cast<long>(input_stride),
-      static_cast<long>(output_stride),
-      static_cast<long>(row_size));
-  return false;
 }
 
 /**
@@ -472,24 +447,98 @@ inline bool nbit_embedding_int4_validate_strides(
  */
 template <typename OutType>
 void nbit_embedding_sanity_check(
-    // assertions are ignored in release mode, in which case these parameters
-    // will be unused
-    const int input_bit_rate [[maybe_unused]],
-    const int output_bit_rate [[maybe_unused]],
-    const bool no_bag [[maybe_unused]]) {
-  assert(
-      (input_bit_rate == 2 || input_bit_rate == 4) &&
-      "input_bit_rate must be 2 or 4");
+    const int input_bit_rate,
+    const int output_bit_rate,
+    const bool no_bag) {
+  FBGEMM_CHECK(
+      input_bit_rate == 2 || input_bit_rate == 4,
+      "N-bit embedding input_bit_rate must be 2 or 4, got ",
+      input_bit_rate);
+  if (no_bag) {
+    FBGEMM_CHECK(
+        input_bit_rate == 4 && output_bit_rate == 4,
+        "N-bit no-bag mode requires INT4 input and output, got input_bit_rate=",
+        input_bit_rate,
+        ", output_bit_rate=",
+        output_bit_rate);
+  }
   // NOLINTNEXTLINE(bugprone-branch-clone)
   if constexpr (std::is_same_v<OutType, uint8_t>) {
-    assert(
-        (no_bag && input_bit_rate == 4 && output_bit_rate == 4) &&
-        "we currently only support int4 to int4 for sequential TBE");
+    FBGEMM_CHECK(
+        no_bag,
+        "uint8_t N-bit output requires no-bag mode, got no_bag=",
+        no_bag,
+        ", input_bit_rate=",
+        input_bit_rate);
   } else {
-    assert(
-        (output_bit_rate == 8 * sizeof(OutType)) &&
-        "output_bit_rate should be equal to 8 * sizeof(OutType)");
+    FBGEMM_CHECK(
+        output_bit_rate == 8 * sizeof(OutType),
+        "N-bit embedding output_bit_rate must match OutType width, got ",
+        output_bit_rate,
+        " bits for sizeof(OutType)=",
+        sizeof(OutType));
   }
 }
+
+template <typename IndexType, typename OutType>
+int64_t nbit_embedding_no_bag_copy_size(
+    const int64_t block_size,
+    const int64_t output_size,
+    const int64_t index_size,
+    const int64_t output_stride,
+    const int64_t input_stride,
+    const uint8_t* input,
+    const IndexType* indices,
+    OutType* out) {
+  FBGEMM_CHECK(
+      block_size > 0,
+      "INT4 no-bag block_size must be positive, got ",
+      block_size);
+  FBGEMM_CHECK(
+      output_size >= 0,
+      "INT4 no-bag output_size must be non-negative, got ",
+      output_size);
+  FBGEMM_CHECK(
+      index_size == output_size,
+      "INT4 no-bag requires one output row per index, got output_size=",
+      output_size,
+      ", index_size=",
+      index_size);
+  const int64_t packed_row_size =
+      nbit_embedding_int4_row_size_in_bytes(block_size);
+  FBGEMM_CHECK(
+      input_stride >= packed_row_size,
+      "INT4 no-bag input_stride is smaller than the packed row, got input_stride=",
+      input_stride,
+      ", packed_row_size=",
+      packed_row_size,
+      ", block_size=",
+      block_size);
+  FBGEMM_CHECK(
+      output_stride >= packed_row_size,
+      "INT4 no-bag output_stride is smaller than the packed row, got output_stride=",
+      output_stride,
+      ", packed_row_size=",
+      packed_row_size,
+      ", block_size=",
+      block_size);
+
+  if (output_size > 0) {
+    FBGEMM_CHECK(input != nullptr, "INT4 no-bag input pointer is null");
+    FBGEMM_CHECK(indices != nullptr, "INT4 no-bag indices pointer is null");
+    FBGEMM_CHECK(out != nullptr, "INT4 no-bag output pointer is null");
+  }
+
+  return packed_row_size;
+}
+
+#define WARN_ONCE(...)              \
+  do {                              \
+    static bool _warned = false;    \
+    if (!_warned) {                 \
+      _warned = true;               \
+      fprintf(stderr, __VA_ARGS__); \
+    }                               \
+  } while (0)
 
 } // namespace fbgemm

--- a/src/EmbeddingSpMDMAutovec.cc
+++ b/src/EmbeddingSpMDMAutovec.cc
@@ -368,7 +368,16 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
   if (data_size < 0) {
     return false;
   }
-
+  const int64_t no_bag_copy_size = no_bag ? nbit_embedding_no_bag_copy_size(
+                                                block_size,
+                                                output_size,
+                                                index_size,
+                                                output_stride,
+                                                input_stride,
+                                                input,
+                                                indices,
+                                                out)
+                                          : 0;
   const int64_t l1_distance = tbe_l1_prefetch_distance();
   const int64_t l2_distance = tbe_l2_prefetch_distance();
   const bool use_tuned_l1_prefetch = l1_distance > 0;
@@ -408,20 +417,6 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
   }
 
   if (no_bag) {
-    // We currently only support int4 to int4 for sequential TBE in this nbit
-    // kernel. Note that assert() will be ignored in release mode, so we check
-    // here to double check and also avoid "unused variable" warning
-    if (input_bit_rate != 4 || output_bit_rate != 4) {
-      WARN_ONCE("no_bag is only supported for int4 to int4");
-      return false;
-    }
-    const int64_t no_bag_row_size =
-        nbit_embedding_int4_row_size_in_bytes(block_size);
-    if (!nbit_embedding_int4_validate_strides(
-            block_size, input_stride, output_stride)) {
-      return false;
-    }
-
     // The preamble above only warms indices [0, l1_prefetch_distance), so
     // without a rolling prefetch every row past that is a cold, dependent load:
     // the gather is one scattered row per iteration over a table far larger
@@ -447,11 +442,11 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
             l1_prefetch_distance);
       }
       const uint8_t* input_row = input + input_stride * idx;
-      memcpy(out, input_row, sizeof(uint8_t) * no_bag_row_size);
+      memcpy(out, input_row, sizeof(uint8_t) * no_bag_copy_size);
       memset(
-          out + no_bag_row_size,
+          out + no_bag_copy_size,
           0,
-          sizeof(uint8_t) * (output_stride - no_bag_row_size));
+          sizeof(uint8_t) * (output_stride - no_bag_copy_size));
       out += output_stride;
     }
 
@@ -1950,11 +1945,9 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
     output_bit_rate = 8 * sizeof(OutType);
   }
   if (output_stride == -1) {
-    if (no_bag && output_bit_rate == 4) {
-      output_stride = nbit_embedding_int4_row_size_in_bytes(block_size);
-    } else {
-      output_stride = block_size;
-    }
+    output_stride = no_bag && output_bit_rate == 4
+        ? nbit_embedding_int4_row_size_in_bytes(block_size)
+        : block_size;
   }
 
   if (input_stride == -1) {

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -1020,14 +1020,7 @@ typename EmbeddingSpMDMKernelSignature<uint8_t, indxType, offsetType, outType>::
   if (output_bit_rate == -1) {
     output_bit_rate = sizeof(outType) * 8;
   }
-  assert(
-      (input_bit_rate == 2 || input_bit_rate == 4) &&
-      "input_bit_rate must be 2 or 4");
-  if constexpr (std::is_same_v<outType, uint8_t>) {
-    assert(
-        (no_bag && input_bit_rate == 4 && output_bit_rate == 4) &&
-        "we currently only support int4 to int4 when using sequential TBE");
-  }
+  nbit_embedding_sanity_check<outType>(input_bit_rate, output_bit_rate, no_bag);
 
   if (output_stride == -1) {
     output_stride = no_bag && output_bit_rate == 4

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -1450,14 +1450,15 @@ bool EmbeddingSpMDMNBit_ref(
     output_bit_rate = 8 * sizeof(OutType);
   }
   nbit_embedding_sanity_check<OutType>(input_bit_rate, output_bit_rate, no_bag);
+  if (data_size < 0) {
+    return false;
+  }
   int num_elem_per_byte = 8 / input_bit_rate;
 
   if (output_stride == -1) {
-    if (no_bag && output_bit_rate == 4) {
-      output_stride = nbit_embedding_int4_row_size_in_bytes(block_size);
-    } else {
-      output_stride = block_size;
-    }
+    output_stride = no_bag && output_bit_rate == 4
+        ? nbit_embedding_int4_row_size_in_bytes(block_size)
+        : block_size;
   }
 
   // block_size is the number of elements and fused_block_size is the size of
@@ -1469,19 +1470,15 @@ bool EmbeddingSpMDMNBit_ref(
   }
 
   if (no_bag) {
-    // We currently only support int4 to int4 for sequential TBE in this nbit
-    // kernel. Note that assert() will be ignored in release mode, so we check
-    // here to double check and also avoid "unused variable" warning
-    if (input_bit_rate != 4 || output_bit_rate != 4) {
-      WARN_ONCE("no_bag is only supported for int4 to int4");
-      return false;
-    }
-    const int64_t packed_row_size =
-        nbit_embedding_int4_row_size_in_bytes(block_size);
-    if (!nbit_embedding_int4_validate_strides(
-            block_size, input_stride, output_stride)) {
-      return false;
-    }
+    const int64_t copy_size = nbit_embedding_no_bag_copy_size(
+        block_size,
+        output_size,
+        index_size,
+        output_stride,
+        input_stride,
+        input,
+        indices,
+        out);
     // This loop is not reference-only on x86: the asmjit nbit generator is
     // gated on !no_bag and the autovec one needs SVE2, so the sequence gather
     // lands here and this is its only chance to prefetch. Each iteration is one
@@ -1511,11 +1508,8 @@ bool EmbeddingSpMDMNBit_ref(
             prefetch_distance);
       }
       const uint8_t* input_row = input + input_stride * idx;
-      memcpy(out, input_row, sizeof(uint8_t) * packed_row_size);
-      memset(
-          out + packed_row_size,
-          0,
-          sizeof(uint8_t) * (output_stride - packed_row_size));
+      memcpy(out, input_row, sizeof(uint8_t) * copy_size);
+      memset(out + copy_size, 0, sizeof(uint8_t) * (output_stride - copy_size));
       out += output_stride;
     }
     return true;

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -71,9 +71,6 @@ class FusedNBitRowwiseEmbeddingLookupTest : public testing::TestWithParam<tuple<
                                                 EmbeddingSpMDMDtypeChoice,
                                                 EmbeddingSpMDMKernelChoice>> {};
 
-using Int4NoBagKernel =
-    EmbeddingSpMDMKernelSignature<uint8_t, int64_t, int64_t, uint8_t>::Type;
-
 constexpr int64_t kInt4NoBagBlockSize = 100;
 constexpr int64_t kInt4NoBagPackedRowSize =
     (kInt4NoBagBlockSize + 1) / 2 + 2 * sizeof(float16);
@@ -83,24 +80,6 @@ constexpr int64_t kInt4NoBagInputStride =
      kInt4NoBagStorageAlignment) *
     kInt4NoBagStorageAlignment;
 
-Int4NoBagKernel makeInt4NoBagKernel(
-    const int64_t output_stride,
-    const int64_t input_stride) {
-  return GenerateEmbeddingSpMDMNBitWithStrides<int64_t, int64_t, uint8_t>(
-      /*input_bit_rate=*/4,
-      /*block_size=*/kInt4NoBagBlockSize,
-      /*has_weight=*/false,
-      /*normalize_by_lengths=*/false,
-      /*prefetch=*/16,
-      /*is_weight_positional=*/false,
-      /*use_offsets=*/true,
-      output_stride,
-      input_stride,
-      /*scale_bias_last=*/true,
-      /*is_bf16_out=*/false,
-      /*no_bag=*/true,
-      /*output_bit_rate=*/4);
-}
 }; // namespace
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1323,43 +1302,58 @@ TEST(
 }
 
 TEST(FusedNBitRowwiseEmbeddingLookupTest, NoBagInt4DropsInputRowPadding) {
+  constexpr int kBitRate = 4;
   constexpr int64_t kNumRows = 2;
+  constexpr int64_t kEmbeddingDim = 100;
   constexpr int64_t kOutputSize = 2;
+  constexpr int64_t kOutputStride = 54;
+  constexpr int64_t kInputStride = 56;
   constexpr int64_t kGuardSize = 16;
   constexpr uint8_t kCanary = 0xa5;
 
-  vector<uint8_t> table(kNumRows * kInt4NoBagInputStride);
+  vector<uint8_t> table(kNumRows * kInputStride);
   for (int64_t row = 0; row < kNumRows; ++row) {
-    for (int64_t col = 0; col < kInt4NoBagPackedRowSize; ++col) {
-      table[row * kInt4NoBagInputStride + col] =
-          static_cast<uint8_t>(row * kInt4NoBagInputStride + col);
+    for (int64_t col = 0; col < kOutputStride; ++col) {
+      table[row * kInputStride + col] =
+          static_cast<uint8_t>(row * kInputStride + col);
     }
     fill(
-        table.begin() + row * kInt4NoBagInputStride + kInt4NoBagPackedRowSize,
-        table.begin() + (row + 1) * kInt4NoBagInputStride,
+        table.begin() + row * kInputStride + kOutputStride,
+        table.begin() + (row + 1) * kInputStride,
         static_cast<uint8_t>(0xe0 + row));
   }
 
   const vector<int64_t> indices{1, 0};
   const vector<int64_t> offsets{0, 1, 2};
-  vector<uint8_t> output(
-      kOutputSize * kInt4NoBagInputStride + kGuardSize, kCanary);
+  vector<uint8_t> output(kOutputSize * kInputStride + kGuardSize, kCanary);
   vector<uint8_t> expected;
-  expected.reserve(kOutputSize * kInt4NoBagPackedRowSize);
+  expected.reserve(kOutputSize * kOutputStride);
   for (const auto idx : indices) {
     expected.insert(
         expected.end(),
-        table.begin() + idx * kInt4NoBagInputStride,
-        table.begin() + idx * kInt4NoBagInputStride + kInt4NoBagPackedRowSize);
+        table.begin() + idx * kInputStride,
+        table.begin() + idx * kInputStride + kOutputStride);
   }
 
-  for (const auto requested_output_stride :
-       {kInt4NoBagPackedRowSize, int64_t{-1}}) {
+  for (const auto requested_output_stride : {kOutputStride, int64_t{-1}}) {
     for (const auto kernel_choice : {DISPATCH_DEFAULT, DISPATCH_AUTOVEC}) {
       ScopedKernelOverride kernel_override(kernel_choice);
       fill(output.begin(), output.end(), kCanary);
       const auto kernel =
-          makeInt4NoBagKernel(requested_output_stride, kInt4NoBagInputStride);
+          GenerateEmbeddingSpMDMNBitWithStrides<int64_t, int64_t, uint8_t>(
+              kBitRate,
+              kEmbeddingDim,
+              /*has_weight=*/false,
+              /*normalize_by_lengths=*/false,
+              /*prefetch=*/16,
+              /*is_weight_positional=*/false,
+              /*use_offsets=*/true,
+              /*output_stride=*/requested_output_stride,
+              /*input_stride=*/kInputStride,
+              /*scale_bias_last=*/true,
+              /*is_bf16_out=*/false,
+              /*no_bag=*/true,
+              /*output_bit_rate=*/kBitRate);
 
       ASSERT_TRUE(kernel(
           kOutputSize,
@@ -1372,13 +1366,12 @@ TEST(FusedNBitRowwiseEmbeddingLookupTest, NoBagInt4DropsInputRowPadding) {
           output.data()));
 
       const vector<uint8_t> actual(
-          output.begin(),
-          output.begin() + kOutputSize * kInt4NoBagPackedRowSize);
+          output.begin(), output.begin() + kOutputSize * kOutputStride);
       EXPECT_EQ(actual, expected)
           << "kernel_choice=" << kernel_choice
           << ", requested_output_stride=" << requested_output_stride;
       EXPECT_TRUE(all_of(
-          output.begin() + kOutputSize * kInt4NoBagPackedRowSize,
+          output.begin() + kOutputSize * kOutputStride,
           output.end(),
           [canary = kCanary](uint8_t value) { return value == canary; }))
           << "kernel_choice=" << kernel_choice
@@ -1478,23 +1471,151 @@ TEST(
       "autovec");
 }
 
+TEST(
+    FusedNBitRowwiseEmbeddingLookupTest,
+    NoBagInt4NegativeDataSizeReturnsFalse) {
+  const vector<int64_t> indices{0};
+  const vector<int64_t> offsets{0, 1};
+  vector<uint8_t> table(kInt4NoBagInputStride);
+  vector<uint8_t> output(kInt4NoBagPackedRowSize);
+
+  EXPECT_FALSE((EmbeddingSpMDMNBit_ref<int64_t, int64_t, uint8_t>(
+      /*input_bit_rate=*/4,
+      /*block_size=*/kInt4NoBagBlockSize,
+      /*output_size=*/1,
+      indices.size(),
+      /*data_size=*/-1,
+      table.data(),
+      indices.data(),
+      offsets.data(),
+      /*weights=*/nullptr,
+      /*normalize_by_lengths=*/false,
+      output.data(),
+      /*is_weight_positional=*/false,
+      /*use_offsets=*/true,
+      /*output_stride=*/kInt4NoBagPackedRowSize,
+      /*input_stride=*/kInt4NoBagInputStride,
+      /*scale_bias_last=*/true,
+      /*is_bf16_out=*/false,
+      /*no_bag=*/true,
+      /*output_bit_rate=*/4)));
+
+  const auto autovec =
+      GenerateEmbeddingSpMDMNBitWithStrides_autovec<int64_t, int64_t, uint8_t>(
+          /*input_bit_rate=*/4,
+          /*block_size=*/kInt4NoBagBlockSize,
+          /*has_weight=*/false,
+          /*normalize_by_lengths=*/false,
+          /*prefetch=*/16,
+          /*is_weight_positional=*/false,
+          /*use_offsets=*/true,
+          /*output_stride=*/kInt4NoBagPackedRowSize,
+          /*input_stride=*/kInt4NoBagInputStride,
+          /*scale_bias_last=*/true,
+          /*is_bf16_out=*/false,
+          /*no_bag=*/true,
+          /*output_bit_rate=*/4);
+  EXPECT_FALSE(autovec(
+      /*output_size=*/1,
+      indices.size(),
+      /*data_size=*/-1,
+      table.data(),
+      indices.data(),
+      offsets.data(),
+      /*weights=*/nullptr,
+      output.data()));
+}
+
+TEST(FusedNBitRowwiseEmbeddingLookupTest, NoBagRejectsNonInt4FloatOutput) {
+  const vector<int64_t> indices{0};
+  const vector<int64_t> offsets{0, 1};
+  vector<uint8_t> table(kInt4NoBagInputStride);
+  vector<float> output(kInt4NoBagBlockSize);
+
+  const auto run_reference = [&]() {
+    return EmbeddingSpMDMNBit_ref<int64_t, int64_t, float>(
+        /*input_bit_rate=*/2,
+        /*block_size=*/kInt4NoBagBlockSize,
+        /*output_size=*/1,
+        indices.size(),
+        /*data_size=*/1,
+        table.data(),
+        indices.data(),
+        offsets.data(),
+        /*weights=*/nullptr,
+        /*normalize_by_lengths=*/false,
+        output.data(),
+        /*is_weight_positional=*/false,
+        /*use_offsets=*/true,
+        /*output_stride=*/kInt4NoBagBlockSize,
+        /*input_stride=*/kInt4NoBagInputStride,
+        /*scale_bias_last=*/true,
+        /*is_bf16_out=*/false,
+        /*no_bag=*/true,
+        /*output_bit_rate=*/8 * sizeof(float));
+  };
+  EXPECT_THROW(run_reference(), std::exception);
+
+  const auto autovec =
+      GenerateEmbeddingSpMDMNBitWithStrides_autovec<int64_t, int64_t, float>(
+          /*input_bit_rate=*/2,
+          /*block_size=*/kInt4NoBagBlockSize,
+          /*has_weight=*/false,
+          /*normalize_by_lengths=*/false,
+          /*prefetch=*/16,
+          /*is_weight_positional=*/false,
+          /*use_offsets=*/true,
+          /*output_stride=*/kInt4NoBagBlockSize,
+          /*input_stride=*/kInt4NoBagInputStride,
+          /*scale_bias_last=*/true,
+          /*is_bf16_out=*/false,
+          /*no_bag=*/true,
+          /*output_bit_rate=*/8 * sizeof(float));
+  EXPECT_THROW(
+      autovec(
+          /*output_size=*/1,
+          indices.size(),
+          /*data_size=*/1,
+          table.data(),
+          indices.data(),
+          offsets.data(),
+          /*weights=*/nullptr,
+          output.data()),
+      std::exception);
+}
+
 TEST(FusedNBitRowwiseEmbeddingLookupTest, NoBagInt4ZerosOutputPadding) {
-  constexpr int64_t kOutputPadding = 6;
-  constexpr int64_t kOutputStride = kInt4NoBagPackedRowSize + kOutputPadding;
+  constexpr int kBitRate = 4;
+  constexpr int64_t kEmbeddingDim = 100;
+  constexpr int64_t kPackedRowSize = 54;
+  constexpr int64_t kInputStride = 56;
+  constexpr int64_t kOutputStride = 60;
   constexpr uint8_t kCanary = 0xa5;
   const vector<int64_t> indices{0};
   const vector<int64_t> offsets{0, 1};
-  vector<uint8_t> table(kInt4NoBagInputStride, 0xe0);
-  iota(table.begin(), table.begin() + kInt4NoBagPackedRowSize, uint8_t{0});
+  vector<uint8_t> table(kInputStride, 0xe0);
+  iota(table.begin(), table.begin() + kPackedRowSize, uint8_t{0});
   vector<uint8_t> expected(kOutputStride, 0);
-  iota(
-      expected.begin(), expected.begin() + kInt4NoBagPackedRowSize, uint8_t{0});
+  iota(expected.begin(), expected.begin() + kPackedRowSize, uint8_t{0});
 
   for (const auto kernel_choice : {DISPATCH_DEFAULT, DISPATCH_AUTOVEC}) {
     ScopedKernelOverride kernel_override(kernel_choice);
     vector<uint8_t> output(kOutputStride, kCanary);
     const auto kernel =
-        makeInt4NoBagKernel(kOutputStride, kInt4NoBagInputStride);
+        GenerateEmbeddingSpMDMNBitWithStrides<int64_t, int64_t, uint8_t>(
+            kBitRate,
+            kEmbeddingDim,
+            /*has_weight=*/false,
+            /*normalize_by_lengths=*/false,
+            /*prefetch=*/16,
+            /*is_weight_positional=*/false,
+            /*use_offsets=*/true,
+            /*output_stride=*/kOutputStride,
+            /*input_stride=*/kInputStride,
+            /*scale_bias_last=*/true,
+            /*is_bf16_out=*/false,
+            /*no_bag=*/true,
+            /*output_bit_rate=*/kBitRate);
 
     ASSERT_TRUE(kernel(
         /*output_size=*/1,
@@ -1511,30 +1632,63 @@ TEST(FusedNBitRowwiseEmbeddingLookupTest, NoBagInt4ZerosOutputPadding) {
 }
 
 TEST(FusedNBitRowwiseEmbeddingLookupTest, NoBagInt4RejectsShortRowStrides) {
+  constexpr int kBitRate = 4;
+  constexpr int64_t kEmbeddingDim = 100;
+  constexpr int64_t kPackedRowSize = 54;
   const vector<int64_t> indices{0};
   const vector<int64_t> offsets{0, 1};
-  vector<uint8_t> table(kInt4NoBagPackedRowSize);
-  vector<uint8_t> output(kInt4NoBagPackedRowSize);
+  vector<uint8_t> table(kPackedRowSize);
+  vector<uint8_t> output(kPackedRowSize);
 
-  for (const auto [output_stride, input_stride] :
-       {pair{kInt4NoBagPackedRowSize, kInt4NoBagPackedRowSize - 1},
-        pair{kInt4NoBagPackedRowSize - 1, kInt4NoBagPackedRowSize}}) {
+  struct InvalidStrides {
+    int64_t output_stride;
+    int64_t input_stride;
+    const char* expected_message;
+  };
+  const vector<InvalidStrides> invalid_strides{
+      {kPackedRowSize, kPackedRowSize - 1, "input_stride=53"},
+      {kPackedRowSize - 1, kPackedRowSize, "output_stride=53"},
+  };
+
+  for (const auto& strides : invalid_strides) {
     for (const auto kernel_choice : {DISPATCH_DEFAULT, DISPATCH_AUTOVEC}) {
       ScopedKernelOverride kernel_override(kernel_choice);
-      const auto kernel = makeInt4NoBagKernel(output_stride, input_stride);
+      const auto kernel =
+          GenerateEmbeddingSpMDMNBitWithStrides<int64_t, int64_t, uint8_t>(
+              kBitRate,
+              kEmbeddingDim,
+              /*has_weight=*/false,
+              /*normalize_by_lengths=*/false,
+              /*prefetch=*/16,
+              /*is_weight_positional=*/false,
+              /*use_offsets=*/true,
+              /*output_stride=*/strides.output_stride,
+              /*input_stride=*/strides.input_stride,
+              /*scale_bias_last=*/true,
+              /*is_bf16_out=*/false,
+              /*no_bag=*/true,
+              /*output_bit_rate=*/kBitRate);
 
-      EXPECT_FALSE(kernel(
-          /*output_size=*/1,
-          indices.size(),
-          /*data_size=*/1,
-          table.data(),
-          indices.data(),
-          offsets.data(),
-          nullptr,
-          output.data()))
-          << "kernel_choice=" << kernel_choice
-          << ", output_stride=" << output_stride
-          << ", input_stride=" << input_stride;
+      try {
+        kernel(
+            /*output_size=*/1,
+            indices.size(),
+            /*data_size=*/1,
+            table.data(),
+            indices.data(),
+            offsets.data(),
+            nullptr,
+            output.data());
+        FAIL() << "Expected invalid INT4 no-bag strides to fail";
+      } catch (const std::exception& error) {
+        const string message = error.what();
+        EXPECT_NE(message.find(strides.expected_message), string::npos)
+            << "kernel_choice=" << kernel_choice << ", error=" << message;
+        EXPECT_NE(message.find("packed_row_size=54"), string::npos)
+            << "kernel_choice=" << kernel_choice << ", error=" << message;
+        EXPECT_NE(message.find("block_size=100"), string::npos)
+            << "kernel_choice=" << kernel_choice << ", error=" << message;
+      }
     }
   }
 }


### PR DESCRIPTION
Summary:
NOTE: No linked task. Please associate a task with this diff.

D118193255 fixes the INT4 packed-row overread seen in the KVZCH Tupperware job. This diff adds release-build diagnostics and protects the generic API around that copy path.

- Validate no-bag sizes, strides, and pointers with `FBGEMM_CHECK`.
- Reject generic non-`uint8_t` no-bag calls before raw byte copying.
- Preserve boolean failure for negative `data_size` and invalid indices.
- Guard autovec prefetch addresses and export `Assert.h` without removing transitive `<cassert>`.
- Cover reference and forced-autovec behavior in fbcode and xplat mirrors.

Reviewed By: emlin

Differential Revision: D118193256


